### PR TITLE
Build errors package

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -5,6 +5,7 @@ A suite of error classes which help you throw the most appropriate error in any 
 
   * [Usage](#usage)
     * [`OperationalError`](#operationalerror)
+      * [`.isErrorMarkedAsOperational`](#operationalerroriserrormarkedasoperational)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -38,6 +39,17 @@ It works in the same way as a normal error, expecting a message:
 ```js
 throw new OperationalError('example message');
 ```
+
+You can alternatively construct an operational error with a data object. Currently this accepts a `code` property, which must be set to a unique identifier for the type of error which is occurring, and a `message` property which contains a human-readable message:
+
+```js
+throw new OperationalError({
+    message: 'example message',
+    code: 'EXAMPLE_CODE'
+});
+```
+
+Error codes are normalized to be uppercase, alphanumeric, and underscore-delimited.
 
 #### `OperationalError.isErrorMarkedAsOperational()`
 

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -58,13 +58,12 @@ error.message // example message
 error.code // EXAMPLE_CODE
 ```
 
-You may also pass additional properties into an error object, these will be collected and stored on a `data` property on the error. Note: TypeScript will complain about these additional properties, so if you're checking types you will need to ignore the relevant lines:
+You may also pass additional properties into an error object, these will be collected and stored on a `data` property on the error:
 
 ```js
 const error = new OperationalError({
     message: 'example message',
     code: 'EXAMPLE_CODE',
-    // @ts-ignore
     article: 'd92acacb-ac53-4505-aa88-eae4b42de994'
 });
 

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -6,6 +6,8 @@ A suite of error classes which help you throw the most appropriate error in any 
   * [Usage](#usage)
     * [`OperationalError`](#operationalerror)
       * [`.isErrorMarkedAsOperational`](#operationalerroriserrormarkedasoperational)
+    * [`HttpError`](#httperror)
+      * [Why use this over `http-errors`?](#why-use-this-over-http-errors)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -40,7 +42,7 @@ It works in the same way as a normal error, expecting a message:
 throw new OperationalError('example message');
 ```
 
-You can alternatively construct an operational error with a data object. Currently this accepts a `code` property, which must be set to a unique identifier for the type of error which is occurring, and a `message` property which contains a human-readable message:
+You can alternatively construct an operational error with a data object. This accepts a `code` property, which must be set to a unique identifier for the type of error which is occurring, and a `message` property which contains a human-readable message:
 
 ```js
 throw new OperationalError({
@@ -49,7 +51,12 @@ throw new OperationalError({
 });
 ```
 
-Error codes are normalized to be uppercase, alphanumeric, and underscore-delimited.
+Error codes are normalized to be uppercase, alphanumeric, and underscore-delimited. Error properties can be accessed like any other property:
+
+```js
+error.message // example message
+error.code // EXAMPLE_CODE
+```
 
 #### `OperationalError.isErrorMarkedAsOperational()`
 
@@ -59,6 +66,43 @@ You can test whether an error is operational (known about) either by using the `
 OperationalError.isErrorMarkedAsOperational(new OperationalError('example message')); // true
 OperationalError.isErrorMarkedAsOperational(new Error('example message')); // false
 ```
+
+### `HttpError`
+
+The `HttpError` class extends `OperationalError` and represents an HTTP error status. It can work in the same way as a normal error, expecting a message. In this case it will represent an HTTP `500`:
+
+```js
+throw new HttpError('example message');
+```
+
+You can alternatively construct an HTTP error with a data object. This accepts a `statusCode` property, which is a valid HTTP status code number, as well as all of the properties you can set in [`OperationalError`](#operationalerror):
+
+```js
+throw new HttpError({
+    message: 'your thing was not found',
+    statusCode: 404
+});
+```
+
+It's also possible to create an HTTP error with a status code alone, which will default the message to the corresponding HTTP status message:
+
+```js
+throw new HttpError(404);
+```
+
+Error properties can be accessed like any other property:
+
+```js
+error.message // your thing was not found
+error.statusCode // 404
+error.status // 404
+error.statusMessage // Not Found
+error.code // HTTP_404
+```
+
+#### Why use this over `http-errors`?
+
+The benefit of using this error rather than the excellent [http-errors](https://github.com/jshttp/http-errors#readme) library is that we extend `OperationalError` by default. This means that all HTTP errors you throw are considered "known errors" by the rest of our tooling. We also set a `code` property by default which results in less code in our monitoring dashboards – we don't need to check both `code` and `statusCode` properties to determine the type of error thrown.
 
 
 ## Contributing

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -58,6 +58,20 @@ error.message // example message
 error.code // EXAMPLE_CODE
 ```
 
+You may also pass additional properties into an error object, these will be collected and stored on a `data` property on the error. Note: TypeScript will complain about these additional properties, so if you're checking types you will need to ignore the relevant lines:
+
+```js
+const error = new OperationalError({
+    message: 'example message',
+    code: 'EXAMPLE_CODE',
+    // @ts-ignore
+    article: 'd92acacb-ac53-4505-aa88-eae4b42de994'
+});
+
+error.data.article // d92acacb-ac53-4505-aa88-eae4b42de994
+```
+
+
 #### `OperationalError.isErrorMarkedAsOperational()`
 
 You can test whether an error is operational (known about) either by using the `isErrorMarkedAsOperational` method. It accepts an error object of any kind and will return `true` if that error has a truthy `isOperational` property and `false` otherwise:

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -15,6 +15,16 @@ const OperationalError = require('./operational-error');
 const STATUS_CODES = require('http').STATUS_CODES;
 
 /**
+ * @typedef {Object} HttpErrorData
+ * @property {String} [code]
+ *     A machine-readable error code which identifies the specific type of error.
+ * @property {String} [message]
+ *     A human readable message which describes the error.
+ * @property {Number} [statusCode]
+ *     An HTTP status code.
+ */
+
+/**
  * Class representing an HTTP error.
  */
 class HttpError extends OperationalError {
@@ -138,15 +148,5 @@ class HttpError extends OperationalError {
 		return STATUS_CODES[500];
 	}
 }
-
-/**
- * @typedef {Object} HttpErrorData
- * @property {String} [code]
- *     A machine-readable error code which identifies the specific type of error.
- * @property {String} [message]
- *     A human readable message which describes the error.
- * @property {Number} [statusCode]
- *     An HTTP status code.
- */
 
 module.exports = HttpError;

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -51,7 +51,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Create an HTTP error.
 	 *
-	 * @param {(String|Number|HttpErrorData)} [data = {}]
+	 * @param {(String|Number|HttpErrorData & Record<String, any>)} [data = {}]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
 	 */

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -63,6 +63,10 @@ class HttpError extends OperationalError {
 			data = { statusCode: data };
 		}
 
+		// Make sure that we don't modify the original data object
+		// by shallow-cloning it
+		data = { ...data };
+
 		// Default the status code
 		data.statusCode =
 			typeof data.statusCode === 'number'
@@ -85,6 +89,18 @@ class HttpError extends OperationalError {
 		this.statusCode = data.statusCode;
 		this.statusMessage = HttpError.getMessageForStatusCode(data.statusCode);
 	}
+
+	/**
+	 * Reserved keys that should not appear in `HttpError.prototype.data`.
+	 *
+	 * @access private
+	 * @type {Array<String>}
+	 */
+	static reservedKeys = [
+		...OperationalError.reservedKeys,
+		'statusCode',
+		'statusMessage'
+	];
 
 	/**
 	 * Normalize an HTTP status code.

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -8,19 +8,19 @@ const OperationalError = require('./operational-error');
  * We have guards in place wherever we use this map of status messages
  * which means we can safely cast it to an object where every property
  * is a string. If we don't do this then TypeScript will complain.
- * {@see HttpError.getMessageForStatusCode}
  *
- * @type {Object<String, String>}
+ * @see HttpError.getMessageForStatusCode
+ * @type {Object<any, string>}
  */
 const STATUS_CODES = require('http').STATUS_CODES;
 
 /**
- * @typedef {Object} HttpErrorData
- * @property {String} [code]
+ * @typedef {object} HttpErrorData
+ * @property {string} [code]
  *     A machine-readable error code which identifies the specific type of error.
- * @property {String} [message]
+ * @property {string} [message]
  *     A human readable message which describes the error.
- * @property {Number} [statusCode]
+ * @property {number} [statusCode]
  *     An HTTP status code.
  */
 
@@ -31,28 +31,28 @@ class HttpError extends OperationalError {
 	/**
 	 * @readonly
 	 * @access public
-	 * @type {String}
+	 * @type {string}
 	 */
 	name = 'HttpError';
 
 	/**
 	 * @readonly
 	 * @access public
-	 * @type {Number}
+	 * @type {number}
 	 */
 	statusCode = 500;
 
 	/**
 	 * @readonly
 	 * @access public
-	 * @type {String}
+	 * @type {string}
 	 */
 	statusMessage = STATUS_CODES[500];
 
 	/**
 	 * @readonly
 	 * @access public
-	 * @type {Number}
+	 * @type {number}
 	 */
 	get status() {
 		return this.statusCode;
@@ -61,7 +61,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Create an HTTP error.
 	 *
-	 * @param {(String|Number|HttpErrorData & Record<String, any>)} [data = {}]
+	 * @param {(string | number | HttpErrorData & Record<string, any>)} [data = {}]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
 	 */
@@ -104,7 +104,7 @@ class HttpError extends OperationalError {
 	 * Reserved keys that should not appear in `HttpError.prototype.data`.
 	 *
 	 * @access private
-	 * @type {Array<String>}
+	 * @type {Array<string>}
 	 */
 	static reservedKeys = [
 		...OperationalError.reservedKeys,
@@ -116,9 +116,9 @@ class HttpError extends OperationalError {
 	 * Normalize an HTTP status code.
 	 *
 	 * @access private
-	 * @param {Number} statusCode
+	 * @param {number} statusCode
 	 *     The HTTP status code to normalize.
-	 * @returns {Number}
+	 * @returns {number}
 	 *     Returns the normalized HTTP status code.
 	 */
 	static normalizeErrorStatusCode(statusCode) {
@@ -133,9 +133,9 @@ class HttpError extends OperationalError {
 	 * Get the HTTP message for a given status code.
 	 *
 	 * @access private
-	 * @param {Number} statusCode
+	 * @param {number} statusCode
 	 *     The HTTP status code to get a message for.
-	 * @returns {String}
+	 * @returns {string}
 	 *     Returns the message.
 	 */
 	static getMessageForStatusCode(statusCode) {

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -1,0 +1,136 @@
+/**
+ * @module @dotcom-reliability-kit/errors/lib/http-error
+ */
+
+const OperationalError = require('./operational-error');
+
+/**
+ * We have guards in place wherever we use this map of status messages
+ * which means we can safely cast it to an object where every property
+ * is a string. If we don't do this then TypeScript will complain.
+ * {@see HttpError.getMessageForStatusCode}
+ *
+ * @type {Object<String, String>}
+ */
+const STATUS_CODES = require('http').STATUS_CODES;
+
+/**
+ * Class representing an HTTP error.
+ */
+class HttpError extends OperationalError {
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {String}
+	 */
+	name = 'HttpError';
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {Number}
+	 */
+	statusCode = 500;
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {String}
+	 */
+	statusMessage = STATUS_CODES[500];
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {Number}
+	 */
+	get status() {
+		return this.statusCode;
+	}
+
+	/**
+	 * Create an HTTP error.
+	 *
+	 * @param {(String|Number|HttpErrorData)} [data = {}]
+	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
+	 *     information if an object.
+	 */
+	constructor(data = {}) {
+		if (typeof data === 'string') {
+			data = { message: data };
+		}
+		if (typeof data === 'number') {
+			data = { statusCode: data };
+		}
+
+		// Default the status code
+		data.statusCode =
+			typeof data.statusCode === 'number'
+				? HttpError.normalizeErrorStatusCode(data.statusCode)
+				: 500;
+
+		// Default the error code
+		data.code =
+			typeof data.code === 'string' ? data.code : `HTTP_${data.statusCode}`;
+
+		// Default the error message
+		data.message =
+			typeof data.message === 'string'
+				? data.message
+				: HttpError.getMessageForStatusCode(data.statusCode);
+
+		// Message and code are set by the parent class, but we need
+		// to set the status code and message properties ourselves
+		super(data);
+		this.statusCode = data.statusCode;
+		this.statusMessage = HttpError.getMessageForStatusCode(data.statusCode);
+	}
+
+	/**
+	 * Normalize an HTTP status code.
+	 *
+	 * @access private
+	 * @param {Number} statusCode
+	 *     The HTTP status code to normalize.
+	 * @returns {Number}
+	 *     Returns the normalized HTTP status code.
+	 */
+	static normalizeErrorStatusCode(statusCode) {
+		statusCode = Math.floor(statusCode);
+		if (statusCode < 400 || statusCode > 599) {
+			statusCode = 500;
+		}
+		return statusCode;
+	}
+
+	/**
+	 * Get the HTTP message for a given status code.
+	 *
+	 * @access private
+	 * @param {Number} statusCode
+	 *     The HTTP status code to get a message for.
+	 * @returns {String}
+	 *     Returns the message.
+	 */
+	static getMessageForStatusCode(statusCode) {
+		if (STATUS_CODES[statusCode]) {
+			return STATUS_CODES[statusCode];
+		}
+		if (statusCode >= 400 && statusCode <= 499) {
+			return STATUS_CODES[400];
+		}
+		return STATUS_CODES[500];
+	}
+}
+
+/**
+ * @typedef {Object} HttpErrorData
+ * @property {String} [code]
+ *     A machine-readable error code which identifies the specific type of error.
+ * @property {String} [message]
+ *     A human readable message which describes the error.
+ * @property {Number} [statusCode]
+ *     An HTTP status code.
+ */
+
+module.exports = HttpError;

--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -3,5 +3,6 @@
  */
 
 module.exports = {
+	HttpError: require('./http-error'),
 	OperationalError: require('./operational-error')
 };

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -3,6 +3,14 @@
  */
 
 /**
+ * @typedef {Object} OperationalErrorData
+ * @property {String} [code]
+ *     A machine-readable error code which identifies the specific type of error.
+ * @property {String} [message]
+ *     A human readable message which describes the error.
+ */
+
+/**
  * Class representing an operational error.
  */
 class OperationalError extends Error {
@@ -103,13 +111,5 @@ class OperationalError extends Error {
 			.replace(/[^a-z0-9_]+/gi, '_');
 	}
 }
-
-/**
- * @typedef {Object} OperationalErrorData
- * @property {String} [code]
- *     A machine-readable error code which identifies the specific type of error.
- * @property {String} [message]
- *     A human readable message which describes the error.
- */
 
 module.exports = OperationalError;

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -32,6 +32,15 @@ class OperationalError extends Error {
 	code = 'UNKNOWN';
 
 	/**
+	 * Additional error information.
+	 *
+	 * @readonly
+	 * @access public
+	 * @type {Object<String, String>}
+	 */
+	data = {};
+
+	/**
 	 * Create an operational error.
 	 *
 	 * @param {(String|OperationalErrorData)} [data = {}]
@@ -46,7 +55,22 @@ class OperationalError extends Error {
 		if (typeof data.code === 'string') {
 			this.code = OperationalError.normalizeErrorCode(data.code);
 		}
+
+		for (const [key, value] of Object.entries(data)) {
+			// @ts-ignore TypeScript does not properly infer the constructor
+			if (!this.constructor.reservedKeys.includes(key)) {
+				this.data[key] = value;
+			}
+		}
 	}
+
+	/**
+	 * Reserved keys that should not appear in `OperationalError.prototype.data`.
+	 *
+	 * @access private
+	 * @type {Array<String>}
+	 */
+	static reservedKeys = ['code', 'message'];
 
 	/**
 	 * Get whether an error object is marked as operational (it has a truthy `isOperational` property).

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -5,29 +5,47 @@
 /**
  * Class representing an operational error.
  */
-module.exports = class OperationalError extends Error {
+class OperationalError extends Error {
 	/**
+	 * @readonly
 	 * @access public
 	 * @type {string}
 	 */
 	name = 'OperationalError';
 
 	/**
+	 * Whether the error is operational.
+	 *
+	 * @readonly
 	 * @access public
 	 * @type {boolean}
 	 */
 	isOperational = true;
 
 	/**
+	 * A machine-readable error code which identifies the specific type of error.
+	 *
+	 * @readonly
+	 * @access public
+	 * @type {String}
+	 */
+	code = 'UNKNOWN';
+
+	/**
 	 * Create an operational error.
 	 *
-	 * @access public
-	 * @param {string} message
-	 *     The error message.
+	 * @param {(String|OperationalErrorData)} [data = {}]
+	 *     The error message if it's a string, or full error information if an object.
 	 */
-	constructor(message) {
-		// TODO process more error data here
-		super(message);
+	constructor(data = {}) {
+		if (typeof data === 'string') {
+			data = { message: data };
+		}
+		super(data.message || 'An operational error occurred');
+
+		if (typeof data.code === 'string') {
+			this.code = OperationalError.normalizeErrorCode(data.code);
+		}
 	}
 
 	/**
@@ -44,4 +62,30 @@ module.exports = class OperationalError extends Error {
 		// case as we're manually casting `undefined` to a Boolean
 		return Boolean(error.isOperational);
 	}
-};
+
+	/**
+	 * Normalize a machine-readable error code.
+	 *
+	 * @access private
+	 * @param {String} code
+	 *     The error code to normalize.
+	 * @returns {String}
+	 *     Returns the normalized error code.
+	 */
+	static normalizeErrorCode(code) {
+		return code
+			.trim()
+			.toUpperCase()
+			.replace(/[^a-z0-9_]+/gi, '_');
+	}
+}
+
+/**
+ * @typedef {Object} OperationalErrorData
+ * @property {String} [code]
+ *     A machine-readable error code which identifies the specific type of error.
+ * @property {String} [message]
+ *     A human readable message which describes the error.
+ */
+
+module.exports = OperationalError;

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -43,7 +43,7 @@ class OperationalError extends Error {
 	/**
 	 * Create an operational error.
 	 *
-	 * @param {(String|OperationalErrorData)} [data = {}]
+	 * @param {(String|OperationalErrorData & Record<String, any>)} [data = {}]
 	 *     The error message if it's a string, or full error information if an object.
 	 */
 	constructor(data = {}) {

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -3,10 +3,10 @@
  */
 
 /**
- * @typedef {Object} OperationalErrorData
- * @property {String} [code]
+ * @typedef {object} OperationalErrorData
+ * @property {string} [code]
  *     A machine-readable error code which identifies the specific type of error.
- * @property {String} [message]
+ * @property {string} [message]
  *     A human readable message which describes the error.
  */
 
@@ -35,7 +35,7 @@ class OperationalError extends Error {
 	 *
 	 * @readonly
 	 * @access public
-	 * @type {String}
+	 * @type {string}
 	 */
 	code = 'UNKNOWN';
 
@@ -44,14 +44,14 @@ class OperationalError extends Error {
 	 *
 	 * @readonly
 	 * @access public
-	 * @type {Object<String, any>}
+	 * @type {Object<string, any>}
 	 */
 	data = {};
 
 	/**
 	 * Create an operational error.
 	 *
-	 * @param {(String|OperationalErrorData & Record<String, any>)} [data = {}]
+	 * @param {(string | OperationalErrorData & Record<string, any>)} [data = {}]
 	 *     The error message if it's a string, or full error information if an object.
 	 */
 	constructor(data = {}) {
@@ -76,7 +76,7 @@ class OperationalError extends Error {
 	 * Reserved keys that should not appear in `OperationalError.prototype.data`.
 	 *
 	 * @access private
-	 * @type {Array<String>}
+	 * @type {Array<string>}
 	 */
 	static reservedKeys = ['code', 'message'];
 
@@ -99,9 +99,9 @@ class OperationalError extends Error {
 	 * Normalize a machine-readable error code.
 	 *
 	 * @access private
-	 * @param {String} code
+	 * @param {string} code
 	 *     The error code to normalize.
-	 * @returns {String}
+	 * @returns {string}
 	 *     Returns the normalized error code.
 	 */
 	static normalizeErrorCode(code) {

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -44,7 +44,7 @@ class OperationalError extends Error {
 	 *
 	 * @readonly
 	 * @access public
-	 * @type {Object<String, String>}
+	 * @type {Object<String, any>}
 	 */
 	data = {};
 

--- a/packages/errors/test/lib/http-error.spec.js
+++ b/packages/errors/test/lib/http-error.spec.js
@@ -45,6 +45,12 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 			});
 		});
 
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
 		describe('.message', () => {
 			it('is set to the status message for the default 500 code', () => {
 				expect(instance.message).toStrictEqual('mock status message');
@@ -94,6 +100,12 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 		describe('.code', () => {
 			it('is set to "HTTP_500"', () => {
 				expect(instance.code).toStrictEqual('HTTP_500');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
 			});
 		});
 
@@ -154,6 +166,12 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 			});
 		});
 
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
 		describe('.message', () => {
 			it('is set to the status message for the normalized status code', () => {
 				expect(instance.message).toStrictEqual('mock status message');
@@ -200,7 +218,8 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 			instance = new HttpError({
 				message: 'mock message',
 				code: 'mock_code',
-				statusCode: 567
+				statusCode: 567,
+				extra: 'mock extra data'
 			});
 		});
 
@@ -219,6 +238,14 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 		describe('.code', () => {
 			it('is set to the normalized error code', () => {
 				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an object containing the extra keys in `data`', () => {
+				expect(instance.data).toEqual({
+					extra: 'mock extra data'
+				});
 			});
 		});
 

--- a/packages/errors/test/lib/http-error.spec.js
+++ b/packages/errors/test/lib/http-error.spec.js
@@ -1,0 +1,316 @@
+const HttpError = require('../../lib/http-error');
+const OperationalError = require('../../lib/operational-error');
+
+jest.mock('http', () => ({
+	STATUS_CODES: {
+		400: 'mock 400 message',
+		456: 'mock 456 message',
+		500: 'mock 500 message'
+	}
+}));
+
+describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('exports a class', () => {
+		expect(HttpError).toBeInstanceOf(Function);
+		expect(() => {
+			HttpError();
+		}).toThrow(/class constructor/i);
+	});
+
+	it('extends the OperationalError class', () => {
+		expect(HttpError.prototype).toBeInstanceOf(OperationalError);
+	});
+
+	describe('new HttpError()', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new HttpError();
+		});
+
+		it('gets the status message for the 500 code', () => {
+			expect(HttpError.getMessageForStatusCode).toBeCalledWith(500);
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_500"', () => {
+				expect(instance.code).toStrictEqual('HTTP_500');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "HttpError"', () => {
+				expect(instance.name).toStrictEqual('HttpError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 500', () => {
+				expect(instance.statusCode).toStrictEqual(500);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new HttpError(message)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new HttpError('mock message');
+		});
+
+		it('gets the status message for the 500 code', () => {
+			expect(HttpError.getMessageForStatusCode).toBeCalledWith(500);
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_500"', () => {
+				expect(instance.code).toStrictEqual('HTTP_500');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the passed in message parameter', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "HttpError"', () => {
+				expect(instance.name).toStrictEqual('HttpError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 500', () => {
+				expect(instance.statusCode).toStrictEqual(500);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new HttpError(statusCode)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new HttpError(567);
+		});
+
+		it('normalizes the passed in status code', () => {
+			expect(HttpError.normalizeErrorStatusCode).toBeCalledWith(567);
+		});
+
+		it('gets the status message for the normalized code', () => {
+			expect(HttpError.getMessageForStatusCode).toBeCalledWith(456);
+		});
+
+		describe('.code', () => {
+			it('is set to a code representing the normalized status code', () => {
+				expect(instance.code).toStrictEqual('HTTP_456');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "HttpError"', () => {
+				expect(instance.name).toStrictEqual('HttpError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new HttpError(data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new HttpError({
+				message: 'mock message',
+				code: 'mock_code',
+				statusCode: 567
+			});
+		});
+
+		it('normalizes the passed in error code', () => {
+			expect(HttpError.normalizeErrorCode).toBeCalledWith('mock_code');
+		});
+
+		it('normalizes the passed in status code', () => {
+			expect(HttpError.normalizeErrorStatusCode).toBeCalledWith(567);
+		});
+
+		it('gets the status message for the normalized code', () => {
+			expect(HttpError.getMessageForStatusCode).toBeCalledWith(456);
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "HttpError"', () => {
+				expect(instance.name).toStrictEqual('HttpError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the passed in status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('.normalizeErrorStatusCode(statusCode)', () => {
+		describe('when the status code is a valid error code', () => {
+			it('returns the passed in status code', () => {
+				expect(HttpError.normalizeErrorStatusCode(456)).toStrictEqual(456);
+			});
+		});
+
+		describe('when the status code is less than 400', () => {
+			it('returns 500', () => {
+				expect(HttpError.normalizeErrorStatusCode(345)).toStrictEqual(500);
+			});
+		});
+
+		describe('when the status code is greater than 500', () => {
+			it('returns 500', () => {
+				expect(HttpError.normalizeErrorStatusCode(678)).toStrictEqual(500);
+			});
+		});
+
+		describe('when the status code is a floating point number', () => {
+			it('returns the floored number', () => {
+				expect(HttpError.normalizeErrorStatusCode(456.8)).toStrictEqual(456);
+			});
+		});
+	});
+
+	describe('.getMessageForStatusCode(statusCode)', () => {
+		describe('when the status code is a valid HTTP status code', () => {
+			it('returns the matching message', () => {
+				expect(HttpError.getMessageForStatusCode(456)).toStrictEqual(
+					'mock 456 message'
+				);
+			});
+		});
+
+		describe('when the status code is an invalid HTTP status code between 400 and 499', () => {
+			it('returns the message for a 400 error', () => {
+				expect(HttpError.getMessageForStatusCode(468)).toStrictEqual(
+					'mock 400 message'
+				);
+			});
+		});
+
+		describe('when the status code is an invalid HTTP status code greater than 499', () => {
+			it('returns the message for a 500 error', () => {
+				expect(HttpError.getMessageForStatusCode(567)).toStrictEqual(
+					'mock 500 message'
+				);
+			});
+		});
+
+		describe('when the status code is an invalid HTTP status code less than 400', () => {
+			it('returns the message for a 500 error', () => {
+				expect(HttpError.getMessageForStatusCode(137)).toStrictEqual(
+					'mock 500 message'
+				);
+			});
+		});
+	});
+});

--- a/packages/errors/test/lib/index.spec.js
+++ b/packages/errors/test/lib/index.spec.js
@@ -1,10 +1,17 @@
 const errors = require('../..');
 
+jest.mock('../../lib/http-error', () => 'mock-http-error');
 jest.mock('../../lib/operational-error', () => 'mock-operational-error');
 
 describe('@dotcom-reliability-kit/errors', () => {
 	it('exports an object', () => {
 		expect(errors).toBeInstanceOf(Object);
+	});
+
+	describe('.HttpError', () => {
+		it('aliases lib/http-error', () => {
+			expect(errors.HttpError).toStrictEqual('mock-http-error');
+		});
 	});
 
 	describe('.OperationalError', () => {

--- a/packages/errors/test/lib/operational-error.spec.js
+++ b/packages/errors/test/lib/operational-error.spec.js
@@ -1,10 +1,13 @@
 const OperationalError = require('../../lib/operational-error');
 
-describe('@dotcom-reliability-kit/errors/lib/operationa-error', () => {
+describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('exports a class', () => {
 		expect(OperationalError).toBeInstanceOf(Function);
 		expect(() => {
-			// @ts-ignore TypeScript will not allow us to use a class constructor like this
 			OperationalError();
 		}).toThrow(/class constructor/i);
 	});
@@ -13,17 +16,48 @@ describe('@dotcom-reliability-kit/errors/lib/operationa-error', () => {
 		expect(OperationalError.prototype).toBeInstanceOf(Error);
 	});
 
+	describe('new OperationalError()', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new OperationalError();
+		});
+
+		describe('.code', () => {
+			it('is set to "UNKNOWN"', () => {
+				expect(instance.code).toStrictEqual('UNKNOWN');
+			});
+		});
+
+		describe('.isOperational', () => {
+			it('is set to true', () => {
+				expect(instance.isOperational).toStrictEqual(true);
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to a default value', () => {
+				expect(instance.message).toStrictEqual('An operational error occurred');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "OperationalError"', () => {
+				expect(instance.name).toStrictEqual('OperationalError');
+			});
+		});
+	});
+
 	describe('new OperationalError(message)', () => {
-		/** @type {OperationalError} */
 		let instance;
 
 		beforeEach(() => {
 			instance = new OperationalError('mock message');
 		});
 
-		describe('.name', () => {
-			it('is set to "OperationalError"', () => {
-				expect(instance.name).toStrictEqual('OperationalError');
+		describe('.code', () => {
+			it('is set to "UNKNOWN"', () => {
+				expect(instance.code).toStrictEqual('UNKNOWN');
 			});
 		});
 
@@ -36,6 +70,54 @@ describe('@dotcom-reliability-kit/errors/lib/operationa-error', () => {
 		describe('.message', () => {
 			it('is set to the passed in message parameter', () => {
 				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "OperationalError"', () => {
+				expect(instance.name).toStrictEqual('OperationalError');
+			});
+		});
+	});
+
+	describe('new OperationalError(data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			instance = new OperationalError({
+				message: 'mock message',
+				code: 'mock_code'
+			});
+		});
+
+		it('normalizes the passed in error code', () => {
+			expect(OperationalError.normalizeErrorCode).toBeCalledWith('mock_code');
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.isOperational', () => {
+			it('is set to true', () => {
+				expect(instance.isOperational).toStrictEqual(true);
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "OperationalError"', () => {
+				expect(instance.name).toStrictEqual('OperationalError');
 			});
 		});
 	});
@@ -62,12 +144,19 @@ describe('@dotcom-reliability-kit/errors/lib/operationa-error', () => {
 		describe('when called with an Error instance that has a manually added `isOperational` property', () => {
 			it('returns `true`', () => {
 				const error = new Error('mock message');
-				// @ts-ignore Fine to add additonal properties for testing purposes
 				error.isOperational = true;
 				expect(
 					OperationalError.isErrorMarkedAsOperational(error)
 				).toStrictEqual(true);
 			});
+		});
+	});
+
+	describe('.normalizeErrorCode(code)', () => {
+		it('uppercases and normalizes spacing in the code', () => {
+			expect(
+				OperationalError.normalizeErrorCode(' ABC-123_foo   bar ')
+			).toStrictEqual('ABC_123_FOO_BAR');
 		});
 	});
 });

--- a/packages/errors/test/lib/operational-error.spec.js
+++ b/packages/errors/test/lib/operational-error.spec.js
@@ -29,6 +29,12 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 			});
 		});
 
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
 		describe('.isOperational', () => {
 			it('is set to true', () => {
 				expect(instance.isOperational).toStrictEqual(true);
@@ -61,6 +67,12 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 			});
 		});
 
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
 		describe('.isOperational', () => {
 			it('is set to true', () => {
 				expect(instance.isOperational).toStrictEqual(true);
@@ -89,7 +101,8 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 				.mockReturnValue('MOCK_CODE');
 			instance = new OperationalError({
 				message: 'mock message',
-				code: 'mock_code'
+				code: 'mock_code',
+				extra: 'mock extra data'
 			});
 		});
 
@@ -100,6 +113,14 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 		describe('.code', () => {
 			it('is set to the normalized error code', () => {
 				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an object containing the extra keys in `data`', () => {
+				expect(instance.data).toEqual({
+					extra: 'mock extra data'
+				});
 			});
 		});
 


### PR DESCRIPTION
This PR is a little large, but I found it difficult to split across multiple PRs because everything is very tightly interlinked. What I have done is written it as [separate smaller commits](https://github.com/Financial-Times/dotcom-reliability-kit/pull/14/commits) which it's possible to review individually. A _lot_ of the added code is in the tests, which maybe don't need to be reviewed quite as thoroughly – I've managed to keep 100% coverage.

## What does this do?

  * I've finished writing the basics for an `OperationalError` class, which allows us to identify when an error is expected vs unexpected. Operational errors also _always_ have an error code so that we can reliably identify the errors when they're logged.

  * I've added an `HttpError` class, which represents a 400–599 response. This is because `http-errors` is one of the most widely-used packages for error handling across our repos – there's clearly a need for something like this.

The best way to understand how these work is to [read the README for the package](https://github.com/Financial-Times/dotcom-reliability-kit/blob/build-errors-package/packages/errors/README.md#dotcom-reliability-kiterrors), as this outlines the full public API for the different error classes.

## Why

I might be jumping the gun a little, but I was having some trouble sleeping and wanted something to work on to engage my brain. Also we've had the proposal up for a week so far and none of the responses have been along the lines of "please don't do this".

## Why not a third party?

I looked into a few third-party libraries for this and opted to not use them under the hood. I'll attempt to explain my thinking here but this is open to argument for sure.

### `OperationalError`

The requirements I think we have for a base error class (which all others extend from) are:

  1. It needs to be marked consistently as "this is an error that we understand". This is so that the rest of our tooling and logging can properly differentiate between known and unknown errors.
  2. It needs to support and encourage having both human-readable and machine-readable identifiers. The error message is for humans to read and might contain information (e.g. `article {ID} is malformed`) which makes it difficult to group the errors because the message may change. The error code is for machines to read and identifies the _class_ of error found and will be the same regardless of slight variations in the error information (e.g. `MALFORMED_ARTICLE`). I think `error.code` would be the best route to go down for this because [it's what Node.js uses](https://nodejs.org/dist/latest-v16.x/docs/api/errors.html#nodejs-error-codes) and means we only have to check one property to determine the class of error.

I looked at the following libraries to see whether they could work for us because they were suggested in the design document (spoiler, I don't think they do):

  * [verror](https://www.npmjs.com/package/verror): this seems to be largely based around strings rather than being able to pass additional data into errors. It also doesn't support setting a `code` or other identifier property easily which I think we need
  * [error-ex](https://www.npmjs.com/package/error-ex): this seems closer to what we want and we could potentially rely on teams extending errors rather than using `code`, but then the rest of our tooling would have to rely on `error.name` or something similar as _well_ as `error.code` (in order to properly identify Node.js built-in errors vs our ones)

### `HttpError`

We do use [http-errors](https://www.npmjs.com/package/http-errors) quite a lot, and I looked into this as an alternative to rolling our own. My main issues were that:

1. This library does not easily support adding a `code` property, so we'd need to extend it somehow anyway. I think it's important that we strive for each error type to have a single (common) property to identify the type of error.
2. Ideally all of our errors will extend a single base error type (in the case of this PR, `OperationalError`). This helps us ensure common required properties are in place and has the benefit of identifying thrown HTTP errors as "known" rather than "unknown"

## What feedback are you looking for?

Anything really. From typos and small suggestions to "your general approach is wrong". Please keep discussion to this PR as it'll be useful in future to have all the conversation in one place if we ever need to explain or justify our approach.