### PR TITLE
docs: outline how to log recoverable errors

### DIFF
--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -104,7 +104,7 @@ When logging errors it's important to consider the level of the log you send. Th
     }
     ```
 
-  * If an error is not recoverable at all and throws the app into an unstable state, e.g. an intial database connection cannot be established, then consider a level of "fatal" or "critical" if your logger supports it (currently [n-logger](https://github.com/Financial-Times/n-logger) does not support critical logs but we'll be investigating adding this in future).
+  * If an error is not recoverable at all and throws the app into an unstable state, e.g. an initial database connection cannot be established, then consider a level of "fatal" or "critical" if your logger supports it (currently [n-logger](https://github.com/Financial-Times/n-logger) does not support critical logs but we'll be investigating adding this in future).
 
 
 ## One way of logging


### PR DESCRIPTION
This reorganises the error logging documentation now that we have the
log-error module and have a codified way of logging recoverable errors.