### PR TITLE
Build serialize-error package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "packages/errors": "0.1.1"
+  "packages/errors": "0.1.1",
+  "packages/serialize-error": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ All of the packages in this monorepo are viewable in the [`packages` folder](./p
   * **[@dotcom-reliability-kit/errors](./packages/errors/#readme):**<br/>
     A suite of error classes which help you throw the most appropriate error in any situation
 
+  * **[@dotcom-reliability-kit/serialize-error](./packages/serialize-error/#readme):**<br/>
+    A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON
+
 
 ## Design
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -914,6 +914,10 @@
       "resolved": "packages/errors",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/serialize-error": {
+      "resolved": "packages/serialize-error",
+      "link": true
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
@@ -7433,6 +7437,14 @@
       "name": "@dotcom-reliability-kit/example",
       "version": "0.0.0",
       "extraneous": true
+    },
+    "packages/serialize-error": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
     }
   },
   "dependencies": {
@@ -8107,6 +8119,9 @@
     },
     "@dotcom-reliability-kit/errors": {
       "version": "file:packages/errors"
+    },
+    "@dotcom-reliability-kit/serialize-error": {
+      "version": "file:packages/serialize-error"
     },
     "@es-joy/jsdoccomment": {
       "version": "0.29.0",

--- a/packages/serialize-error/.npmignore
+++ b/packages/serialize-error/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -84,7 +84,7 @@ This is extracted from the `error.stack` property. If this property is not a str
 
 #### `SerializedError.statusCode`
 
-This is extracted from the `error.statusCode` property first, then the `error.status` property otherwise. These are always cast to a `Number` and this property defaults to `null`.
+This is extracted from the `error.statusCode` property first, then the `error.status` property otherwise (we use look at both properties to maintain compatibility with third-party request and error libraries). These are always cast to a `Number` and this property defaults to `null`.
 
 #### `SerializedError.data`
 

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -45,7 +45,7 @@ serializeError(new Error('example message'));
 //     message: 'An error occurred',
 //     isOperational: false,
 //     stack: '...',
-//     statusCode: 500,
+//     statusCode: null,
 //     data: {}
 // }
 ```
@@ -84,7 +84,7 @@ This is extracted from the `error.stack` property. If this property is not a str
 
 #### `SerializedError.statusCode`
 
-This is extracted from the `error.statusCode` property first, then the `error.status` property otherwise. These are always cast to a `Number` and this property defaults to `500`.
+This is extracted from the `error.statusCode` property first, then the `error.status` property otherwise. These are always cast to a `Number` and this property defaults to `null`.
 
 #### `SerializedError.data`
 

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -6,6 +6,7 @@ A utility function to serialize an error object in a way that's friendly to logg
   * [Usage](#usage)
     * [`serializeError`](#serializeerror)
     * [`SerializedError` type](#serializederror-type)
+      * [`SerializedError.name`](#serializederrorname)
       * [`SerializedError.code`](#serializederrorcode)
       * [`SerializedError.message`](#serializederrormessage)
       * [`SerializedError.isOperational`](#serializederrorisoperational)
@@ -39,6 +40,7 @@ The `serializeError` function accepts an error-like object (e.g. an instance of 
 ```js
 serializeError(new Error('example message'));
 // {
+//     name: 'Error',
 //     code: 'UNKNOWN',
 //     message: 'An error occurred',
 //     isOperational: false,
@@ -59,6 +61,10 @@ serializeError({
 ### `SerializedError` type
 
 The `SerializedError` type documents the return value of the [`serializeError` function](#serializeerror). It will always have the following properties, extracting them from a given error object.
+
+#### `SerializedError.name`
+
+This is extracted from the `error.name` property and is always cast to a `String`. It defaults to `"Error"`.
 
 #### `SerializedError.code`
 

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -1,0 +1,96 @@
+
+## @dotcom-reliability-kit/serialize-error
+
+A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`serializeError`](#serializeerror)
+    * [`SerializedError` type](#serializederror-type)
+      * [`SerializedError.code`](#serializederrorcode)
+      * [`SerializedError.message`](#serializederrormessage)
+      * [`SerializedError.isOperational`](#serializederrorisoperational)
+      * [`SerializedError.stack`](#serializederrorstack)
+      * [`SerializedError.statusCode`](#serializederrorstatuscode)
+      * [`SerializedError.data`](#serializederrordata)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/serialize-error` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/serialize-error
+```
+
+Include in your code:
+
+```js
+import serializeError from '@dotcom-reliability-kit/serialize-error';
+// or
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+```
+
+### `serializeError`
+
+The `serializeError` function accepts an error-like object (e.g. an instance of `Error` or an object with a `message` property) and returns a plain JavaScript object (conforming to the [`SerializedError` type](#serializederror-type)) which contains the relevant properties:
+
+```js
+serializeError(new Error('example message'));
+// {
+//     code: 'UNKNOWN',
+//     message: 'An error occurred',
+//     isOperational: false,
+//     stack: '...',
+//     statusCode: 500,
+//     data: {}
+// }
+```
+
+You can also pass in a plain object if you already have one that looks like an error (e.g. from a JSON API response):
+
+```js
+serializeError({
+    message: 'example message'
+});
+```
+
+### `SerializedError` type
+
+The `SerializedError` type documents the return value of the [`serializeError` function](#serializeerror). It will always have the following properties, extracting them from a given error object.
+
+#### `SerializedError.code`
+
+This is extracted from the `error.code` property and is always cast to a `String`. It defaults to `"UNKNOWN"`.
+
+#### `SerializedError.message`
+
+This is extracted from the `error.message` property and is always cast to a `String`. It defaults to `"An error occurred"`, which is not very helpful but we want this library to be resilient to unexpected input data.
+
+#### `SerializedError.isOperational`
+
+This indicates whether the error is operational (known about). See the documentation for [`OperationalError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#operationalerror) for more information. It is extracted from the `error.isOperational` property. It is always cast to a `Boolean` and defaults to `false`.
+
+#### `SerializedError.stack`
+
+This is extracted from the `error.stack` property. If this property is not a string, then it will default to `null`.
+
+#### `SerializedError.statusCode`
+
+This is extracted from the `error.statusCode` property first, then the `error.status` property otherwise. These are always cast to a `Number` and this property defaults to `500`.
+
+#### `SerializedError.data`
+
+This is extracted from the `error.data` property. If this property is not a plain object, then it will default to an empty object: `{}`.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -14,7 +14,7 @@
  *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
  * @property {(string | null)} stack
  *     The full error stack.
- * @property {number} statusCode
+ * @property {(number | null)} statusCode
  *     An HTTP status code to represent the error.
  * @property {Object<string, any>} data
  *     Any additional error information.
@@ -96,7 +96,7 @@ function createSerializedError(properties) {
 			message: 'An error occurred',
 			isOperational: false,
 			stack: null,
-			statusCode: 500,
+			statusCode: null,
 			data: {}
 		},
 		properties

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -1,0 +1,98 @@
+/**
+ * @module @dotcom-reliability-kit/serialize-error
+ */
+
+/**
+ * @typedef {Object} SerializedError
+ * @property {String} code
+ *     A machine-readable error code which identifies the specific type of error.
+ * @property {String} message
+ *     A human readable message which describes the error.
+ * @property {Boolean} isOperational
+ *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
+ * @property {(String|null)} stack
+ *     The full error stack.
+ * @property {Number} statusCode
+ *     An HTTP status code to represent the error.
+ * @property {Object<String, any>} data
+ *     Any additional error information.
+ */
+
+/**
+ * Serialize an error object so that it can be consistently logged or output as JSON.
+ *
+ * @access public
+ * @param {(String|Error & Record<String, any>)} error
+ *     The error object to serialize.
+ * @returns {SerializedError}
+ *     Returns the serialized error object.
+ */
+function serializeError(error) {
+	if (typeof error !== 'object' || Array.isArray(error) || error === null) {
+		return createSerializedError({
+			message: `${error}`
+		});
+	}
+
+	const errorProperties = {};
+
+	// If set, error code is cast to a string
+	if (error.code) {
+		errorProperties.code = `${error.code}`;
+	}
+
+	// If set, error message is cast to a string
+	if (error.message) {
+		errorProperties.message = `${error.message}`;
+	}
+
+	// The `isOperational` property is cast to a boolean
+	errorProperties.isOperational = Boolean(error.isOperational);
+
+	// Only include error stack if it's a string
+	if (typeof error.stack === 'string') {
+		errorProperties.stack = error.stack;
+	}
+
+	// If set, cast the error status code to a number
+	if (error.statusCode || error.status) {
+		errorProperties.statusCode = parseInt(error.statusCode || error.status, 10);
+	}
+
+	// Only include additional error data if it's defined as an object
+	if (
+		typeof error.data === 'object' &&
+		!Array.isArray(error.data) &&
+		error.data !== null
+	) {
+		errorProperties.data = error.data;
+	}
+
+	return createSerializedError(errorProperties);
+}
+
+/**
+ * Create a new serialized error object.
+ *
+ * @access private
+ * @param {Record<String, any>} properties
+ *     The properties of the serialized error.
+ * @returns {SerializedError}
+ *     Returns the serialized error object.
+ */
+function createSerializedError(properties) {
+	return Object.assign(
+		{},
+		{
+			code: 'UNKNOWN',
+			message: 'An error occurred',
+			isOperational: false,
+			stack: null,
+			statusCode: 500,
+			data: {}
+		},
+		properties
+	);
+}
+
+module.exports = serializeError;

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -4,6 +4,8 @@
 
 /**
  * @typedef {Object} SerializedError
+ * @property {String} name
+ *     The name of the class that the error is an instance of.
  * @property {String} code
  *     A machine-readable error code which identifies the specific type of error.
  * @property {String} message
@@ -35,6 +37,11 @@ function serializeError(error) {
 	}
 
 	const errorProperties = {};
+
+	// If set, error name is cast to a string
+	if (error.name) {
+		errorProperties.name = `${error.name}`;
+	}
 
 	// If set, error code is cast to a string
 	if (error.code) {
@@ -84,6 +91,7 @@ function createSerializedError(properties) {
 	return Object.assign(
 		{},
 		{
+			name: 'Error',
 			code: 'UNKNOWN',
 			message: 'An error occurred',
 			isOperational: false,

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -3,20 +3,20 @@
  */
 
 /**
- * @typedef {Object} SerializedError
- * @property {String} name
+ * @typedef {object} SerializedError
+ * @property {string} name
  *     The name of the class that the error is an instance of.
- * @property {String} code
+ * @property {string} code
  *     A machine-readable error code which identifies the specific type of error.
- * @property {String} message
+ * @property {string} message
  *     A human readable message which describes the error.
- * @property {Boolean} isOperational
+ * @property {boolean} isOperational
  *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
- * @property {(String|null)} stack
+ * @property {(string | null)} stack
  *     The full error stack.
- * @property {Number} statusCode
+ * @property {number} statusCode
  *     An HTTP status code to represent the error.
- * @property {Object<String, any>} data
+ * @property {Object<string, any>} data
  *     Any additional error information.
  */
 
@@ -24,7 +24,7 @@
  * Serialize an error object so that it can be consistently logged or output as JSON.
  *
  * @access public
- * @param {(String|Error & Record<String, any>)} error
+ * @param {(string | Error & Record<string, any>)} error
  *     The error object to serialize.
  * @returns {SerializedError}
  *     Returns the serialized error object.
@@ -82,7 +82,7 @@ function serializeError(error) {
  * Create a new serialized error object.
  *
  * @access private
- * @param {Record<String, any>} properties
+ * @param {Record<string, any>} properties
  *     The properties of the serialized error.
  * @returns {SerializedError}
  *     Returns the serialized error object.

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dotcom-reliability-kit/serialize-error",
+  "version": "0.0.0",
+  "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/serialize-error"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib"
+}

--- a/packages/serialize-error/test/lib/index.spec.js
+++ b/packages/serialize-error/test/lib/index.spec.js
@@ -15,7 +15,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: 'mock message',
 				isOperational: false,
 				stack: error.stack,
-				statusCode: 500,
+				statusCode: null,
 				data: {}
 			});
 		});
@@ -138,7 +138,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: 'An error occurred',
 				isOperational: false,
 				stack: null,
-				statusCode: 500,
+				statusCode: null,
 				data: {}
 			});
 		});
@@ -220,7 +220,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: 'mock message',
 				isOperational: false,
 				stack: null,
-				statusCode: 500,
+				statusCode: null,
 				data: {}
 			});
 		});
@@ -235,7 +235,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: '123',
 				isOperational: false,
 				stack: null,
-				statusCode: 500,
+				statusCode: null,
 				data: {}
 			});
 		});
@@ -250,7 +250,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: 'mock,message',
 				isOperational: false,
 				stack: null,
-				statusCode: 500,
+				statusCode: null,
 				data: {}
 			});
 		});

--- a/packages/serialize-error/test/lib/index.spec.js
+++ b/packages/serialize-error/test/lib/index.spec.js
@@ -10,12 +10,22 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 
 		it('returns the expected serialized error properties', () => {
 			expect(serializeError(error)).toMatchObject({
+				name: 'Error',
 				code: 'UNKNOWN',
 				message: 'mock message',
 				isOperational: false,
 				stack: error.stack,
 				statusCode: 500,
 				data: {}
+			});
+		});
+
+		describe('when the error is an instance of something other than `Error`', () => {
+			it('returns the class name in the serialized error properties', () => {
+				error = new TypeError('mock type error');
+				expect(serializeError(error)).toMatchObject({
+					name: 'TypeError'
+				});
 			});
 		});
 
@@ -123,12 +133,22 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 
 		it('returns the expected serialized error properties', () => {
 			expect(serializeError(error)).toMatchObject({
+				name: 'Error',
 				code: 'UNKNOWN',
 				message: 'An error occurred',
 				isOperational: false,
 				stack: null,
 				statusCode: 500,
 				data: {}
+			});
+		});
+
+		describe('when the object has a `name` property', () => {
+			it('returns the name in the serialized error properties', () => {
+				error.name = 'MockError';
+				expect(serializeError(error)).toMatchObject({
+					name: 'MockError'
+				});
 			});
 		});
 
@@ -195,6 +215,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 		it('returns the expected serialized error properties', () => {
 			const error = 'mock message';
 			expect(serializeError(error)).toMatchObject({
+				name: 'Error',
 				code: 'UNKNOWN',
 				message: 'mock message',
 				isOperational: false,
@@ -209,6 +230,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 		it('returns the expected serialized error properties', () => {
 			const error = 123;
 			expect(serializeError(error)).toMatchObject({
+				name: 'Error',
 				code: 'UNKNOWN',
 				message: '123',
 				isOperational: false,
@@ -223,6 +245,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 		it('returns the expected serialized error properties', () => {
 			const error = ['mock', 'message'];
 			expect(serializeError(error)).toMatchObject({
+				name: 'Error',
 				code: 'UNKNOWN',
 				message: 'mock,message',
 				isOperational: false,

--- a/packages/serialize-error/test/lib/index.spec.js
+++ b/packages/serialize-error/test/lib/index.spec.js
@@ -1,0 +1,235 @@
+const serializeError = require('../../lib/index');
+
+describe('@dotcom-reliability-kit/serialize-error', () => {
+	describe('when called with an error object', () => {
+		let error;
+
+		beforeEach(() => {
+			error = new Error('mock message');
+		});
+
+		it('returns the expected serialized error properties', () => {
+			expect(serializeError(error)).toMatchObject({
+				code: 'UNKNOWN',
+				message: 'mock message',
+				isOperational: false,
+				stack: error.stack,
+				statusCode: 500,
+				data: {}
+			});
+		});
+
+		describe('when the error has a `code` property', () => {
+			it('returns the code in the serialized error properties', () => {
+				error.code = 'MOCK_CODE';
+				expect(serializeError(error)).toMatchObject({
+					code: 'MOCK_CODE'
+				});
+			});
+
+			describe('when the `code` property is not a string', () => {
+				it('casts the given value to a string', () => {
+					error.code = 123;
+					expect(serializeError(error)).toMatchObject({
+						code: '123'
+					});
+				});
+			});
+		});
+
+		describe('when the error has an `isOperational` property', () => {
+			it('returns whether the error is operational in the serialized error properties', () => {
+				error.isOperational = true;
+				expect(serializeError(error)).toMatchObject({
+					isOperational: true
+				});
+			});
+
+			describe('when the `isOperational` property is not a boolean', () => {
+				it('casts the given value to a boolean', () => {
+					error.isOperational = 1;
+					expect(serializeError(error)).toMatchObject({
+						isOperational: true
+					});
+				});
+			});
+		});
+
+		describe('when the error has a `statusCode` property', () => {
+			it('returns the status code in the serialized error properties', () => {
+				error.statusCode = 456;
+				expect(serializeError(error)).toMatchObject({
+					statusCode: 456
+				});
+			});
+
+			describe('when the `statusCode` property is not a number', () => {
+				it('casts the given value to a number', () => {
+					error.statusCode = '123';
+					expect(serializeError(error)).toMatchObject({
+						statusCode: 123
+					});
+				});
+			});
+		});
+
+		describe('when the error has a `status` property', () => {
+			it('returns the status code in the serialized error properties', () => {
+				error.status = 456;
+				expect(serializeError(error)).toMatchObject({
+					statusCode: 456
+				});
+			});
+
+			describe('when the `status` property is not a number', () => {
+				it('casts the given value to a number', () => {
+					error.status = '123';
+					expect(serializeError(error)).toMatchObject({
+						statusCode: 123
+					});
+				});
+			});
+		});
+
+		describe('when the error has additional data', () => {
+			it('returns the data in the serialized error properties', () => {
+				error.data = {
+					isMockData: true
+				};
+				expect(serializeError(error)).toMatchObject({
+					data: {
+						isMockData: true
+					}
+				});
+			});
+
+			describe('when the `data` property is not an object', () => {
+				it('defaults the data to an empty object', () => {
+					error.data = null;
+					expect(serializeError(error)).toMatchObject({
+						data: {}
+					});
+				});
+			});
+		});
+	});
+
+	describe('when called with an error-like object', () => {
+		let error;
+
+		beforeEach(() => {
+			error = {};
+		});
+
+		it('returns the expected serialized error properties', () => {
+			expect(serializeError(error)).toMatchObject({
+				code: 'UNKNOWN',
+				message: 'An error occurred',
+				isOperational: false,
+				stack: null,
+				statusCode: 500,
+				data: {}
+			});
+		});
+
+		describe('when the object has a `code` property', () => {
+			it('returns the code in the serialized error properties', () => {
+				error.code = 'MOCK_CODE';
+				expect(serializeError(error)).toMatchObject({
+					code: 'MOCK_CODE'
+				});
+			});
+		});
+
+		describe('when the object has a `message` property', () => {
+			it('returns the message in the serialized error properties', () => {
+				error.message = 'mock message';
+				expect(serializeError(error)).toMatchObject({
+					message: 'mock message'
+				});
+			});
+		});
+
+		describe('when the object has an `isOperational` property', () => {
+			it('returns whether the error is operational in the serialized error properties', () => {
+				error.isOperational = true;
+				expect(serializeError(error)).toMatchObject({
+					isOperational: true
+				});
+			});
+		});
+
+		describe('when the object has a `statusCode` property', () => {
+			it('returns the status code in the serialized error properties', () => {
+				error.statusCode = 456;
+				expect(serializeError(error)).toMatchObject({
+					statusCode: 456
+				});
+			});
+		});
+
+		describe('when the object has a `status` property', () => {
+			it('returns the status code in the serialized error properties', () => {
+				error.status = 456;
+				expect(serializeError(error)).toMatchObject({
+					statusCode: 456
+				});
+			});
+		});
+
+		describe('when the object has additional data', () => {
+			it('returns the data in the serialized error properties', () => {
+				error.data = {
+					isMockData: true
+				};
+				expect(serializeError(error)).toMatchObject({
+					data: {
+						isMockData: true
+					}
+				});
+			});
+		});
+	});
+
+	describe('when called with a string', () => {
+		it('returns the expected serialized error properties', () => {
+			const error = 'mock message';
+			expect(serializeError(error)).toMatchObject({
+				code: 'UNKNOWN',
+				message: 'mock message',
+				isOperational: false,
+				stack: null,
+				statusCode: 500,
+				data: {}
+			});
+		});
+	});
+
+	describe('when called with a number', () => {
+		it('returns the expected serialized error properties', () => {
+			const error = 123;
+			expect(serializeError(error)).toMatchObject({
+				code: 'UNKNOWN',
+				message: '123',
+				isOperational: false,
+				stack: null,
+				statusCode: 500,
+				data: {}
+			});
+		});
+	});
+
+	describe('when called with an array', () => {
+		it('returns the expected serialized error properties', () => {
+			const error = ['mock', 'message'];
+			expect(serializeError(error)).toMatchObject({
+				code: 'UNKNOWN',
+				message: 'mock,message',
+				isOperational: false,
+				stack: null,
+				statusCode: 500,
+				data: {}
+			});
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,7 @@
 		"node-workspace"
 	],
 	"packages": {
-		"packages/errors": {}
+		"packages/errors": {},
+		"packages/serialize-error": {}
 	}
 }


### PR DESCRIPTION
This adds a serialize-error utility package. This new package exports
a utility function to serialize an error object in a way that's friendly
to loggers, view engines, and converting to JSON.

I'm writing this because we need a reliable way to serialize error data
if we tackle any of the following:

  * An error logging middleware so that thrown errors are logged
    consistently to Splunk (planned)

  * Modifications to `n-logger` to enforce more consistent logging of
    errors (not planned but likely we will need it)

  * A debugging page middleware which renders an HTML error page to help
    engineers debug while working locally (planned)

I think it makes sense to publish this as a separate package which is a
dependency of these others.

See the README in this PR for usage documentation.