### PR TITLE
feat: add error logging middleware

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/errors": "0.1.2",
+  "packages/middleware-log-errors": "0.0.0",
   "packages/serialize-error": "0.1.1",
   "packages/serialize-request": "0.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ All of the packages in this monorepo are viewable in the [`packages` folder](./p
   * **[@dotcom-reliability-kit/errors](./packages/errors/#readme):**<br/>
     A suite of error classes which help you throw the most appropriate error in any situation
 
+  * **[@dotcom-reliability-kit/middleware-log-errors](./packages/middleware-log-errors/#readme):**<br/>
+    Express middleware to consistently log errors
+
   * **[@dotcom-reliability-kit/serialize-error](./packages/serialize-error/#readme):**<br/>
     A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,8 +4,12 @@
 		"checkJs": true,
 		"module": "commonjs",
 		"resolveJsonModule": true,
-		"strict": true,
-		"target": "es2020"
+		"strictBindCallApply": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"strictPropertyInitialization": true,
+		"target": "es2020",
+		"useUnknownInCatchVariables": true
 	},
 	"exclude": [
 		"coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7586,7 +7586,7 @@
       "dependencies": {
         "@dotcom-reliability-kit/serialize-error": "^0.1.1",
         "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-        "@financial-times/n-logger": "^10.1.0"
+        "@financial-times/n-logger": ">=6.0.0 <11.0.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -8296,7 +8296,7 @@
       "requires": {
         "@dotcom-reliability-kit/serialize-error": "^0.1.1",
         "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-        "@financial-times/n-logger": "10.1.0",
+        "@financial-times/n-logger": ">=6.0.0 <11.0.0",
         "@types/express": "^4.17.13"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -914,6 +914,10 @@
       "resolved": "packages/errors",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/middleware-log-errors": {
+      "resolved": "packages/middleware-log-errors",
+      "link": true
+    },
     "node_modules/@dotcom-reliability-kit/serialize-error": {
       "resolved": "packages/serialize-error",
       "link": true
@@ -965,6 +969,21 @@
       "dependencies": {
         "eslint": ">=5.0.0",
         "eslint-plugin-no-only-tests": ">=2.0.0"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@financial-times/n-logger": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.1.0.tgz",
+      "integrity": "sha512-QUgNLRvPah33B6Ab4zUOV2pFbCi7DQA+/WhgaliAAwGpkc6PymA+V+CcMhQUn5rd/id8ZxywZP6BNPnSvNoZzQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "node-fetch": "^2.6.0",
+        "winston": "^2.4.0"
       },
       "engines": {
         "node": "14.x || 16.x",
@@ -2268,6 +2287,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -2741,6 +2765,14 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -2975,6 +3007,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dargs": {
@@ -3675,6 +3715,14 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4355,6 +4403,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -5069,8 +5122,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -5579,7 +5631,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6742,6 +6793,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -7021,8 +7080,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -7273,14 +7331,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7308,6 +7364,22 @@
       "dev": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/winston": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
+      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/word-wrap": {
@@ -7500,21 +7572,33 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
-    "packages/example": {
-      "name": "@dotcom-reliability-kit/example",
+    "packages/middleware-log-errors": {
+      "name": "@dotcom-reliability-kit/middleware-log-errors",
       "version": "0.0.0",
-      "extraneous": true
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+        "@financial-times/n-logger": "^10.1.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "engines": {
         "node": "14.x || 16.x",
@@ -7523,7 +7607,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -8207,13 +8291,22 @@
     "@dotcom-reliability-kit/errors": {
       "version": "file:packages/errors"
     },
+    "@dotcom-reliability-kit/middleware-log-errors": {
+      "version": "file:packages/middleware-log-errors",
+      "requires": {
+        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+        "@financial-times/n-logger": "10.1.0",
+        "@types/express": "^4.17.13"
+      }
+    },
     "@dotcom-reliability-kit/serialize-error": {
       "version": "file:packages/serialize-error"
     },
     "@dotcom-reliability-kit/serialize-request": {
       "version": "file:packages/serialize-request",
       "requires": {
-        "@types/express": "*"
+        "@types/express": "^4.17.13"
       }
     },
     "@es-joy/jsdoccomment": {
@@ -8252,6 +8345,16 @@
       "requires": {
         "eslint": ">=5.0.0",
         "eslint-plugin-no-only-tests": ">=2.0.0"
+      }
+    },
+    "@financial-times/n-logger": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.1.0.tgz",
+      "integrity": "sha512-QUgNLRvPah33B6Ab4zUOV2pFbCi7DQA+/WhgaliAAwGpkc6PymA+V+CcMhQUn5rd/id8ZxywZP6BNPnSvNoZzQ==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "node-fetch": "^2.6.0",
+        "winston": "^2.4.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -9352,6 +9455,11 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
     "async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -9706,6 +9814,11 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -9891,6 +10004,11 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "dargs": {
       "version": "7.0.0",
@@ -10398,6 +10516,11 @@
         "jest-util": "^28.0.2"
       }
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10898,6 +11021,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11448,8 +11576,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.1",
@@ -11835,7 +11962,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -12683,6 +12809,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -12895,8 +13026,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -13079,14 +13209,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -13108,6 +13236,19 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "winston": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
+      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "requires": {
+        "async": "^3.2.3",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       }
     },
     "word-wrap": {

--- a/packages/middleware-log-errors/.npmignore
+++ b/packages/middleware-log-errors/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -1,0 +1,97 @@
+
+## @dotcom-reliability-kit/middleware-log-errors
+
+Express middleware to consistently log errors. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`createErrorLogger`](#createerrorlogger)
+    * [configuration options](#configuration-options)
+      * [`includeHeaders`](#optionsincludeheaders)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/middleware-log-errors` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/middleware-log-errors
+```
+
+Include in your code:
+
+```js
+import createErrorLogger from '@dotcom-reliability-kit/middleware-log-errors';
+// or
+const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors');
+```
+
+### `createErrorLogger`
+
+The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). It must be added to your Express app _after_ all your application routes:
+
+```js
+const app = express();
+// App routes go here
+app.use(createErrorLogger());
+```
+
+This will automatically [serialize error objects](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme) and log them along with [a serialized HTTP request](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which lead to the error being thrown. The information logged looks like this:
+
+```js
+{
+    event: 'HANDLED_ERROR',
+
+    error: {
+        // See `@dotcom-reliability-kit/serialize-error` (linked above)
+        // for information about the logged properties
+    },
+
+    request: {
+        // See `dotcom-reliability-kit/serialize-request` (linked above)
+        // for information about the logged properties
+    },
+
+    app: {
+        name: 'example-app',
+        region: 'EU'
+    }
+}
+```
+
+### Configuration options
+
+Config options can be passed into the `createErrorLogger` function as an object with any of the keys below.
+
+```js
+app.use(createErrorLogger({
+    // Config options go here
+}));
+```
+
+#### `options.includeHeaders`
+
+An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
+
+```js
+serializeRequest(request, {
+    includeHeaders: [
+        'accept',
+        'content-length',
+        'content-type',
+        'user-agent'
+    ]
+});
+```
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -1,0 +1,61 @@
+/**
+ * @module @dotcom-reliability-kit/middleware-log-errors
+ */
+
+const logger = require('@financial-times/n-logger').default;
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+
+/**
+ * @typedef {object} ErrorLoggingOptions
+ * @property {Array<string>} [includeHeaders]
+ *     An array of request headers to include in the log.
+ */
+
+/**
+ * Create a middleware function to log errors.
+ *
+ * @access public
+ * @param {ErrorLoggingOptions} [options = {}]
+ *     Options to configure the middleware.
+ * @returns {import('express').ErrorRequestHandler}
+ *     Returns error logging middleware.
+ */
+function createErrorLoggingMiddleware(options = {}) {
+	// Validate the included headers (this stops the request serializer from erroring
+	// on every request if the included headers are invalid)
+	const includeHeaders = options?.includeHeaders;
+	if (includeHeaders) {
+		if (
+			!Array.isArray(includeHeaders) ||
+			!includeHeaders.every((header) => typeof header === 'string')
+		) {
+			throw new TypeError(
+				'The `includeHeaders` option must be an array of strings'
+			);
+		}
+	}
+
+	return (error, request, response, next) => {
+		// We add a paranoid try/catch here because it'd be really embarassing
+		// if the error logging middleware threw an unhandled error, wouldn't it
+		try {
+			const app = {
+				name: response.getHeader('ft-app-name') || null,
+				region: process.env.REGION || null
+			};
+
+			logger.error({
+				event: 'HANDLED_ERROR',
+				error: serializeError(error),
+				request: serializeRequest(request, { includeHeaders }),
+				app
+			});
+		} catch (_) {
+			// Not a lot we can do here
+		}
+		next(error);
+	};
+}
+
+module.exports = createErrorLoggingMiddleware;

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@dotcom-reliability-kit/serialize-error": "^0.1.1",
     "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-    "@financial-times/n-logger": "^10.1.0"
+    "@financial-times/n-logger": ">=6.0.0 <11.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13"

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dotcom-reliability-kit/middleware-log-errors",
+  "version": "0.0.0",
+  "description": "Express middleware to consistently log errors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/middleware-log-errors"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+    "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+    "@financial-times/n-logger": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13"
+  }
+}

--- a/packages/middleware-log-errors/test/lib/index.spec.js
+++ b/packages/middleware-log-errors/test/lib/index.spec.js
@@ -1,0 +1,200 @@
+const createErrorLoggingMiddleware = require('../../lib/index');
+
+jest.mock('@financial-times/n-logger', () => ({
+	default: { error: jest.fn() }
+}));
+const logger = require('@financial-times/n-logger').default;
+
+jest.mock('@dotcom-reliability-kit/serialize-error', () =>
+	jest.fn().mockReturnValue('mock-serialized-error')
+);
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+
+jest.mock('@dotcom-reliability-kit/serialize-request', () =>
+	jest.fn().mockReturnValue('mock-serialized-request')
+);
+const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+
+describe('@dotcom-reliability-kit/middleware-log-errors', () => {
+	let middleware;
+
+	beforeEach(() => {
+		middleware = createErrorLoggingMiddleware();
+	});
+
+	describe('middleware(error, request, response, next)', () => {
+		let error;
+		let next;
+		let request;
+		let response;
+
+		beforeEach(() => {
+			process.env.REGION = 'mock-region';
+			error = new Error('mock error');
+			request = { isMockRequest: true };
+			response = {
+				getHeader: jest.fn()
+			};
+			next = jest.fn();
+
+			response.getHeader.mockImplementation((header) => {
+				return `mock-response-${header}-value`;
+			});
+
+			middleware(error, request, response, next);
+		});
+
+		it('serializes the error', () => {
+			expect(serializeError).toBeCalledWith(error);
+		});
+
+		it('serializes the request', () => {
+			expect(serializeRequest).toBeCalledWith(request, {
+				includeHeaders: undefined
+			});
+		});
+
+		it('logs the serialized error, request, and app details', () => {
+			expect(logger.error).toBeCalledWith({
+				event: 'HANDLED_ERROR',
+				error: 'mock-serialized-error',
+				request: 'mock-serialized-request',
+				app: {
+					name: 'mock-response-ft-app-name-value',
+					region: 'mock-region'
+				}
+			});
+		});
+
+		it('calls `next` with the original error', () => {
+			expect(next).toBeCalledWith(error);
+		});
+
+		describe('when the response has no "ft-app-name" header', () => {
+			beforeEach(() => {
+				response.getHeader.mockImplementation(() => undefined);
+				middleware(error, request, response, next);
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app name', () => {
+				expect(logger.error).toBeCalledWith({
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: null,
+						region: 'mock-region'
+					}
+				});
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+
+		describe('when `process.env.REGION` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.REGION;
+				middleware(error, request, response, next);
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('logs without an app region', () => {
+				expect(logger.error).toBeCalledWith({
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-response-ft-app-name-value',
+						region: null
+					}
+				});
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+
+		describe('when the includeHeaders option is set', () => {
+			beforeEach(() => {
+				middleware = createErrorLoggingMiddleware({
+					includeHeaders: ['header-1', 'header-2']
+				});
+				middleware(error, request, response, next);
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request with the configured headers', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('logs the serialized error, request, and app details', () => {
+				expect(logger.error).toBeCalledWith({
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-response-ft-app-name-value',
+						region: 'mock-region'
+					}
+				});
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+
+		describe('when the includeHeaders option is set incorrectly', () => {
+			it('throws an error', () => {
+				const expectedError = new TypeError(
+					'The `includeHeaders` option must be an array of strings'
+				);
+				expect(() => {
+					createErrorLoggingMiddleware({
+						includeHeaders: {}
+					});
+				}).toThrowError(expectedError);
+				expect(() => {
+					createErrorLoggingMiddleware({
+						includeHeaders: ['string', 123, 'another string']
+					});
+				}).toThrowError(expectedError);
+			});
+		});
+
+		describe('when logging fails', () => {
+			beforeEach(() => {
+				logger.error.mockImplementation(() => {
+					throw new Error('logger error');
+				});
+
+				middleware(error, request, response, next);
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
 	],
 	"packages": {
 		"packages/errors": {},
+		"packages/middleware-log-errors": {},
 		"packages/serialize-error": {},
 		"packages/serialize-request": {}
 	}


### PR DESCRIPTION
This adds error logging middleware based on the discussion in the repo
here: https://github.com/Financial-Times/dotcom-reliability-kit/discussions/26. It's relatively small because it leans on the [serialize-error](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme) and
[serialize-request](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) packages.

You use it like this:

```js
import createErrorLogger from '@dotcom-reliability-kit/middleware-log-errors';
import express from '@financial-times/n-express';

// All your app setup and routes

app.use(createErrorLogger());
```

And all errors which get thrown in routes or passed onto Express
will end up logging all this information:

```js
{
    event: 'HANDLED_ERROR',

    // This is just the output of `@dotcom-reliability-kit/serialize-error`
    error: {
        name: 'Error',
        code: 'EXAMPLE_CODE',
        message: 'This is an example error message',
        isOperational: true,
        stack: '...',
        statusCode: 503,
        relatedToSystems: [ 'next-example' ],
        data: {}
    },

    // This is just the output of `@dotcom-reliability-kit/serialize-request`
    request: {
        id: 'xxx-xxxx-xxx',
        method: 'GET',
        url: '/categories/example?page=137',
        headers: {
            accept: '*/*',
            'content-type': null
        },
        route: {
            path: '/categories/:categoryId',
            params: {
                categoryId: 'example'
            }
        }
    },

    // Some of the easier-to-retrieve app details
    app: {
        name: 'example', // the app name as set in the `FT-App-Name` header
        region: 'EU' // the contents of the `REGION` environment variable
    }

}
```

The linked discussion contains most of the rationale behind the logging
structure. This is a first pass which we think should work well for most of
our HTTP-based apps.