### PR TITLE
docs: fix a copy/paste error in the README

### DIFF
--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -75,14 +75,14 @@ app.use(createErrorLogger({
 An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
 
 ```js
-serializeRequest(request, {
+app.use(createErrorLogger({
     includeHeaders: [
         'accept',
         'content-length',
         'content-type',
         'user-agent'
     ]
-});
+}));
 ```
 
 


### PR DESCRIPTION
This is a copy/paste error that I somehow didn't spot. It's now
documented correctly.