### PR TITLE
Modify handling recoverable errors example

### DIFF
--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -337,6 +337,7 @@ app.get('/fruit/:name', async (request, response, next) => {
             console.warn({
                 event: 'RECOVERABLE_ERROR',
                 error: serializeError(new OperationalError({
+                    statusCode: error.statusCode,
                     code: 'FRUIT_STOCK_LEVEL_FAILED',
                     message: `The Fruit API did not return a stock level for ID ${fruit.id}`,
                     relatesToSystems: ['fruit-api']


### PR DESCRIPTION
This PR applies a documentation revision that came out of [this Slack discussion](https://financialtimes.slack.com/archives/CPNKK12S1/p1659013086713049?thread_ts=1659003590.492259&cid=CPNKK12S1):

> @andygout: In the last example in [handling errors](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/handling-errors.md), is there a specific reason to not include any information from the caught `error` in the `OperationalError` instance? E.g. to give information about why the fruit API did not return a stock level for a given ID

> @rowanmanning: Nope, I think that’s actually an issue so if you fancy opening a PR to address this then I’d happily review! I’d probably check the status code and error message and include it in the new operational error message? Or possibly just as extra properties.
As an aside, I have a mental note to add a `cause` property to `OperationalError`  which you can use to pass in the raw error which resulted in the operational error. I think this’d be super useful in this case and I’m gonna open a ticket so we don’t lose that [[mentioned Jira ticket](https://financialtimes.atlassian.net/browse/FTDCS-250)]

I added the `statusCode` property only. I could not think of a good property name to which to assign the `error.message` value given that `message` was already taken and neither did I want to interpolate it into the existing `message` value because it could hypothetically be quite a long and detailed message in and of itself.

In any case, this will eventually be replaced by the `cause` property mentioned in the above discussion, so the change in this PR feels sufficient as an interim measure to demonstrate how you might want to incorporate aspects of the `error` value into your `OperationError` instance for recoverable errors.