### PR TITLE
feat: add a log-error package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/errors": "0.1.2",
+  "packages/log-error": "0.0.0",
   "packages/middleware-log-errors": "0.1.2",
   "packages/serialize-error": "0.1.1",
   "packages/serialize-request": "0.1.0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ We maintain documentation in this repo:
     * **[@dotcom-reliability-kit/errors](./packages/errors/#readme):**<br/>
       A suite of error classes which help you throw the most appropriate error in any situation
 
+    * **[@dotcom-reliability-kit/log-error](./packages/log-error/#readme):**<br/>
+      A method to consistently log error object with optional request information
+
     * **[@dotcom-reliability-kit/middleware-log-errors](./packages/middleware-log-errors/#readme):**<br/>
       Express middleware to consistently log errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -914,6 +914,10 @@
       "resolved": "packages/errors",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/log-error": {
+      "resolved": "packages/log-error",
+      "link": true
+    },
     "node_modules/@dotcom-reliability-kit/middleware-log-errors": {
       "resolved": "packages/middleware-log-errors",
       "link": true
@@ -7579,9 +7583,26 @@
         "npm": "7.x || 8.x"
       }
     },
+    "packages/log-error": {
+      "name": "@dotcom-reliability-kit/log-error",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+        "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "0.0.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/serialize-error": "^0.1.1",
@@ -8290,6 +8311,15 @@
     },
     "@dotcom-reliability-kit/errors": {
       "version": "file:packages/errors"
+    },
+    "@dotcom-reliability-kit/log-error": {
+      "version": "file:packages/log-error",
+      "requires": {
+        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+        "@financial-times/n-logger": ">=6.0.0 <11.0.0",
+        "@types/express": "^4.17.13"
+      }
     },
     "@dotcom-reliability-kit/middleware-log-errors": {
       "version": "file:packages/middleware-log-errors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7605,9 +7605,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
-        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-        "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+        "@dotcom-reliability-kit/log-error": "*"
       },
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -8324,9 +8322,7 @@
     "@dotcom-reliability-kit/middleware-log-errors": {
       "version": "file:packages/middleware-log-errors",
       "requires": {
-        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
-        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-        "@financial-times/n-logger": ">=6.0.0 <11.0.0",
+        "@dotcom-reliability-kit/log-error": "*",
         "@types/express": "^4.17.13"
       }
     },

--- a/packages/log-error/.npmignore
+++ b/packages/log-error/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -1,0 +1,200 @@
+
+## @dotcom-reliability-kit/log-error
+
+A method to consistently log error object with optional request information. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`logHandledError`](#loghandlederror)
+    * [`logRecoverableError`](#logrecoverableerror)
+    * [`logUnhandledError`](#logunhandlederror)
+    * [configuration options](#configuration-options)
+      * [`error`](#optionserror)
+      * [`includeHeaders`](#optionsincludeheaders)
+      * [`request`](#optionsrequest)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/log-error` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/log-error
+```
+
+Include in your code:
+
+```js
+import {logRecoverableError} from '@dotcom-reliability-kit/log-error';
+// or
+const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
+```
+
+### `logHandledError`
+
+The `logHandledError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged has been correctly handled and the application can continue to run.
+
+```js
+logHandledError({
+    error: new Error('Something went wrong')
+});
+```
+
+This will automatically [serialize error objects](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme) and log them. The information logged looks like this:
+
+```js
+{
+    event: 'HANDLED_ERROR',
+
+    error: {
+        // See `@dotcom-reliability-kit/serialize-error` (linked above)
+        // for information about the logged properties
+    },
+
+    app: {
+        name: 'example-app',
+        region: 'EU'
+    }
+}
+```
+
+### `logRecoverableError`
+
+The `logRecoverableError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged was completely recoverable, with no error page sent to a user.
+
+```js
+logRecoverableError({
+    error: new Error('Something went wrong')
+});
+```
+
+The information logged looks like this:
+
+```js
+{
+    event: 'RECOVERABLE_ERROR',
+
+    error: {
+        // See `@dotcom-reliability-kit/serialize-error` (linked above)
+        // for information about the logged properties
+    },
+
+    app: {
+        name: 'example-app',
+        region: 'EU'
+    }
+}
+```
+
+### `logUnhandledError`
+
+The `logUnhandledError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged was not recoverable and resulted in an application crashing.
+
+```js
+logUnhandledError({
+    error: new Error('Something went wrong')
+});
+```
+
+The information logged looks like this:
+
+```js
+{
+    event: 'RECOVERABLE_ERROR',
+
+    error: {
+        // See `@dotcom-reliability-kit/serialize-error` (linked above)
+        // for information about the logged properties
+    },
+
+    app: {
+        name: 'example-app',
+        region: 'EU'
+    }
+}
+```
+
+### Configuration options
+
+Config options can be passed into all of the provided logging functions as an object, with the keys below:
+
+```js
+logRecoverableError({
+    // Options go here
+});
+```
+
+#### `options.error`
+
+The error object to log. This is the only required option.
+
+```js
+logRecoverableError({
+    error: new Error('Something went wrong')
+});
+```
+
+#### `options.includeHeaders`
+
+An array of request headers to include in the serialized request object (if one is provided with `options.request`). This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
+
+```js
+logRecoverableError({
+    // ...other required options
+    includeHeaders: [
+        'accept',
+        'content-length',
+        'content-type',
+        'user-agent'
+    ]
+});
+```
+
+#### `options.request`
+
+A request object (e.g. an instance of `Express.Request` or an object with `method` and `url` properties) to include alongside the error in the log. This will be [automatically serialized with `@dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme).
+
+```js
+app.get('/example', (request, response, next) => {
+    logRecoverableError({
+        // ...other required options
+        request: request
+    });
+    next();
+});
+```
+
+When this option is defined, the logged data looks includes request data:
+
+```js
+{
+    event: 'RECOVERABLE_ERROR',
+
+    error: {
+        // See `@dotcom-reliability-kit/serialize-error` (linked above)
+        // for information about the logged properties
+    },
+
+    request: {
+        // See `@dotcom-reliability-kit/serialize-request` (linked above)
+        // for information about the logged properties
+    },
+
+    app: {
+        name: 'example-app',
+        region: 'EU'
+    }
+}
+```
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -101,7 +101,7 @@ The information logged looks like this:
 
 ```js
 {
-    event: 'RECOVERABLE_ERROR',
+    event: 'UNHANDLED_ERROR',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -1,0 +1,107 @@
+/**
+ * @module @dotcom-reliability-kit/log-error
+ */
+
+const logger = require('@financial-times/n-logger').default;
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+
+/**
+ * @typedef {object} ErrorLoggingOptions
+ * @property {(string | Error & Record<string, any>)} error
+ *     The error to log.
+ * @property {Array<string>} [includeHeaders]
+ *     An array of request headers to include in the log.
+ * @property {(string | import('@dotcom-reliability-kit/serialize-request').Request)} [request]
+ *     An request object to include in the log.
+ */
+
+/**
+ * @typedef {object} InternalErrorLoggingOptions
+ * @property {string} event
+ *     The event to log.
+ * @property {("error" | "warn")} [level="error"]
+ *     The log level to use. One of "error" or "warn".
+ */
+
+/**
+ * Log an error object with optional request information.
+ *
+ * @access private
+ * @param {ErrorLoggingOptions & InternalErrorLoggingOptions} options
+ *     The data to log.
+ * @returns {void}
+ */
+function logError({ error, event, includeHeaders, level = 'error', request }) {
+	const logData = {
+		event,
+		error: serializeError(error),
+		app: {
+			name: process.env.SYSTEM_CODE || null,
+			region: process.env.REGION || null
+		}
+	};
+	if (request) {
+		logData.request = serializeRequest(request, { includeHeaders });
+	}
+
+	logger.log(level, logData);
+}
+
+/**
+ * Log a handled error.
+ *
+ * @access public
+ * @param {ErrorLoggingOptions} options
+ *     The data to log.
+ * @returns {void}
+ */
+function logHandledError({ error, includeHeaders, request }) {
+	logError({
+		error,
+		event: 'HANDLED_ERROR',
+		includeHeaders,
+		request
+	});
+}
+
+/**
+ * Log a recoverable error.
+ *
+ * @access public
+ * @param {ErrorLoggingOptions} options
+ *     The data to log.
+ * @returns {void}
+ */
+function logRecoverableError({ error, includeHeaders, request }) {
+	logError({
+		error,
+		event: 'RECOVERABLE_ERROR',
+		includeHeaders,
+		level: 'warn',
+		request
+	});
+}
+
+/**
+ * Log an unhandled error.
+ *
+ * @access public
+ * @param {ErrorLoggingOptions} options
+ *     The data to log.
+ * @returns {void}
+ */
+function logUnhandledError({ error, includeHeaders, request }) {
+	logError({
+		error,
+		event: 'UNHANDLED_ERROR',
+		includeHeaders,
+		request
+	});
+}
+
+module.exports = {
+	logHandledError,
+	logRecoverableError,
+	logUnhandledError
+};

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dotcom-reliability-kit/log-error",
+  "version": "0.0.0",
+  "description": "A method to consistently log error object with optional request information",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/log-error"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/log-error#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/serialize-error": "^0.1.1",
+    "@dotcom-reliability-kit/serialize-request": "^0.1.0",
+    "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13"
+  }
+}

--- a/packages/log-error/test/lib/index.spec.js
+++ b/packages/log-error/test/lib/index.spec.js
@@ -1,0 +1,484 @@
+const {
+	logHandledError,
+	logRecoverableError,
+	logUnhandledError
+} = require('../../lib/index');
+
+jest.mock('@financial-times/n-logger', () => ({
+	default: { log: jest.fn() }
+}));
+const logger = require('@financial-times/n-logger').default;
+
+jest.mock('@dotcom-reliability-kit/serialize-error', () =>
+	jest.fn().mockReturnValue('mock-serialized-error')
+);
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+
+jest.mock('@dotcom-reliability-kit/serialize-request', () =>
+	jest.fn().mockReturnValue('mock-serialized-request')
+);
+const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+
+describe('@dotcom-reliability-kit/log-errors', () => {
+	afterEach(() => {
+		serializeError.mockClear();
+		serializeRequest.mockClear();
+		logger.log.mockClear();
+	});
+
+	describe('logHandledError(options)', () => {
+		let error;
+		let request;
+
+		beforeEach(() => {
+			process.env.REGION = 'mock-region';
+			process.env.SYSTEM_CODE = 'mock-system-code';
+			error = new Error('mock error');
+			request = { isMockRequest: true };
+
+			logHandledError({ error, request });
+		});
+
+		it('serializes the error', () => {
+			expect(serializeError).toBeCalledWith(error);
+		});
+
+		it('serializes the request', () => {
+			expect(serializeRequest).toBeCalledWith(request, {
+				includeHeaders: undefined
+			});
+		});
+
+		it('logs the serialized error, request, and app details', () => {
+			expect(logger.log).toBeCalledWith('error', {
+				event: 'HANDLED_ERROR',
+				error: 'mock-serialized-error',
+				request: 'mock-serialized-request',
+				app: {
+					name: 'mock-system-code',
+					region: 'mock-region'
+				}
+			});
+		});
+
+		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.SYSTEM_CODE;
+				logHandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app name', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: null,
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.REGION` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.REGION;
+				logHandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app region', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: null
+					}
+				});
+			});
+		});
+
+		describe('when the includeHeaders option is set', () => {
+			beforeEach(() => {
+				logHandledError({
+					error,
+					request,
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request with the configured headers', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('logs the serialized error, request, and app details', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the request option is not set', () => {
+			beforeEach(() => {
+				serializeRequest.mockClear();
+				logHandledError({ error });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('does not serialize the request', () => {
+				expect(serializeRequest).toBeCalledTimes(0);
+			});
+
+			it('logs the serialized error and app details', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					error: 'mock-serialized-error',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+	});
+
+	describe('logRecoverableError(options)', () => {
+		let error;
+		let request;
+
+		beforeEach(() => {
+			process.env.REGION = 'mock-region';
+			process.env.SYSTEM_CODE = 'mock-system-code';
+			error = new Error('mock error');
+			request = { isMockRequest: true };
+
+			logRecoverableError({ error, request });
+		});
+
+		it('serializes the error', () => {
+			expect(serializeError).toBeCalledWith(error);
+		});
+
+		it('serializes the request', () => {
+			expect(serializeRequest).toBeCalledWith(request, {
+				includeHeaders: undefined
+			});
+		});
+
+		it('logs the serialized error, request, and app details', () => {
+			expect(logger.log).toBeCalledWith('warn', {
+				event: 'RECOVERABLE_ERROR',
+				error: 'mock-serialized-error',
+				request: 'mock-serialized-request',
+				app: {
+					name: 'mock-system-code',
+					region: 'mock-region'
+				}
+			});
+		});
+
+		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.SYSTEM_CODE;
+				logRecoverableError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app name', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: null,
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.REGION` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.REGION;
+				logRecoverableError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app region', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: null
+					}
+				});
+			});
+		});
+
+		describe('when the includeHeaders option is set', () => {
+			beforeEach(() => {
+				logRecoverableError({
+					error,
+					request,
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request with the configured headers', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('logs the serialized error, request, and app details', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the request option is not set', () => {
+			beforeEach(() => {
+				serializeRequest.mockClear();
+				logRecoverableError({ error });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('does not serialize the request', () => {
+				expect(serializeRequest).toBeCalledTimes(0);
+			});
+
+			it('logs the serialized error and app details', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					error: 'mock-serialized-error',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+	});
+
+	describe('logUnhandledError(options)', () => {
+		let error;
+		let request;
+
+		beforeEach(() => {
+			process.env.REGION = 'mock-region';
+			process.env.SYSTEM_CODE = 'mock-system-code';
+			error = new Error('mock error');
+			request = { isMockRequest: true };
+
+			logUnhandledError({ error, request });
+		});
+
+		it('serializes the error', () => {
+			expect(serializeError).toBeCalledWith(error);
+		});
+
+		it('serializes the request', () => {
+			expect(serializeRequest).toBeCalledWith(request, {
+				includeHeaders: undefined
+			});
+		});
+
+		it('logs the serialized error, request, and app details', () => {
+			expect(logger.log).toBeCalledWith('error', {
+				event: 'UNHANDLED_ERROR',
+				error: 'mock-serialized-error',
+				request: 'mock-serialized-request',
+				app: {
+					name: 'mock-system-code',
+					region: 'mock-region'
+				}
+			});
+		});
+
+		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.SYSTEM_CODE;
+				logUnhandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app name', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: null,
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.REGION` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.REGION;
+				logUnhandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without an app region', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: null
+					}
+				});
+			});
+		});
+
+		describe('when the includeHeaders option is set', () => {
+			beforeEach(() => {
+				logUnhandledError({
+					error,
+					request,
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request with the configured headers', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: ['header-1', 'header-2']
+				});
+			});
+
+			it('logs the serialized error, request, and app details', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					error: 'mock-serialized-error',
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the request option is not set', () => {
+			beforeEach(() => {
+				serializeRequest.mockClear();
+				logUnhandledError({ error });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('does not serialize the request', () => {
+				expect(serializeRequest).toBeCalledTimes(0);
+			});
+
+			it('logs the serialized error and app details', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					error: 'mock-serialized-error',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+	});
+});

--- a/packages/log-error/test/lib/index.spec.js
+++ b/packages/log-error/test/lib/index.spec.js
@@ -19,7 +19,7 @@ jest.mock('@dotcom-reliability-kit/serialize-request', () =>
 );
 const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
 
-describe('@dotcom-reliability-kit/log-errors', () => {
+describe('@dotcom-reliability-kit/log-error', () => {
 	afterEach(() => {
 		serializeError.mockClear();
 		serializeRequest.mockClear();

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -2,9 +2,7 @@
  * @module @dotcom-reliability-kit/middleware-log-errors
  */
 
-const logger = require('@financial-times/n-logger').default;
-const serializeError = require('@dotcom-reliability-kit/serialize-error');
-const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
+const { logHandledError } = require('@dotcom-reliability-kit/log-error');
 
 /**
  * @typedef {object} ErrorLoggingOptions
@@ -40,18 +38,10 @@ function createErrorLoggingMiddleware(options = {}) {
 		// We add a paranoid try/catch here because it'd be really embarassing
 		// if the error logging middleware threw an unhandled error, wouldn't it
 		try {
-			const systemCode = process.env.SYSTEM_CODE;
-			const appNameHeader = response.getHeader('ft-app-name');
-			const app = {
-				name: systemCode || appNameHeader || null,
-				region: process.env.REGION || null
-			};
-
-			logger.error({
-				event: 'HANDLED_ERROR',
-				error: serializeError(error),
-				request: serializeRequest(request, { includeHeaders }),
-				app
+			logHandledError({
+				error,
+				includeHeaders,
+				request
 			});
 
 			// HACK: this suppresses the Raven error logger. We can remove this

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -16,9 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/serialize-error": "^0.1.1",
-    "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-    "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+    "@dotcom-reliability-kit/log-error": "*"
   },
   "devDependencies": {
     "@types/express": "^4.17.13"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
 	],
 	"packages": {
 		"packages/errors": {},
+		"packages/log-error": {},
 		"packages/middleware-log-errors": {},
 		"packages/serialize-error": {},
 		"packages/serialize-request": {}


### PR DESCRIPTION
This splits out the main logging functionality from the middleware into
a new package which allows us to log handled, recoverable, and unhandled
logs consistently no matter where we need them (not just in middleware).
This means we can support more non-Express uses-cases and will massively
simplify the code in the Express middleware.

This PR includes splitting out the logging functionality and switching the
middleware to use the new functions.

This refactor has the benefit of resolving [FTDCS-192](https://financialtimes.atlassian.net/browse/FTDCS-192) 🎉