### PR TITLE
feat: log an error summary in the message property

### DIFF
--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -173,6 +173,7 @@ When this option is defined, the logged data looks includes request data:
 ```js
 {
     event: 'RECOVERABLE_ERROR',
+    message: 'Error: something went wrong',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -46,6 +46,7 @@ This will automatically [serialize error objects](https://github.com/Financial-T
 ```js
 {
     event: 'HANDLED_ERROR',
+    message: 'Error: something went wrong',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)
@@ -74,6 +75,7 @@ The information logged looks like this:
 ```js
 {
     event: 'RECOVERABLE_ERROR',
+    message: 'Error: something went wrong',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)
@@ -102,6 +104,7 @@ The information logged looks like this:
 ```js
 {
     event: 'UNHANDLED_ERROR',
+    message: 'Error: something went wrong',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -33,9 +33,11 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  * @returns {void}
  */
 function logError({ error, event, includeHeaders, level = 'error', request }) {
+	const serializedError = serializeError(error);
 	const logData = {
 		event,
-		error: serializeError(error),
+		message: getErrorMessage(serializedError),
+		error: serializedError,
 		app: {
 			name: process.env.SYSTEM_CODE || null,
 			region: process.env.REGION || null
@@ -46,6 +48,21 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
 	}
 
 	logger.log(level, logData);
+}
+
+/**
+ * Get a human readable error message from a serialized error object.
+ *
+ * @access private
+ * @param {serializeError.SerializedError} serializedError
+ *     The serialized error to get a message for.
+ * @returns {string}
+ *     Returns the human readable error message.
+ */
+function getErrorMessage(serializedError) {
+	return `${serializedError.name || 'Error'}${
+		serializedError.message ? `: ${serializedError.message}` : ''
+	}`;
 }
 
 /**

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -36,7 +36,7 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
 	const serializedError = serializeError(error);
 	const logData = {
 		event,
-		message: getErrorMessage(serializedError),
+		message: extractErrorMessage(serializedError),
 		error: serializedError,
 		app: {
 			name: process.env.SYSTEM_CODE || null,
@@ -59,7 +59,7 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
  * @returns {string}
  *     Returns the human readable error message.
  */
-function getErrorMessage(serializedError) {
+function extractErrorMessage(serializedError) {
 	return `${serializedError.name || 'Error'}${
 		serializedError.message ? `: ${serializedError.message}` : ''
 	}`;

--- a/packages/log-error/test/lib/index.spec.js
+++ b/packages/log-error/test/lib/index.spec.js
@@ -10,7 +10,10 @@ jest.mock('@financial-times/n-logger', () => ({
 const logger = require('@financial-times/n-logger').default;
 
 jest.mock('@dotcom-reliability-kit/serialize-error', () =>
-	jest.fn().mockReturnValue('mock-serialized-error')
+	jest.fn().mockReturnValue({
+		name: 'MockError',
+		message: 'mock error'
+	})
 );
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
 
@@ -52,7 +55,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		it('logs the serialized error, request, and app details', () => {
 			expect(logger.log).toBeCalledWith('error', {
 				event: 'HANDLED_ERROR',
-				error: 'mock-serialized-error',
+				message: 'MockError: mock error',
+				error: {
+					name: 'MockError',
+					message: 'mock error'
+				},
 				request: 'mock-serialized-request',
 				app: {
 					name: 'mock-system-code',
@@ -80,7 +87,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app name', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'HANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: null,
@@ -109,7 +120,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app region', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'HANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -141,7 +156,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error, request, and app details', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'HANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -168,7 +187,61 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error and app details', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'HANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a name', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					message: 'mock error'
+				});
+				logHandledError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to use "Error"', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					message: 'Error: mock error',
+					error: {
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a message', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					name: 'MockError'
+				});
+				logHandledError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to only use the name', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					message: 'MockError',
+					error: {
+						name: 'MockError'
+					},
+					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
 						region: 'mock-region'
@@ -204,7 +277,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		it('logs the serialized error, request, and app details', () => {
 			expect(logger.log).toBeCalledWith('warn', {
 				event: 'RECOVERABLE_ERROR',
-				error: 'mock-serialized-error',
+				message: 'MockError: mock error',
+				error: {
+					name: 'MockError',
+					message: 'mock error'
+				},
 				request: 'mock-serialized-request',
 				app: {
 					name: 'mock-system-code',
@@ -232,7 +309,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app name', () => {
 				expect(logger.log).toBeCalledWith('warn', {
 					event: 'RECOVERABLE_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: null,
@@ -261,7 +342,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app region', () => {
 				expect(logger.log).toBeCalledWith('warn', {
 					event: 'RECOVERABLE_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -293,7 +378,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error, request, and app details', () => {
 				expect(logger.log).toBeCalledWith('warn', {
 					event: 'RECOVERABLE_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -320,7 +409,61 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error and app details', () => {
 				expect(logger.log).toBeCalledWith('warn', {
 					event: 'RECOVERABLE_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a name', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					message: 'mock error'
+				});
+				logRecoverableError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to use "Error"', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					message: 'Error: mock error',
+					error: {
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a message', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					name: 'MockError'
+				});
+				logRecoverableError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to only use the name', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					message: 'MockError',
+					error: {
+						name: 'MockError'
+					},
+					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
 						region: 'mock-region'
@@ -356,7 +499,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		it('logs the serialized error, request, and app details', () => {
 			expect(logger.log).toBeCalledWith('error', {
 				event: 'UNHANDLED_ERROR',
-				error: 'mock-serialized-error',
+				message: 'MockError: mock error',
+				error: {
+					name: 'MockError',
+					message: 'mock error'
+				},
 				request: 'mock-serialized-request',
 				app: {
 					name: 'mock-system-code',
@@ -384,7 +531,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app name', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'UNHANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: null,
@@ -413,7 +564,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs without an app region', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'UNHANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -445,7 +600,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error, request, and app details', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'UNHANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
 					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
@@ -472,7 +631,61 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			it('logs the serialized error and app details', () => {
 				expect(logger.log).toBeCalledWith('error', {
 					event: 'UNHANDLED_ERROR',
-					error: 'mock-serialized-error',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a name', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					message: 'mock error'
+				});
+				logUnhandledError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to use "Error"', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					message: 'Error: mock error',
+					error: {
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						name: 'mock-system-code',
+						region: 'mock-region'
+					}
+				});
+			});
+		});
+
+		describe('when the serialized error does not have a message', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValueOnce({
+					name: 'MockError'
+				});
+				logUnhandledError({ error, request });
+				serializeError.mockClear();
+			});
+
+			it('defaults the message to only use the name', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					message: 'MockError',
+					error: {
+						name: 'MockError'
+					},
+					request: 'mock-serialized-request',
 					app: {
 						name: 'mock-system-code',
 						region: 'mock-region'

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -42,6 +42,7 @@ This will automatically [serialize error objects](https://github.com/Financial-T
 ```js
 {
     event: 'HANDLED_ERROR',
+    message: 'Error: something went wrong',
 
     error: {
         // See `@dotcom-reliability-kit/serialize-error` (linked above)


### PR DESCRIPTION
n-logger seems to expect a message field when logging, so we're now
providing a human-readable short summary of the error message in this
field. This does duplicate some data but will make error logs much
easier to quickly analyse in Splunk (the `error` property is collapsed
by default).

I decided to use both the error name and message so that you can also
tell if you're dealing with an operational error at a quick glance:

```
OperationalError: something expected went wrong
Error: something unexpected went wrong
```

**Note for reviewing:** there are a lot of changes in the tests because
every instance of a log call had to change to cater for the new message
property. We also had to make our mock serialised error into a proper
object so that we could test with and without certain properties.