### PR TITLE
Add a serialize-request package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/errors": "0.1.1",
-  "packages/serialize-error": "0.1.0"
+  "packages/serialize-error": "0.1.0",
+  "packages/serialize-request": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ All of the packages in this monorepo are viewable in the [`packages` folder](./p
   * **[@dotcom-reliability-kit/serialize-error](./packages/serialize-error/#readme):**<br/>
     A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON
 
+  * **[@dotcom-reliability-kit/serialize-request](./packages/serialize-request/#readme):**<br/>
+    A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON
+
 
 ## Design
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,10 @@
       "resolved": "packages/serialize-error",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/serialize-request": {
+      "resolved": "packages/serialize-request",
+      "link": true
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
@@ -1794,6 +1798,48 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1917,6 +1963,12 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -1952,6 +2004,28 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -7426,7 +7500,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "engines": {
         "node": "14.x || 16.x",
@@ -7439,8 +7513,21 @@
       "extraneous": true
     },
     "packages/serialize-error": {
+      "name": "@dotcom-reliability-kit/serialize-error",
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "packages/serialize-request": {
+      "name": "@dotcom-reliability-kit/serialize-request",
       "version": "0.0.0",
       "license": "MIT",
+      "devDependencies": {
+        "@types/express": "^4.17.13"
+      },
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
@@ -8122,6 +8209,12 @@
     },
     "@dotcom-reliability-kit/serialize-error": {
       "version": "file:packages/serialize-error"
+    },
+    "@dotcom-reliability-kit/serialize-request": {
+      "version": "file:packages/serialize-request",
+      "requires": {
+        "@types/express": "*"
+      }
     },
     "@es-joy/jsdoccomment": {
       "version": "0.29.0",
@@ -8855,6 +8948,48 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8959,6 +9094,12 @@
         }
       }
     },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -8994,6 +9135,28 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",

--- a/packages/serialize-request/.npmignore
+++ b/packages/serialize-request/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/serialize-request/README.md
+++ b/packages/serialize-request/README.md
@@ -8,6 +8,7 @@ A utility function to serialize a request object ([Express](https://expressjs.co
     * [configuration options](#configuration-options)
       * [`includeHeaders`](#optionsincludeheaders)
     * [`SerializedRequest` type](#serializedrequest-type)
+      * [`SerializedRequest.id`](#serializedrequestid)
       * [`SerializedRequest.method`](#serializedrequestmethod)
       * [`SerializedRequest.url`](#serializedrequesturl)
       * [`SerializedRequest.headers`](#serializedrequestheaders)
@@ -42,6 +43,7 @@ app.get('/fruit/:fruitId', (request, response, next) => {
 	next();
 });
 // {
+//     id: 'request137',
 //     method: 'GET',
 //     url: '/fruit/feijoa',
 //     headers: {
@@ -91,6 +93,10 @@ serializeRequest(request, {
 ### `SerializedRequest` type
 
 The `SerializedRequest` type documents the return value of the [`serializeRequest` function](#serializerequest). It will have the following properties, extracting them from a given request object.
+
+#### `SerializedRequest.id`
+
+This is extracted from the `request.headers['x-request-id']` property and is always cast to a `String`. It defaults to `null`.
 
 #### `SerializedRequest.method`
 

--- a/packages/serialize-request/README.md
+++ b/packages/serialize-request/README.md
@@ -1,0 +1,120 @@
+
+## @dotcom-reliability-kit/serialize-request
+
+A utility function to serialize a request object ([Express](https://expressjs.com/en/4x/api.html#req) or [IncomingMessage](https://nodejs.org/api/http.html#class-httpincomingmessage)) in a way that's friendly to loggers, view engines, and converting to JSON. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`serializeRequest`](#serializerequest)
+    * [configuration options](#configuration-options)
+      * [`includeHeaders`](#optionsincludeheaders)
+    * [`SerializedRequest` type](#serializedrequest-type)
+      * [`SerializedRequest.method`](#serializedrequestmethod)
+      * [`SerializedRequest.url`](#serializedrequesturl)
+      * [`SerializedRequest.headers`](#serializedrequestheaders)
+      * [`SerializedRequest.route`](#serializedrequestroute)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/serialize-request` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/serialize-request
+```
+
+Include in your code:
+
+```js
+import serializeRequest from '@dotcom-reliability-kit/serialize-request';
+// or
+const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+```
+
+### `serializeRequest`
+
+The `serializeRequest` function accepts a request-like object (e.g. an instance of `Express.Request` or an object with `method` and `url` properties) and returns a plain JavaScript object (conforming to the [`SerializedRequest` type](#serializedrequest-type)) which contains the relevant properties. The example below assumes that `app` is an Express application:
+
+```js
+app.get('/fruit/:fruitId', (request, response, next) => {
+	console.log(serializeRequest(request));
+	next();
+});
+// {
+//     method: 'GET',
+//     url: '/fruit/feijoa',
+//     headers: {
+//         accept: '*/*'
+//     },
+//     route: {
+//         path: '/fruit/:fruitId',
+//         params: { fruitId: 'feijoa' }
+//     }
+// }
+```
+
+You can also pass in a plain object if you already have one that looks like a request:
+
+```js
+serializeRequest({
+	method: 'get',
+    url: '/hello'
+});
+```
+
+### Configuration options
+
+Config options can be passed into the `serializeRequest` function as a second argument. It expects an object with any of the keys below.
+
+```js
+serializeRequest(request, {
+    // Config options go here
+});
+```
+
+#### `options.includeHeaders`
+
+An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`.
+
+```js
+serializeRequest(request, {
+    includeHeaders: [
+        'accept',
+        'content-length',
+        'content-type',
+        'user-agent'
+    ]
+});
+```
+
+### `SerializedRequest` type
+
+The `SerializedRequest` type documents the return value of the [`serializeRequest` function](#serializerequest). It will have the following properties, extracting them from a given request object.
+
+#### `SerializedRequest.method`
+
+This is extracted from the `request.method` property and is always cast to a `String` and switched to uppercase. It defaults to `"-"`.
+
+#### `SerializedRequest.url`
+
+This is extracted from the `request.url` property and is always cast to a `String`. It defaults to `"/"`.
+
+#### `SerializedRequest.headers`
+
+This is extracted from the `request.headers` property and is filtered to only include the headers specified in the [`includeHeaders` option](#optionsincludeheaders). It defaults to an empty object.
+
+#### `SerializedRequest.route`
+
+This is an object extracted from `request.route.path` (string) and `request.params` (object) if they are present and conform to the same properties on an [Express Request object](https://expressjs.com/en/4x/api.html#req). It defaults to `undefined`.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -1,0 +1,165 @@
+/**
+ * @module @dotcom-reliability-kit/serialize-request
+ */
+
+/**
+ * @typedef {import('express').Request | import('http').IncomingMessage & {route: object, params: object}} Request
+ */
+
+/**
+ * @typedef {object} SerializeRequestOptions
+ * @property {Array<string>} [includeHeaders]
+ *     An array of request headers to include.
+ */
+
+/**
+ * @typedef {Object<string, string>} SerializedRequestHeaders
+ */
+
+/**
+ * @typedef {Object<string, string>} SerializedRequestRouteParams
+ */
+
+/**
+ * @typedef {object} SerializedRequestRoute
+ * @property {string} path
+ *     The route path which the request object was matched by.
+ * @property {SerializedRequestRouteParams} params
+ *     The parameters which were matched in the request path.
+ */
+
+/**
+ * @typedef {object} SerializedRequest
+ * @property {string} method
+ *     The HTTP method for the request.
+ * @property {string} url
+ *     The full path and querystring of the resource being requested.
+ * @property {SerializedRequestHeaders} headers
+ *     A subset of HTTP headers which came with the request.
+ * @property {SerializedRequestRoute} [route]
+ *     A subset of HTTP headers which came with the request.
+ */
+
+/**
+ * The default request headers to include in the serialization.
+ *
+ * @access private
+ * @type {Array<string>}
+ */
+const DEFAULT_INCLUDED_HEADERS = ['accept', 'content-type'];
+
+/**
+ * Serialize a request object so that it can be consistently logged or output as JSON.
+ *
+ * @access public
+ * @param {(string | Request)} request
+ *     The request object to serialize. Either an Express Request object or a
+ *     built-in Node.js IncomingMessage object.
+ * @param {SerializeRequestOptions} [options = {}]
+ *     Options to configure the serialization.
+ * @returns {SerializedRequest}
+ *     Returns the serialized request object.
+ */
+function serializeRequest(request, options = {}) {
+	// If the request is not an object, assume it's the request
+	// URL and return early
+	if (
+		typeof request !== 'object' ||
+		Array.isArray(request) ||
+		request === null
+	) {
+		return createSerializedRequest({
+			url: `${request}`
+		});
+	}
+
+	// Default and validate the included headers
+	let includeHeaders = options?.includeHeaders || DEFAULT_INCLUDED_HEADERS;
+	if (
+		!Array.isArray(includeHeaders) ||
+		!includeHeaders.every((header) => typeof header === 'string')
+	) {
+		throw new TypeError(
+			'The `includeHeaders` option must be an array of strings'
+		);
+	}
+	includeHeaders = includeHeaders.map((header) => header.toLowerCase());
+
+	const requestProperties = {};
+
+	// If set, request method is cast to a string and upper-cased
+	if (request.method) {
+		requestProperties.method = `${request.method}`.toUpperCase();
+	}
+
+	// If set, request URL is cast to a string
+	if (request.url) {
+		requestProperties.url = `${request.url}`;
+	}
+
+	// Serialize the headers
+	if (
+		request.headers &&
+		typeof request.headers === 'object' &&
+		!Array.isArray(request.headers) &&
+		request.headers !== null
+	) {
+		requestProperties.headers = serializeHeaders(
+			request.headers,
+			includeHeaders
+		);
+	}
+
+	// If the request route is present and valid, add it
+	const routePath = request.route?.path;
+	if (routePath && typeof routePath === 'string') {
+		requestProperties.route = {
+			path: request.route.path,
+			params: request.params || {}
+		};
+	}
+
+	return createSerializedRequest(requestProperties);
+}
+
+/**
+ * Serialize request headers.
+ *
+ * @access private
+ * @param {Record<string, any>} headers
+ *     The headers object to serialize.
+ * @param {Array<string>} includeHeaders
+ *     An array of request headers to include.
+ * @returns {SerializedRequestHeaders}
+ *     Returns the serialized request headers.
+ */
+function serializeHeaders(headers, includeHeaders) {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([header]) =>
+			includeHeaders.includes(header)
+		)
+	);
+}
+
+/**
+ * Create a new serialized request object.
+ *
+ * @access private
+ * @param {Record<string, any>} properties
+ *     The properties of the serialized error.
+ * @returns {SerializedRequest}
+ *     Returns the serialized error object.
+ */
+function createSerializedRequest(properties) {
+	return Object.assign(
+		{},
+		{
+			method: '-',
+			url: '/',
+			headers: {}
+		},
+		properties
+	);
+}
+
+module.exports = serializeRequest;

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -30,6 +30,8 @@
 
 /**
  * @typedef {object} SerializedRequest
+ * @property {(string|null)} id
+ *     A unique identifier for the request.
  * @property {string} method
  *     The HTTP method for the request.
  * @property {string} url
@@ -86,6 +88,11 @@ function serializeRequest(request, options = {}) {
 	includeHeaders = includeHeaders.map((header) => header.toLowerCase());
 
 	const requestProperties = {};
+
+	// If set, request ID is cast to a string
+	if (request.headers?.['x-request-id']) {
+		requestProperties.id = `${request.headers?.['x-request-id']}`;
+	}
 
 	// If set, request method is cast to a string and upper-cased
 	if (request.method) {
@@ -154,6 +161,7 @@ function createSerializedRequest(properties) {
 	return Object.assign(
 		{},
 		{
+			id: null,
 			method: '-',
 			url: '/',
 			headers: {}

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dotcom-reliability-kit/serialize-request",
+  "version": "0.0.0",
+  "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/serialize-request"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "devDependencies": {
+    "@types/express": "^4.17.13"
+  }
+}

--- a/packages/serialize-request/test/lib/index.spec.js
+++ b/packages/serialize-request/test/lib/index.spec.js
@@ -11,13 +11,15 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				headers: {
 					accept: '*/*',
 					'content-type': 'application/json',
-					'mock-header': 'mock-param-value'
+					'mock-header': 'mock-param-value',
+					'x-request-id': 'mock-id'
 				}
 			};
 		});
 
 		it('returns the expected serialized request properties', () => {
 			expect(serializeRequest(request)).toEqual({
+				id: 'mock-id',
 				method: 'GET',
 				url: '/mock-url',
 				headers: {
@@ -38,7 +40,8 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				headers: {
 					accept: '*/*',
 					'content-type': 'application/json',
-					'mock-header': 'mock-param-value'
+					'mock-header': 'mock-param-value',
+					'x-request-id': 'mock-id'
 				},
 				route: {
 					path: '/mock-route-path'
@@ -51,6 +54,7 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 
 		it('returns the expected serialized request properties', () => {
 			expect(serializeRequest(request)).toEqual({
+				id: 'mock-id',
 				method: 'GET',
 				url: '/mock-url',
 				headers: {
@@ -77,7 +81,8 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				headers: {
 					accept: '*/*',
 					'content-type': 'application/json',
-					'mock-header': 'mock-param-value'
+					'mock-header': 'mock-param-value',
+					'x-request-id': 'mock-id'
 				},
 				route: {
 					path: '/mock-route-path'
@@ -86,6 +91,18 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 					'mock-param': 'mock-param-value'
 				}
 			};
+		});
+
+		describe('when `request.headers.x-request-id` is undefined', () => {
+			beforeEach(() => {
+				delete request.headers['x-request-id'];
+			});
+
+			it('defaults the serialized ID to `null`', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					id: null
+				});
+			});
 		});
 
 		describe('when `request.method` is undefined', () => {
@@ -187,6 +204,7 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 		it('returns the expected serialized request properties', () => {
 			const request = 'mock message';
 			expect(serializeRequest(request)).toEqual({
+				id: null,
 				method: '-',
 				url: 'mock message',
 				headers: {}
@@ -204,7 +222,8 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				headers: {
 					accept: '*/*',
 					'content-type': 'application/json',
-					'mock-header': 'mock-param-value'
+					'mock-header': 'mock-param-value',
+					'x-request-id': 'mock-id'
 				}
 			};
 		});

--- a/packages/serialize-request/test/lib/index.spec.js
+++ b/packages/serialize-request/test/lib/index.spec.js
@@ -1,0 +1,249 @@
+const serializeRequest = require('../../lib/index');
+
+describe('@dotcom-reliability-kit/serialize-request', () => {
+	describe('when called with an `http.IncomingMessage` object', () => {
+		let request;
+
+		beforeEach(() => {
+			request = {
+				method: 'get',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json',
+					'mock-header': 'mock-param-value'
+				}
+			};
+		});
+
+		it('returns the expected serialized request properties', () => {
+			expect(serializeRequest(request)).toEqual({
+				method: 'GET',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json'
+				}
+			});
+		});
+	});
+
+	describe('when called with an `express.Request` object', () => {
+		let request;
+
+		beforeEach(() => {
+			request = {
+				method: 'get',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json',
+					'mock-header': 'mock-param-value'
+				},
+				route: {
+					path: '/mock-route-path'
+				},
+				params: {
+					'mock-param': 'mock-param-value'
+				}
+			};
+		});
+
+		it('returns the expected serialized request properties', () => {
+			expect(serializeRequest(request)).toEqual({
+				method: 'GET',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json'
+				},
+				route: {
+					path: '/mock-route-path',
+					params: {
+						'mock-param': 'mock-param-value'
+					}
+				}
+			});
+		});
+	});
+
+	describe('when called with an request-like object', () => {
+		let request;
+
+		beforeEach(() => {
+			request = {
+				method: 'get',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json',
+					'mock-header': 'mock-param-value'
+				},
+				route: {
+					path: '/mock-route-path'
+				},
+				params: {
+					'mock-param': 'mock-param-value'
+				}
+			};
+		});
+
+		describe('when `request.method` is undefined', () => {
+			beforeEach(() => {
+				delete request.method;
+			});
+
+			it('defaults the serialized method to "-"', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					method: '-'
+				});
+			});
+		});
+
+		describe('when `request.method` is not a string', () => {
+			beforeEach(() => {
+				request.method = 123;
+			});
+
+			it('casts the method to a string', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					method: '123'
+				});
+			});
+		});
+
+		describe('when `request.url` is undefined', () => {
+			beforeEach(() => {
+				delete request.url;
+			});
+
+			it('defaults the serialized url to "/"', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					url: '/'
+				});
+			});
+		});
+
+		describe('when `request.url` is not a string', () => {
+			beforeEach(() => {
+				request.url = 123;
+			});
+
+			it('casts the url to a string', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					url: '123'
+				});
+			});
+		});
+
+		describe('when `request.headers` is undefined', () => {
+			beforeEach(() => {
+				delete request.headers;
+			});
+
+			it('defaults the serialized headers to an empty object', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					headers: {}
+				});
+			});
+		});
+
+		describe('when `request.headers` is not an object', () => {
+			beforeEach(() => {
+				request.headers = ['a', 'b', 'c'];
+			});
+
+			it('defaults the serialized headers to an empty object', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					headers: {}
+				});
+			});
+		});
+
+		describe('when `request.route.path` is not a string', () => {
+			beforeEach(() => {
+				request.route.path = 123;
+			});
+
+			it('does not include a `route` property in the output', () => {
+				expect(serializeRequest(request).route).toBeUndefined();
+			});
+		});
+
+		describe('when `request.params` is not defined', () => {
+			beforeEach(() => {
+				delete request.params;
+			});
+
+			it('defaults the serialized route params to an empty object', () => {
+				expect(serializeRequest(request).route).toMatchObject({
+					params: {}
+				});
+			});
+		});
+	});
+
+	describe('when called with a string', () => {
+		it('returns the expected serialized request properties', () => {
+			const request = 'mock message';
+			expect(serializeRequest(request)).toEqual({
+				method: '-',
+				url: 'mock message',
+				headers: {}
+			});
+		});
+	});
+
+	describe('when the `includeHeaders` option is set', () => {
+		let request;
+
+		beforeEach(() => {
+			request = {
+				method: 'get',
+				url: '/mock-url',
+				headers: {
+					accept: '*/*',
+					'content-type': 'application/json',
+					'mock-header': 'mock-param-value'
+				}
+			};
+		});
+
+		it('only includes the specified headers in the serialized request object', () => {
+			expect(
+				serializeRequest(request, {
+					includeHeaders: ['mock-header', 'content-type', 'mock-second-header']
+				})
+			).toMatchObject({
+				headers: {
+					'content-type': 'application/json',
+					'mock-header': 'mock-param-value'
+				}
+			});
+		});
+	});
+
+	describe('when the `includeHeaders` option is set incorrectly', () => {
+		it('throws an error', () => {
+			const expectedError = new TypeError(
+				'The `includeHeaders` option must be an array of strings'
+			);
+			expect(() => {
+				serializeRequest(
+					{},
+					{
+						includeHeaders: {}
+					}
+				);
+			}).toThrowError(expectedError);
+			expect(() => {
+				serializeRequest(
+					{},
+					{
+						includeHeaders: ['string', 123, 'another string']
+					}
+				);
+			}).toThrowError(expectedError);
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
 	],
 	"packages": {
 		"packages/errors": {},
-		"packages/serialize-error": {}
+		"packages/serialize-error": {},
+		"packages/serialize-request": {}
 	}
 }


### PR DESCRIPTION
This is the equivalent of the `serializeError` function but built to handle `Request` objects (either Express or plain Node.js `IncomingMessage`).

Most of the information needed to review this should be in the README (part of this PR). I'm matching our serialized request object to the current format outlined in [this discussion](https://github.com/Financial-Times/dotcom-reliability-kit/discussions/26) so it looks like this:

```js
{
    id: 'request137',
    method: 'GET',
    url: '/fruit/feijoa',
    headers: {
        accept: '*/*'
    },
    route: {
        path: '/fruit/:fruitId',
        params: { fruitId: 'feijoa' }
    }
}
```

I decided against trying to tackle an [API Gateway request](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-example-event) for now. I think it should be possible to add support for this later without requiring a breaking change.

Once this is merged, I'll refactor #27 to use this function instead of handling the serialisation itself.