### PR TITLE
chore: write a script to create new packages

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,7 @@ We're glad you want to contribute to Reliability Kit!
   * [Requirements](#requirements)
     * [Optional](#optional)
   * [Getting set up](#getting-set-up)
+  * [Creating a new package](#creating-a-new-package)
   * [Testing](#testing)
     * [Linters](#linters)
     * [Type safety](#type-safety)
@@ -40,6 +41,19 @@ To set up this repo to make changes locally, make sure you have all of the [requ
   * Clone this repo and `cd` into it
   * Run `npm install` to install dependencies
   * Run `npm test` to verify that everything's working
+
+
+## Creating a new package
+
+To create a new package in this repo, run the following command. This will bootstrap the package files and make sure it's added to the [release configuration](#releasing) and is auto-versioned correctly.
+
+The name of the package must be lowercase with words hyphen-delimited.
+
+```
+npm run create-package <NAME>
+```
+
+You'll need to manually add the package to the list of packages in the README once it's ready to be used by other teams.
 
 
 ## Testing

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,7 @@
 		"allowJs": true,
 		"checkJs": true,
 		"module": "commonjs",
+		"resolveJsonModule": true,
 		"strict": true,
 		"target": "es2020"
 	},

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "packages/*"
   ],
   "scripts": {
+    "create-package": "./scripts/create-package.js",
     "lint": "npm run lint:eslint && npm run lint:tsc",
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit --project ./jsconfig.json",

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fs = require('fs/promises');
+const path = require('path');
+const rootManifest = require('../package.json');
+const releasePleaseConfig = require('../release-please-config.json');
+const releasePleaseManifest = require('../.release-please-manifest.json');
+
+(async () => {
+	// Get the package name
+	const name = process.argv[2];
+	if (!name) {
+		throw new Error('No package name provided');
+	}
+
+	// Create the package directory
+	const packagePath = path.resolve(__dirname, '..', 'packages', name);
+	console.log(`📂 creating package directory "packages/${name}"`);
+	await fs.mkdir(packagePath);
+
+	// Create a package manifest
+	const manifest = {
+		name: `@dotcom-reliability-kit/${name}`,
+		version: '0.0.0',
+		description: 'TODO',
+		repository: {
+			type: 'git',
+			url: 'https://github.com/Financial-Times/dotcom-reliability-kit.git',
+			directory: `packages/${name}`
+		},
+		homepage: `https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/${name}#readme`,
+		bugs: 'https://github.com/Financial-Times/dotcom-reliability-kit/issues',
+		license: rootManifest.license,
+		engines: rootManifest.engines,
+		main: 'lib'
+	};
+	console.log('📦 initialising "package.json"');
+	await fs.writeFile(
+		path.join(packagePath, 'package.json'),
+		JSON.stringify(manifest, null, 2)
+	);
+
+	console.log('📖 writing "README.md"');
+	await fs.writeFile(
+		path.join(packagePath, 'README.md'),
+		`
+## @dotcom-reliability-kit/${name}
+
+This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+`
+	);
+
+	// Create an npm ignore file
+	console.log('📄 adding ".npmignore"');
+	await fs.writeFile(
+		path.join(packagePath, '.npmignore'),
+		['CHANGELOG.md', 'docs', 'test'].join('\n')
+	);
+
+	// Bootstrap base JavaScript files
+	console.log('🏗  adding "lib/index.js"');
+	const libPath = path.join(packagePath, 'lib');
+	await fs.mkdir(libPath);
+	await fs.writeFile(
+		path.join(libPath, 'index.js'),
+		`/**
+ * @module @dotcom-reliability-kit/${name}
+ */
+
+module.exports = {};
+`
+	);
+
+	// Bootstrap test JavaScript files
+	console.log('🏗  adding "test/lib/index.spec.js"');
+	const testPath = path.join(packagePath, 'test', 'lib');
+	await fs.mkdir(testPath, { recursive: true });
+	await fs.writeFile(
+		path.join(testPath, 'index.spec.js'),
+		`describe('@dotcom-reliability-kit/${name}', () => {
+	it('has some tests', () => {
+		throw new Error('Plase write some tests');
+	});
+});
+`
+	);
+
+	// Add package to Release Please config
+	console.log('🚢 adding package to Release Please config');
+	// @ts-ignore
+	releasePleaseConfig.packages[`packages/${name}`] = {};
+	await fs.writeFile(
+		path.resolve(__dirname, '..', 'release-please-config.json'),
+		JSON.stringify(releasePleaseConfig, null, '\t')
+	);
+
+	console.log('🚢 adding package to Release Please manifest');
+	// @ts-ignore
+	releasePleaseManifest[`packages/${name}`] = '0.0.0';
+	await fs.writeFile(
+		path.resolve(__dirname, '..', '.release-please-manifest.json'),
+		JSON.stringify(releasePleaseManifest, null, '\t')
+	);
+})().catch((error) => {
+	console.error(error.message);
+	process.exitCode = 1;
+});

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -80,7 +80,7 @@ module.exports = {};
 		path.join(testPath, 'index.spec.js'),
 		`describe('@dotcom-reliability-kit/${name}', () => {
 	it('has some tests', () => {
-		throw new Error('Plase write some tests');
+		throw new Error('Please write some tests');
 	});
 });
 `


### PR DESCRIPTION
When I was setting up `packages/errors`, I missed a lot of things that
were required to get the package to be released with Release Please. I
also think it'll be easy to see some inconsistency in the way packages
are built the more we add them.

This PR adds a new script which automatically creates the boilerplate
for a new Reliability Kit package, taking a lot of inspiration from the
[equivalent script in Tool Kit](https://github.com/Financial-Times/dotcom-tool-kit/blob/main/scripts/create-plugin.js).

There's documentation on how the script is run in the contributing
guide, as I think that's where people would most likely look.