### PR TITLE
feat: add a method to check for operational errors

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -37,24 +37,13 @@ It works in the same way as a normal error, expecting a message:
 throw new OperationalError('example message');
 ```
 
-You can test whether an error is operational (known about) either by checking whether it's an instance of this class:
+#### `OperationalError.isErrorMarkedAsOperational()`
+
+You can test whether an error is operational (known about) either by using the `isErrorMarkedAsOperational` method. It accepts an error object of any kind and will return `true` if that error has a truthy `isOperational` property and `false` otherwise:
 
 ```js
-try {
-    // your code
-} catch (error) {
-    console.log(error instanceof OperationalError); // true
-}
-```
-
-Or by checking the `isOperational` property:
-
-```js
-try {
-    // your code
-} catch (error) {
-    console.log(error.isOperational); // true
-}
+OperationalError.isErrorMarkedAsOperational(new OperationalError('example message')); // true
+OperationalError.isErrorMarkedAsOperational(new Error('example message')); // false
 ```
 
 

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -29,4 +29,19 @@ module.exports = class OperationalError extends Error {
 		// TODO process more error data here
 		super(message);
 	}
+
+	/**
+	 * Get whether an error object is marked as operational (it has a truthy `isOperational` property).
+	 *
+	 * @public
+	 * @param {Error} error
+	 *     The error object to check.
+	 * @returns {Boolean}
+	 *     Returns whether the error is operational.
+	 */
+	static isErrorMarkedAsOperational(error) {
+		// @ts-ignore Error.prototype.isOperational does not exist, but it's OK to check in this
+		// case as we're manually casting `undefined` to a Boolean
+		return Boolean(error.isOperational);
+	}
 };

--- a/packages/errors/test/lib/operational-error.spec.js
+++ b/packages/errors/test/lib/operational-error.spec.js
@@ -39,4 +39,35 @@ describe('@dotcom-reliability-kit/errors/lib/operationa-error', () => {
 			});
 		});
 	});
+
+	describe('isErrorMarkedAsOperational(error)', () => {
+		describe('when called with an OperationalError instance', () => {
+			it('returns `true`', () => {
+				expect(
+					OperationalError.isErrorMarkedAsOperational(
+						new OperationalError('mock message')
+					)
+				).toStrictEqual(true);
+			});
+		});
+
+		describe('when called with an Error instance', () => {
+			it('returns `false`', () => {
+				expect(
+					OperationalError.isErrorMarkedAsOperational(new Error('mock message'))
+				).toStrictEqual(false);
+			});
+		});
+
+		describe('when called with an Error instance that has a manually added `isOperational` property', () => {
+			it('returns `true`', () => {
+				const error = new Error('mock message');
+				// @ts-ignore Fine to add additonal properties for testing purposes
+				error.isOperational = true;
+				expect(
+					OperationalError.isErrorMarkedAsOperational(error)
+				).toStrictEqual(true);
+			});
+		});
+	});
 });


### PR DESCRIPTION
This method is mostly being added so that I can legitimately bump the
package version (see the commit footer which indicates a version).

I think this is still a useful method anyway, as ideally an engineer
should be able to choose to decorate existing errors with an
`isOperational` property if it's not possible to use our classes for
some reason.