### PR TITLE
feat: require n-logger v10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@financial-times/n-logger": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.1.0.tgz",
-      "integrity": "sha512-QUgNLRvPah33B6Ab4zUOV2pFbCi7DQA+/WhgaliAAwGpkc6PymA+V+CcMhQUn5rd/id8ZxywZP6BNPnSvNoZzQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
       "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
@@ -9341,7 +9341,7 @@
       "dependencies": {
         "@dotcom-reliability-kit/serialize-error": "^1.0.0",
         "@dotcom-reliability-kit/serialize-request": "^1.0.0",
-        "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+        "@financial-times/n-logger": "^10.2.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -10136,7 +10136,7 @@
       "requires": {
         "@dotcom-reliability-kit/serialize-error": "^1.0.0",
         "@dotcom-reliability-kit/serialize-request": "^1.0.0",
-        "@financial-times/n-logger": ">=6.0.0 <11.0.0",
+        "@financial-times/n-logger": "^10.2.0",
         "@types/express": "^4.17.13"
       }
     },
@@ -10245,9 +10245,9 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.1.0.tgz",
-      "integrity": "sha512-QUgNLRvPah33B6Ab4zUOV2pFbCi7DQA+/WhgaliAAwGpkc6PymA+V+CcMhQUn5rd/id8ZxywZP6BNPnSvNoZzQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.0",

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@dotcom-reliability-kit/serialize-error": "^1.0.0",
     "@dotcom-reliability-kit/serialize-request": "^1.0.0",
-    "@financial-times/n-logger": ">=6.0.0 <11.0.0"
+    "@financial-times/n-logger": "^10.2.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13"


### PR DESCRIPTION
n-logger v10.2.0 adds in the ability to switch to Heroku log drains
rather than sending logs to Splunk manually. In order to support this
feature we need to limit the version range to be v10.2.0 or above
otherwise the feature will be present inconsistently.

This is not a breaking change because the major versions of n-logger
between 6 and 10 have no impact on this package:

  - v7.0.0 of n-logger only supports Node.js 14+ (no change for us)
  - v8.0.0 of n-logger re-adds support for Node.js 12
  - v9.0.0 of n-logger deprecates the SYSTEM_CODE environment variable
    (but then undeprecates it in v9.0.1)
  - v10.0.0 of n-logger only supports Node.js 14+ (no change for us)