### PR TITLE
chore: add dependabot config for packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/errors"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/log-error"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/middleware-log-errors"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/serialize-error"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/serialize-request"
+    schedule:
+      interval: "daily"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,6 +55,8 @@ npm run create-package <NAME>
 
 You'll need to manually add the package to the list of packages in the README once it's ready to be used by other teams.
 
+You'll also need to manually add an entry for the package to [the Dependabot config](../.github/dependabot.yml) so that dependency update pull requests can be opened.
+
 
 ## Testing
 


### PR DESCRIPTION
This means that Dependabot should now keep the individual packages up to
date as well as the central dev dependencies.