### PR TITLE
chore: add automated type checking

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,6 +8,7 @@ We're glad you want to contribute to Reliability Kit!
   * [Getting set up](#getting-set-up)
   * [Testing](#testing)
     * [Linters](#linters)
+    * [Type safety](#type-safety)
     * [Unit tests](#unit-tests)
   * [Committing](#committing)
     * [Commit type prefixes](#commit-type-prefixes)
@@ -53,6 +54,18 @@ npm run lint
 ```
 
 The linters are also run on pull requests and linting errors will block merging, so it's useful to check before opening a PR.
+
+### Type safety
+
+We do not write TypeScript in this project, but we _do_ write [thorough JSDoc](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) and test against it which gives us all the benefits of TypeScript ([more info](./design.md#languages)).
+
+We do not compile the code in our packages, but we do check that all variables are set to the correct types. If there are any type errors then you should see these in your editor if you're using VS Code. Otherwise type checking can be manually run as part of linting:
+
+```
+npm run lint
+```
+
+As with ESLint, we check types in pull requests and errors will block merging, so it's useful to check before opening a PR.
 
 ### Unit tests
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"module": "commonjs",
+		"strict": true
+	},
+	"exclude": [
+		"coverage",
+		"node_modules"
+	],
+	"include": [
+		"**/*.js"
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "jest": "^28.0.3",
         "lint-staged": "^12.4.1",
         "prettier": "^2.6.2",
-        "release-please": "^13.15.0"
+        "release-please": "^13.15.0",
+        "typescript": "^4.6.4"
       },
       "engines": {
         "node": "14.x || 16.x",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "eslint .",
+    "lint": "npm run lint:eslint && npm run lint:tsc",
+    "lint:eslint": "eslint .",
+    "lint:tsc": "tsc --noEmit --project ./jsconfig.json",
     "test": "jest --silent",
     "prepare": "husky install"
   },
@@ -29,7 +31,8 @@
     "jest": "^28.0.3",
     "lint-staged": "^12.4.1",
     "prettier": "^2.6.2",
-    "release-please": "^13.15.0"
+    "release-please": "^13.15.0",
+    "typescript": "^4.6.4"
   },
   "engines": {
     "node": "14.x || 16.x",


### PR DESCRIPTION
We now explicitly check types with TypeScript, so that if we provide
valid JSDoc comments for our code we can be sure that everything is
type-safe. This will hopefully result in fewer unexpected bugs and
increase confidence in our tooling!

This also gives us useful hinting in VS Code, so hopefully writing the
code will be easier for us as well.