### PR TITLE
chore: don't check types in test files

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,8 @@
 	},
 	"exclude": [
 		"coverage",
-		"node_modules"
+		"node_modules",
+		"**/*.spec.js"
 	],
 	"include": [
 		"**/*.js"


### PR DESCRIPTION
I found that I was really fighting TypeScript in the tests, because it's
often useful to mock with dummy data rather than fully mocking the
expected return values of methods.

This stops us from having to litter our tests with ts-ignore comments.