### PR TITLE
Fix release please

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "lint-staged": "^13.0.3",
         "node-fetch": "^2.6.7",
         "prettier": "^2.7.1",
-        "release-please": "^13.15.0",
+        "release-please": "^13.18.6",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -737,20 +737,6 @@
       },
       "engines": {
         "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -1841,9 +1827,9 @@
       }
     },
     "node_modules/@octokit/core/node_modules/@octokit/request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.0.2.tgz",
-      "integrity": "sha512-WPMcm8nUET2v6P5AbTIhNzEorMLFPbFnzfP/VMAaRFwNzaqHmVvS+YLvqtWyKq0vnZ6a9ImQuCHNb3L4oNovRw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.0.tgz",
+      "integrity": "sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1896,9 +1882,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
-      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg==",
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.10.1.tgz",
+      "integrity": "sha512-P+SukKanjFY0ZhsK6wSVnQmxTP2eVPPE8OPSNuxaMYtgVzwJZgfGdwlYjf4RlRU4vLEw4ts2fsE2icG4nZ5ddQ==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -1997,12 +1983,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
-      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.40.0.tgz",
+      "integrity": "sha512-MFZOU5r8SwgJWDMhrLUSvyJPtVsqA6VnbVI3TNbsmw+Jnvrktzvq2fYES/6RiJA/5Ykdwq4mJmtlYUfW7CGjmw==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^12.7.0"
+        "@octokit/openapi-types": "^12.10.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3025,9 +3011,9 @@
       }
     },
     "node_modules/code-suggester": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-2.2.0.tgz",
-      "integrity": "sha512-jd88Goo0tP51es+DDXCCB4sYVWsrTHmlvStg7JeEFAm5X92imixzLbJl1B6BYaf4MCBQE0RajzDviWDfK0Fcdw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-3.0.0.tgz",
+      "integrity": "sha512-DoTVTaMgU1VygKF84sZ4v6qCsb4yd0wDHVJFp+BywDr1+GUCTe0b3QL+GFB4a+RcTP9HQOYDDS59lVXRGcy3SA==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^18.3.5",
@@ -3042,7 +3028,7 @@
         "code-suggester": "build/src/bin/code-suggester.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/code-suggester/node_modules/diff": {
@@ -3183,9 +3169,9 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
-      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0",
@@ -7898,9 +7884,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.15.0.tgz",
-      "integrity": "sha512-bdB5PTZMIiGXCxi5RYN/4oLX2XOrpNIBvE7GHkHagu/YsOUlf/dHG/oh1BWEhK1IyL0jYm0neBjyTMlUe9SAiA==",
+      "version": "13.18.6",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.6.tgz",
+      "integrity": "sha512-cMLux5+CZ+YbOolOBaHr9lx3NcF1rKqHIOb/nmhasOy8OHQKakh02vBTvS1TmkjIWDe1nNsebvZWciTolHG2xg==",
       "dev": true,
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
@@ -7916,8 +7902,8 @@
         "@types/npm-package-arg": "^6.1.0",
         "@xmldom/xmldom": "^0.8.2",
         "chalk": "^4.0.0",
-        "code-suggester": "^2.0.0",
-        "conventional-changelog-conventionalcommits": "^4.6.0",
+        "code-suggester": "^3.0.0",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "conventional-changelog-writer": "^5.0.0",
         "conventional-commits-filter": "^2.0.2",
         "detect-indent": "^6.1.0",
@@ -7929,7 +7915,7 @@
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.0.0",
         "type-fest": "^2.0.0",
-        "typescript": "^3.8.3",
+        "typescript": "^4.6.4",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
         "xpath": "^0.0.32",
@@ -7961,19 +7947,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/release-please/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/require-directory": {
@@ -9958,19 +9931,6 @@
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
-      },
-      "dependencies": {
-        "conventional-changelog-conventionalcommits": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-          "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
-          "dev": true,
-          "requires": {
-            "compare-func": "^2.0.0",
-            "lodash": "^4.17.15",
-            "q": "^1.5.1"
-          }
-        }
       }
     },
     "@commitlint/config-validator": {
@@ -10880,9 +10840,9 @@
           }
         },
         "@octokit/request": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.0.2.tgz",
-          "integrity": "sha512-WPMcm8nUET2v6P5AbTIhNzEorMLFPbFnzfP/VMAaRFwNzaqHmVvS+YLvqtWyKq0vnZ6a9ImQuCHNb3L4oNovRw==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.0.tgz",
+          "integrity": "sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -10931,9 +10891,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
-      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg==",
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.10.1.tgz",
+      "integrity": "sha512-P+SukKanjFY0ZhsK6wSVnQmxTP2eVPPE8OPSNuxaMYtgVzwJZgfGdwlYjf4RlRU4vLEw4ts2fsE2icG4nZ5ddQ==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
@@ -11026,12 +10986,12 @@
       }
     },
     "@octokit/types": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
-      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.40.0.tgz",
+      "integrity": "sha512-MFZOU5r8SwgJWDMhrLUSvyJPtVsqA6VnbVI3TNbsmw+Jnvrktzvq2fYES/6RiJA/5Ykdwq4mJmtlYUfW7CGjmw==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^12.7.0"
+        "@octokit/openapi-types": "^12.10.0"
       }
     },
     "@sinclair/typebox": {
@@ -11864,9 +11824,9 @@
       "dev": true
     },
     "code-suggester": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-2.2.0.tgz",
-      "integrity": "sha512-jd88Goo0tP51es+DDXCCB4sYVWsrTHmlvStg7JeEFAm5X92imixzLbJl1B6BYaf4MCBQE0RajzDviWDfK0Fcdw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-3.0.0.tgz",
+      "integrity": "sha512-DoTVTaMgU1VygKF84sZ4v6qCsb4yd0wDHVJFp+BywDr1+GUCTe0b3QL+GFB4a+RcTP9HQOYDDS59lVXRGcy3SA==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.3.5",
@@ -11991,9 +11951,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
-      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -15465,9 +15425,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.15.0.tgz",
-      "integrity": "sha512-bdB5PTZMIiGXCxi5RYN/4oLX2XOrpNIBvE7GHkHagu/YsOUlf/dHG/oh1BWEhK1IyL0jYm0neBjyTMlUe9SAiA==",
+      "version": "13.18.6",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.6.tgz",
+      "integrity": "sha512-cMLux5+CZ+YbOolOBaHr9lx3NcF1rKqHIOb/nmhasOy8OHQKakh02vBTvS1TmkjIWDe1nNsebvZWciTolHG2xg==",
       "dev": true,
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
@@ -15483,8 +15443,8 @@
         "@types/npm-package-arg": "^6.1.0",
         "@xmldom/xmldom": "^0.8.2",
         "chalk": "^4.0.0",
-        "code-suggester": "^2.0.0",
-        "conventional-changelog-conventionalcommits": "^4.6.0",
+        "code-suggester": "^3.0.0",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "conventional-changelog-writer": "^5.0.0",
         "conventional-commits-filter": "^2.0.2",
         "detect-indent": "^6.1.0",
@@ -15496,7 +15456,7 @@
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.0.0",
         "type-fest": "^2.0.0",
-        "typescript": "^3.8.3",
+        "typescript": "^4.6.4",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
         "xpath": "^0.0.32",
@@ -15513,12 +15473,6 @@
           "version": "2.12.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
           "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7898,9 +7898,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.19.3",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.19.3.tgz",
-      "integrity": "sha512-Y3E6y57Y934E3y8ZNAxFWvP03kAQDSbtroVIDUc/+UvcCgcO8ZvFhFHP6MZMyEl1/Y1tiRpsujYOWVxRFvYSQw==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.15.0.tgz",
+      "integrity": "sha512-bdB5PTZMIiGXCxi5RYN/4oLX2XOrpNIBvE7GHkHagu/YsOUlf/dHG/oh1BWEhK1IyL0jYm0neBjyTMlUe9SAiA==",
       "dev": true,
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
@@ -15465,9 +15465,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "13.19.3",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.19.3.tgz",
-      "integrity": "sha512-Y3E6y57Y934E3y8ZNAxFWvP03kAQDSbtroVIDUc/+UvcCgcO8ZvFhFHP6MZMyEl1/Y1tiRpsujYOWVxRFvYSQw==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.15.0.tgz",
+      "integrity": "sha512-bdB5PTZMIiGXCxi5RYN/4oLX2XOrpNIBvE7GHkHagu/YsOUlf/dHG/oh1BWEhK1IyL0jYm0neBjyTMlUe9SAiA==",
       "dev": true,
       "requires": {
         "@conventional-commits/parser": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-staged": "^13.0.3",
     "node-fetch": "^2.6.7",
     "prettier": "^2.7.1",
-    "release-please": "^13.15.0",
+    "release-please": "^13.18.6",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,31 +1,12 @@
 # Changelog
 
-## What's Changed
-* chore(deps-dev): bump release-please from 13.15.0 to 13.18.7 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/50
-* chore(deps-dev): bump @commitlint/config-conventional from 16.2.4 to 17.0.3 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/51
-* chore(deps-dev): bump @commitlint/cli from 16.2.4 to 17.0.3 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/52
-* chore(deps-dev): bump lint-staged from 12.4.1 to 13.0.3 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/53
-* chore(deps-dev): bump @babel/core from 7.17.10 to 7.18.6 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/54
-* chore: add dependabot config for packages by @rowanmanning in https://github.com/Financial-Times/dotcom-reliability-kit/pull/56
-* chore(deps-dev): bump eslint from 8.14.0 to 8.19.0 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/57
-* chore(deps-dev): bump eslint-plugin-jsdoc from 39.2.9 to 39.3.3 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/58
-* chore(deps-dev): bump @babel/eslint-parser from 7.17.0 to 7.18.2 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/59
-* chore(deps-dev): bump typescript from 4.6.4 to 4.7.4 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/60
-* chore(deps-dev): bump eslint-plugin-prettier from 4.0.0 to 4.2.1 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/61
-* chore(deps-dev): bump jest and @types/jest by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/62
-* chore(deps-dev): bump prettier from 2.6.2 to 2.7.1 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/64
-* chore(deps): bump @financial-times/n-express from 23.2.0 to 23.5.0 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/65
-* chore(deps-dev): bump husky from 7.0.4 to 8.0.1 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/63
-* chore(deps-dev): bump release-please from 13.18.7 to 13.19.1 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/67
-* chore(deps): bump moment from 2.29.3 to 2.29.4 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/68
-* chore(deps-dev): bump release-please from 13.19.1 to 13.19.2 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/69
-* feat: require n-logger v10.2.0 by @rowanmanning in https://github.com/Financial-Times/dotcom-reliability-kit/pull/71
-* chore(deps-dev): bump release-please from 13.19.2 to 13.19.3 by @dependabot in https://github.com/Financial-Times/dotcom-reliability-kit/pull/70
+## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.0.0...log-error-v1.1.0) (2022-07-11)
 
-## New Contributors
-* @dependabot made their first contribution in https://github.com/Financial-Times/dotcom-reliability-kit/pull/50
 
-**Full Changelog**: https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.0.0...log-error-v1.1.0
+### Features
+
+* require n-logger v10.2.0 ([c0c0da1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c0c0da19aa81bdbecf8727085d85dc610265fb05))
+
 
 ## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v0.1.0...log-error-v1.0.0) (2022-07-05)
 

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.0.0...middleware-log-errors-v1.0.1) (2022-07-11)
+
+
 ### Dependencies
 
 * The following workspace dependencies were updated

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-	"changelog-type": "github",
+	"changelog-type": "default",
 	"changelog-sections": [
 		{
 			"type": "feat",


### PR DESCRIPTION
This is annoying, but I dug into the code for Release Please and it gets the manifest config directly from GitHub rather than the local file so our change needs to be merged into `main` before we can progress beyond Release Please v13.18.6.

This addresses the broken changelog files and also makes sure we're using a version of Release Please that works.