### PR TITLE
chore: set the ESLint JSDoc mode to TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,5 +22,10 @@
 		"prettier/prettier": "error",
 		"quotes": 0,
 		"space-before-function-paren": 0
+	},
+	"settings": {
+		"jsdoc": {
+			"mode": "typescript"
+		}
 	}
 }


### PR DESCRIPTION
This ensures that we can use things like type unions in our code.
See https://github.com/gajus/eslint-plugin-jsdoc#mode for documentation.