### PR TITLE
chore: use Babel with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,11 @@
 		"jest": true
 	},
 	"extends": ["@financial-times/eslint-config-next"],
+	"parser": "@babel/eslint-parser",
 	"parserOptions": {
-		"ecmaVersion": 2020
+		"ecmaVersion": 2020,
+		"requireConfigFile": false,
+		"sourceType": "script"
 	},
 	"plugins": [
 		"prettier"

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,8 @@
 		"allowJs": true,
 		"checkJs": true,
 		"module": "commonjs",
-		"strict": true
+		"strict": true,
+		"target": "es2020"
 	},
 	"exclude": [
 		"coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@babel/core": "^7.17.10",
+        "@babel/eslint-parser": "^7.17.0",
         "@commitlint/cli": "^16.2.4",
         "@commitlint/config-conventional": "^16.2.4",
         "@financial-times/eslint-config-next": "^4.0.0",
@@ -95,6 +97,55 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+      "integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
@@ -857,6 +908,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@dotcom-reliability-kit/errors": {
+      "resolved": "packages/errors",
+      "link": true
     },
     "node_modules/@dotcom-reliability-kit/example": {
       "resolved": "packages/example",
@@ -7303,6 +7358,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/errors": {
+      "name": "@dotcom-reliability-kit/errors",
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "packages/example": {
       "name": "@dotcom-reliability-kit/example",
       "version": "0.0.0"
@@ -7357,6 +7421,41 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+      "integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7942,6 +8041,9 @@
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
+    },
+    "@dotcom-reliability-kit/errors": {
+      "version": "file:packages/errors"
     },
     "@dotcom-reliability-kit/example": {
       "version": "file:packages/example"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.10",
+    "@babel/eslint-parser": "^7.17.0",
     "@commitlint/cli": "^16.2.4",
     "@commitlint/config-conventional": "^16.2.4",
     "@financial-times/eslint-config-next": "^4.0.0",


### PR DESCRIPTION
ESLint does not support many ES2020 features, e.g. class public and
private fields. It'd be nice to be able to use these considering that
we're only targeting environments where they're available.

This addresses the issue and makes sure that both ESLint and TypeScript
do not complain when we use modern features.