### PR TITLE
feat: add OperationalError cause property

### DIFF
--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -337,10 +337,10 @@ app.get('/fruit/:name', async (request, response, next) => {
             console.warn({
                 event: 'RECOVERABLE_ERROR',
                 error: serializeError(new OperationalError({
-                    statusCode: error.statusCode,
                     code: 'FRUIT_STOCK_LEVEL_FAILED',
                     message: `The Fruit API did not return a stock level for ID ${fruit.id}`,
-                    relatesToSystems: ['fruit-api']
+                    relatesToSystems: ['fruit-api'],
+                    cause: error
                 }))
             });
             fruit.stockLevel = null;

--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -228,6 +228,20 @@ throw new OperationalError({
 });
 ```
 
+You might create an `OperationalError` instance in reaction to an error that has been caught. The root cause error and all the diagnostic information it contains can be included in the `OperationalError` instance by setting it as the value of the `cause` property:
+
+```js
+try {
+    fruit.stockLevel = await fruitApiClient.getStockLevel(fruit.id);
+} catch (error) {
+    throw new OperationalError({
+        message: `A "${fruitName}" is not a valid fruit`,
+        code: 'INVALID_FRUIT',
+        cause: error
+    });
+}
+````
+
 ### Being specific
 
 When you're working on more complex code than our previous examples and catching errors in places where they could have been caused by multiple things, it's important to throw _specific_ errors which identify the cause rather than a generic one.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -5,6 +5,7 @@ A suite of error classes which help you throw the most appropriate error in any 
 
   * [Usage](#usage)
     * [`OperationalError`](#operationalerror)
+      * [`.cause`](#operationalerrorcause)
       * [`.isErrorMarkedAsOperational`](#operationalerroriserrormarkedasoperational)
     * [`HttpError`](#httperror)
       * [Why use this over `http-errors`?](#why-use-this-over-http-errors)
@@ -79,6 +80,10 @@ This array could include:
 
 - dependencies which have returned an HTTP error status code
 - data stores which haven't provided the expected data
+
+#### `OperationalError.cause`
+
+The `cause` property of an operational error stores the root cause error instance, e.g. an error that has been caught as part of a `try`/`catch` block. It allows the operational error to include the diagnostic information captured by the root cause error.
 
 #### `OperationalError.isErrorMarkedAsOperational()`
 

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -10,6 +10,8 @@
  *     A human readable message which describes the error.
  * @property {Array<string>} [relatesToSystems]
  *     An array of FT system codes which are related to this error.
+ * @property {Error|null} [cause]
+ *     The root cause error instance.
  */
 
 /**
@@ -52,6 +54,15 @@ class OperationalError extends Error {
 	relatesToSystems = [];
 
 	/**
+	 * The root cause error instance.
+	 *
+	 * @readonly
+	 * @access public
+	 * @type {Error|null}
+	 */
+	cause = null;
+
+	/**
 	 * Additional error information.
 	 *
 	 * @readonly
@@ -84,6 +95,10 @@ class OperationalError extends Error {
 			}
 		}
 
+		if (data.cause instanceof Error) {
+			this.cause = data.cause;
+		}
+
 		for (const [key, value] of Object.entries(data)) {
 			// @ts-ignore TypeScript does not properly infer the constructor
 			if (!this.constructor.reservedKeys.includes(key)) {
@@ -98,7 +113,7 @@ class OperationalError extends Error {
 	 * @access private
 	 * @type {Array<string>}
 	 */
-	static reservedKeys = ['code', 'message', 'relatesToSystems'];
+	static reservedKeys = ['code', 'message', 'relatesToSystems', 'cause'];
 
 	/**
 	 * Get whether an error object is marked as operational (it has a truthy `isOperational` property).

--- a/packages/errors/test/lib/operational-error.spec.js
+++ b/packages/errors/test/lib/operational-error.spec.js
@@ -58,6 +58,12 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 				expect(instance.relatesToSystems).toStrictEqual([]);
 			});
 		});
+
+		describe('.cause', () => {
+			it('is set to null', () => {
+				expect(instance.cause).toStrictEqual(null);
+			});
+		});
 	});
 
 	describe('new OperationalError(message)', () => {
@@ -96,20 +102,31 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 				expect(instance.name).toStrictEqual('OperationalError');
 			});
 		});
+
+		describe('.cause', () => {
+			it('is set to null', () => {
+				expect(instance.cause).toStrictEqual(null);
+			});
+		});
 	});
 
 	describe('new OperationalError(data)', () => {
 		let instance;
+		let rootCauseErrorInstance;
 
 		beforeEach(() => {
 			jest
 				.spyOn(OperationalError, 'normalizeErrorCode')
 				.mockReturnValue('MOCK_CODE');
+
+			rootCauseErrorInstance = new Error('mock root cause error message');
+
 			instance = new OperationalError({
 				message: 'mock message',
 				code: 'mock_code',
 				extra: 'mock extra data',
-				relatesToSystems: ['system-one', 'system-two']
+				relatesToSystems: ['system-one', 'system-two'],
+				cause: rootCauseErrorInstance
 			});
 		});
 
@@ -164,6 +181,12 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 				expect(singleSystemError.relatesToSystems).toStrictEqual([
 					'system-one'
 				]);
+			});
+		});
+
+		describe('.cause', () => {
+			it('is set to the root cause error instance', () => {
+				expect(instance.cause).toEqual(rootCauseErrorInstance);
 			});
 		});
 	});

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -10,6 +10,7 @@ A utility function to serialize an error object in a way that's friendly to logg
       * [`SerializedError.code`](#serializederrorcode)
       * [`SerializedError.message`](#serializederrormessage)
       * [`SerializedError.isOperational`](#serializederrorisoperational)
+      * [`SerializedError.cause`](#serializederrorcause)
       * [`SerializedError.stack`](#serializederrorstack)
       * [`SerializedError.statusCode`](#serializederrorstatuscode)
       * [`SerializedError.data`](#serializederrordata)
@@ -45,6 +46,7 @@ serializeError(new Error('example message'));
 //     message: 'An error occurred',
 //     isOperational: false,
 //     relatesToSystems: [],
+//     cause: null,
 //     stack: '...',
 //     statusCode: null,
 //     data: {}
@@ -82,6 +84,10 @@ This indicates whether the error is operational (known about). See the documenta
 #### `SerializedError.relatesToSystems`
 
 This array contains a list of [system codes](https://biz-ops.in.ft.com/list/Systems) which are related to the error. It defaults to an empty array.
+
+#### `SerializedError.cause`
+
+This is an error instance extracted from the `error.cause` property, which is serialized before being assigned. It defaults to `null`.
 
 #### `SerializedError.stack`
 

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -12,6 +12,8 @@
  *     A human readable message which describes the error.
  * @property {boolean} isOperational
  *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
+ * @property {(Error | null)} cause
+ *     The root cause error instance.
  * @property {(string | null)} stack
  *     The full error stack.
  * @property {(number | null)} statusCode
@@ -61,6 +63,11 @@ function serializeError(error) {
 		errorProperties.relatesToSystems = error.relatesToSystems;
 	}
 
+	// If set, error cause (which in turn is an error instance) is serialized
+	if (error.cause && error.cause instanceof Error) {
+		errorProperties.cause = serializeError(error.cause);
+	}
+
 	// Only include error stack if it's a string
 	if (typeof error.stack === 'string') {
 		errorProperties.stack = error.stack;
@@ -101,6 +108,7 @@ function createSerializedError(properties) {
 			message: 'An error occurred',
 			isOperational: false,
 			relatesToSystems: [],
+			cause: null,
 			stack: null,
 			statusCode: null,
 			data: {}

--- a/packages/serialize-error/test/lib/index.spec.js
+++ b/packages/serialize-error/test/lib/index.spec.js
@@ -15,6 +15,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				message: 'mock message',
 				isOperational: false,
 				relatesToSystems: [],
+				cause: null,
 				stack: error.stack,
 				statusCode: null,
 				data: {}
@@ -79,6 +80,30 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 					error.relatesToSystems = 'system-one';
 					expect(serializeError(error)).toMatchObject({
 						relatesToSystems: []
+					});
+				});
+			});
+		});
+
+		describe('when the error has a `cause` property', () => {
+			it('includes the root cause error instance in serialized form in the serialized error properties', () => {
+				const rootCauseErrorInstance = new Error(
+					'mock root cause error message'
+				);
+				error.cause = rootCauseErrorInstance;
+				expect(serializeError(error)).toMatchObject({
+					cause: serializeError(rootCauseErrorInstance)
+				});
+				expect(serializeError(error).cause).toMatchObject({
+					message: 'mock root cause error message'
+				});
+			});
+
+			describe('when the `cause` property is not an Error instance', () => {
+				it('leaves the property value unassigned', () => {
+					error.cause = 'foo';
+					expect(serializeError(error)).toMatchObject({
+						cause: null
 					});
 				});
 			});
@@ -156,6 +181,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'An error occurred',
 				isOperational: false,
+				cause: null,
 				stack: null,
 				statusCode: null,
 				data: {}
@@ -194,6 +220,21 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				error.isOperational = true;
 				expect(serializeError(error)).toMatchObject({
 					isOperational: true
+				});
+			});
+		});
+
+		describe('when the object has a `cause` property', () => {
+			it('includes the root cause error instance in serialized form in the serialized error properties', () => {
+				const rootCauseErrorInstance = new Error(
+					'mock root cause error message'
+				);
+				error.cause = rootCauseErrorInstance;
+				expect(serializeError(error)).toMatchObject({
+					cause: serializeError(rootCauseErrorInstance)
+				});
+				expect(serializeError(error).cause).toMatchObject({
+					message: 'mock root cause error message'
 				});
 			});
 		});
@@ -238,6 +279,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'mock message',
 				isOperational: false,
+				cause: null,
 				stack: null,
 				statusCode: null,
 				data: {}
@@ -253,6 +295,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: '123',
 				isOperational: false,
+				cause: null,
 				stack: null,
 				statusCode: null,
 				data: {}
@@ -268,6 +311,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'mock,message',
 				isOperational: false,
+				cause: null,
 				stack: null,
 				statusCode: null,
 				data: {}


### PR DESCRIPTION
FTDCS-250

Jira card: https://financialtimes.atlassian.net/jira/software/c/projects/FTDCS/boards/1426?modal=detail&selectedIssue=FTDCS-250

> **Rowan Manning:** @andygout [pointed out](https://financialtimes.slack.com/archives/CPNKK12S1/p1659013086713049?thread_ts=1659003590.492259&cid=CPNKK12S1) in one of my examples for handling errors we lose some information about the original error. I’ve had a potential solution in mind for this for a while and it’s worth getting down on paper.

> I think that OperationalError should have a new first-class property named cause. This expects another Error object and marks that error as the root cause of the operational error. This will allow us to use generic messages in some places but still capture the original error information. Using the example from the error handling docs, we could update it to be:

```js
try {
    fruit.stockLevel = await fruitApiClient.getStockLevel(fruit.id);
} catch (error) {
    console.warn({
        event: 'RECOVERABLE_ERROR',
        error: serializeError(new OperationalError({
            code: 'FRUIT_STOCK_LEVEL_FAILED',
            message: `The Fruit API did not return a stock level for ID ${fruit.id}`,
            relatesToSystems: ['fruit-api'],
            cause: error // This is the new code
        }))
    });
    fruit.stockLevel = null;
}
```

> We’d also want to update our logger so that it exposes this information and also serialises any errors on the cause property, e.g. the log output could change to:

```js
{
    event: 'RECOVERABLE_ERROR',
    message: 'OperationalError: The Fruit API did not return a stock level for ID X',

    error: {
        // missing some properties for brevity
        name: 'OperationalError',
        code: 'FRUIT_STOCK_LEVEL_FAILED',
        message: 'The Fruit API did not return a stock level for ID X',
        
        cause: {
            name: 'Error',
            code: null,
            message: 'HTTP 503'
        }
    },

    app: {
        // etc
    }
}
```