### PR TITLE
docs: link to Joyent's Error Handling documentation

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -31,6 +31,8 @@ This module exports different Error classes which have different jobs. All can b
 
 The `OperationalError` class is the base class for most other error types. "Operational" in this context means "we understand why this error has occurred", so by using this error type you're helping your team to understand when a thrown error is unexpected.
 
+[Joyent's Error Handling docs](https://www.joyent.com/node-js/production/design/errors) have a good explanation of Operational Errors.
+
 It works in the same way as a normal error, expecting a message:
 
 ```js


### PR DESCRIPTION
@rowanmanning linked to this in #ft-next-dev. It's a good intro for people who are starting to think more seriously about error handling (as we are).

I don't think this will conflict with #14 but if it will we can merge it afterwards.