### PR TITLE
feat: add new app properties to error logs

### DIFF
--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -54,8 +54,11 @@ This will automatically [serialize error objects](https://github.com/Financial-T
     },
 
     app: {
+        commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        region: 'EU'
+        nodeVersion: '16.16.0',
+        region: 'EU',
+        releaseDate: '2022-07-25T01:37:00Z'
     }
 }
 ```
@@ -83,8 +86,11 @@ The information logged looks like this:
     },
 
     app: {
+        commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        region: 'EU'
+        nodeVersion: '16.16.0',
+        region: 'EU',
+        releaseDate: '2022-07-25T01:37:00Z'
     }
 }
 ```
@@ -112,8 +118,11 @@ The information logged looks like this:
     },
 
     app: {
+        commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        region: 'EU'
+        nodeVersion: '16.16.0',
+        region: 'EU',
+        releaseDate: '2022-07-25T01:37:00Z'
     }
 }
 ```
@@ -186,8 +195,11 @@ When this option is defined, the logged data looks includes request data:
     },
 
     app: {
+        commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        region: 'EU'
+        nodeVersion: '16.16.0',
+        region: 'EU',
+        releaseDate: '2022-07-25T01:37:00Z'
     }
 }
 ```

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -39,8 +39,11 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
 		message: extractErrorMessage(serializedError),
 		error: serializedError,
 		app: {
+			commit: process.env.HEROKU_SLUG_COMMIT || null,
 			name: process.env.SYSTEM_CODE || null,
-			region: process.env.REGION || null
+			nodeVersion: process.versions.node,
+			region: process.env.REGION || null,
+			releaseDate: process.env.HEROKU_RELEASE_CREATED_AT || null
 		}
 	};
 	if (request) {

--- a/packages/log-error/test/lib/index.spec.js
+++ b/packages/log-error/test/lib/index.spec.js
@@ -34,6 +34,8 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
+			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
+			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
 			process.env.REGION = 'mock-region';
 			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
@@ -62,8 +64,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 				},
 				request: 'mock-serialized-request',
 				app: {
+					commit: 'mock-commit-hash',
 					name: 'mock-system-code',
-					region: 'mock-region'
+					nodeVersion: process.versions.node,
+					region: 'mock-region',
+					releaseDate: 'mock-release-date'
 				}
 			});
 		});
@@ -94,8 +99,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: null,
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -127,8 +135,83 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: null
+						nodeVersion: process.versions.node,
+						region: null,
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_SLUG_COMMIT;
+				logHandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a commit hash', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: null,
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_RELEASE_CREATED_AT;
+				logHandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a release date', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'HANDLED_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: 'mock-commit-hash',
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: null
 					}
 				});
 			});
@@ -163,8 +246,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -193,8 +279,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 						message: 'mock error'
 					},
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -218,8 +307,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -243,8 +335,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -256,6 +351,8 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
+			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
+			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
 			process.env.REGION = 'mock-region';
 			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
@@ -284,8 +381,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 				},
 				request: 'mock-serialized-request',
 				app: {
+					commit: 'mock-commit-hash',
 					name: 'mock-system-code',
-					region: 'mock-region'
+					nodeVersion: process.versions.node,
+					region: 'mock-region',
+					releaseDate: 'mock-release-date'
 				}
 			});
 		});
@@ -316,8 +416,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: null,
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -349,8 +452,83 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: null
+						nodeVersion: process.versions.node,
+						region: null,
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_SLUG_COMMIT;
+				logRecoverableError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a commit hash', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: null,
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_RELEASE_CREATED_AT;
+				logRecoverableError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a release date', () => {
+				expect(logger.log).toBeCalledWith('warn', {
+					event: 'RECOVERABLE_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: 'mock-commit-hash',
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: null
 					}
 				});
 			});
@@ -385,8 +563,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -415,8 +596,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 						message: 'mock error'
 					},
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -440,8 +624,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -465,8 +652,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -478,6 +668,8 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
+			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
+			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
 			process.env.REGION = 'mock-region';
 			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
@@ -506,8 +698,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 				},
 				request: 'mock-serialized-request',
 				app: {
+					commit: 'mock-commit-hash',
 					name: 'mock-system-code',
-					region: 'mock-region'
+					nodeVersion: process.versions.node,
+					region: 'mock-region',
+					releaseDate: 'mock-release-date'
 				}
 			});
 		});
@@ -538,8 +733,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: null,
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -571,8 +769,83 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: null
+						nodeVersion: process.versions.node,
+						region: null,
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_SLUG_COMMIT;
+				logUnhandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a commit hash', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: null,
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
+			beforeEach(() => {
+				delete process.env.HEROKU_RELEASE_CREATED_AT;
+				logUnhandledError({ error, request });
+			});
+
+			it('serializes the error', () => {
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			it('serializes the request', () => {
+				expect(serializeRequest).toBeCalledWith(request, {
+					includeHeaders: undefined
+				});
+			});
+
+			it('logs without a release date', () => {
+				expect(logger.log).toBeCalledWith('error', {
+					event: 'UNHANDLED_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: 'mock-commit-hash',
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: null
 					}
 				});
 			});
@@ -607,8 +880,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -637,8 +913,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 						message: 'mock error'
 					},
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -662,8 +941,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});
@@ -687,8 +969,11 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					},
 					request: 'mock-serialized-request',
 					app: {
+						commit: 'mock-commit-hash',
 						name: 'mock-system-code',
-						region: 'mock-region'
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
 					}
 				});
 			});

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -55,8 +55,11 @@ This will automatically [serialize error objects](https://github.com/Financial-T
     },
 
     app: {
+        commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        region: 'EU'
+        nodeVersion: '16.16.0',
+        region: 'EU',
+        releaseDate: '2022-07-25T01:37:00Z'
     }
 }
 ```


### PR DESCRIPTION
This adds new app-related properties to error logs. We decided these
would be useful to help us debug issues and will bring logs in Splunk
closer to Sentry in terms of the information they hold.

These are the added properties:

  - `app.commit`: set to `process.env.HEROKU_SLUG_COMMIT`
  - `app.nodeVersion`: set to `process.versions.node`
  - `app.releaseDate`: set to `process.env.HEROKU_RELEASE_CREATED_AT`

Some of these rely on the Heroku Dyno Metadata labs feature but we
recommend use of this in all our apps anyway:
https://devcenter.heroku.com/articles/dyno-metadata

**Note to reviewers:** most of the changes here are to the tests, which
all need to be updated when we add new properties to fields. I think the
tests themselves need less of a review as it's a lot of repetition.

This resolves FTDCS-248.