### PR TITLE
chore: bump errors package in root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7356,7 +7356,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "engines": {
         "node": "14.x || 16.x",


### PR DESCRIPTION
Not exactly sure what's going on here.

---

This is the result of running npm install on main. For some reason the version bump commit doesn't bump this part of package-lock.json