### PR TITLE
chore: fix the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
       - *create_cache
       - persist_to_workspace:
           root: *workspace_root
+          paths:
+            - build
 
   lint:
     <<: *container_config_node


### PR DESCRIPTION
I accidentally removed a required parameter from the
persist_to_workspace action.