### PR TITLE
feat: add a middleware-render-error-info package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
+    directory: "/packages/middleware-render-error-info"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
     directory: "/packages/serialize-error"
     schedule:
       interval: "daily"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
   "packages/errors": "1.1.1",
   "packages/log-error": "1.3.2",
   "packages/middleware-log-errors": "1.2.2",
+  "packages/middleware-render-error-info": "0.0.0",
   "packages/serialize-error": "1.1.1",
   "packages/serialize-request": "1.0.0"
 }

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -5,6 +5,7 @@
 
 const express = require('@financial-times/n-express');
 const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors');
+const createErrorRenderingMiddleware = require('@dotcom-reliability-kit/middleware-render-error-info');
 const {
 	HttpError,
 	OperationalError
@@ -68,6 +69,9 @@ app.get('/recoverable', (request, response) => {
 
 // Register the logging middleware
 app.use(createErrorLogger());
+
+// Register the error info page middleware
+app.use(createErrorRenderingMiddleware());
 
 // JSON-based error handler for demo/testing purposes
 app.use(

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -22,6 +22,7 @@
     "@dotcom-reliability-kit/errors": "*",
     "@dotcom-reliability-kit/log-error": "*",
     "@dotcom-reliability-kit/middleware-log-errors": "*",
+    "@dotcom-reliability-kit/middleware-render-error-info": "*",
     "@dotcom-reliability-kit/serialize-error": "*",
     "@financial-times/n-express": "^25.1.0"
   }

--- a/examples/express/test/index.spec.js
+++ b/examples/express/test/index.spec.js
@@ -6,6 +6,10 @@ jest.mock('@financial-times/n-logger', () => ({
 	}
 }));
 
+// The node enironment be set to "test" to get around the error info renderer
+// so that our JSON error handler triggers
+process.env.NODE_ENV = 'test';
+
 process.env.SYSTEM_CODE = 'reliability-kit-express-example';
 process.env.REGION = 'test';
 

--- a/examples/express/test/index.spec.js
+++ b/examples/express/test/index.spec.js
@@ -6,7 +6,7 @@ jest.mock('@financial-times/n-logger', () => ({
 	}
 }));
 
-// The node enironment be set to "test" to get around the error info renderer
+// The node environment is set to "test" to get around the error info renderer
 // so that our JSON error handler triggers
 process.env.NODE_ENV = 'test';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@dotcom-reliability-kit/errors": "*",
         "@dotcom-reliability-kit/log-error": "*",
         "@dotcom-reliability-kit/middleware-log-errors": "*",
+        "@dotcom-reliability-kit/middleware-render-error-info": "*",
         "@dotcom-reliability-kit/serialize-error": "*",
         "@financial-times/n-express": "^25.1.0"
       },
@@ -1009,6 +1010,10 @@
     },
     "node_modules/@dotcom-reliability-kit/middleware-log-errors": {
       "resolved": "packages/middleware-log-errors",
+      "link": true
+    },
+    "node_modules/@dotcom-reliability-kit/middleware-render-error-info": {
+      "resolved": "packages/middleware-render-error-info",
       "link": true
     },
     "node_modules/@dotcom-reliability-kit/serialize-error": {
@@ -9618,6 +9623,22 @@
         "npm": "7.x || 8.x"
       }
     },
+    "packages/middleware-render-error-info": {
+      "name": "@dotcom-reliability-kit/middleware-render-error-info",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^1.3.1",
+        "@dotcom-reliability-kit/serialize-error": "^1.1.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
       "version": "1.1.0",
@@ -10351,6 +10372,7 @@
         "@dotcom-reliability-kit/errors": "*",
         "@dotcom-reliability-kit/log-error": "*",
         "@dotcom-reliability-kit/middleware-log-errors": "*",
+        "@dotcom-reliability-kit/middleware-render-error-info": "*",
         "@dotcom-reliability-kit/serialize-error": "*",
         "@financial-times/n-express": "^25.1.0"
       },
@@ -10390,6 +10412,14 @@
       "version": "file:packages/middleware-log-errors",
       "requires": {
         "@dotcom-reliability-kit/log-error": "^1.3.1",
+        "@types/express": "^4.17.13"
+      }
+    },
+    "@dotcom-reliability-kit/middleware-render-error-info": {
+      "version": "file:packages/middleware-render-error-info",
+      "requires": {
+        "@dotcom-reliability-kit/log-error": "^1.3.1",
+        "@dotcom-reliability-kit/serialize-error": "^1.1.0",
         "@types/express": "^4.17.13"
       }
     },

--- a/packages/middleware-render-error-info/.npmignore
+++ b/packages/middleware-render-error-info/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -1,0 +1,4 @@
+
+## @dotcom-reliability-kit/middleware-render-error-info
+
+Express middleware to render error information in a way that makes debugging easier. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -1,4 +1,4 @@
 
 ## @dotcom-reliability-kit/middleware-render-error-info
 
-Express middleware to render error information in a way that makes debugging easier. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+Express middleware to render error information in a browser in a way that makes debugging easier. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -1,0 +1,57 @@
+/**
+ * @module @dotcom-reliability-kit/middleware-render-error-info
+ */
+
+const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+
+/**
+ * Create a middleware function to render an error info page.
+ *
+ * @access public
+ * @returns {import('express').ErrorRequestHandler}
+ *     Returns error info rendering middleware.
+ */
+function createErrorRenderingMiddleware() {
+	// Only render the error info page if we're not in production
+	const performRendering =
+		process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
+
+	return (error, request, response, next) => {
+		if (performRendering) {
+			// It's unlikely that this will fail but we want to be sure
+			// that any rendering errors are caught properly
+			try {
+				const serializedError = serializeError(error);
+				response.status(serializedError.statusCode || 500);
+				response.set('content-type', 'text/html');
+				return response.send(renderErrorPage(serializedError));
+				// TODO do we need to call `next` anyway for n-raven to work?
+			} catch (/** @type {any} */ renderingError) {
+				logRecoverableError({
+					error: renderingError,
+					request
+				});
+			}
+		}
+		next(error);
+	};
+}
+
+/**
+ * Render an HTML error info page.
+ *
+ * @access private
+ * @param {serializeError.SerializedError} serializedError
+ *     The error to render a page for.
+ * @returns {string}
+ *     Returns the rendered error page.
+ */
+function renderErrorPage(serializedError) {
+	return `
+		<h1>${serializedError.name}: ${serializedError.message}</h1>
+		<pre>${serializedError.stack}</pre>
+	`;
+}
+
+module.exports = createErrorRenderingMiddleware;

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@dotcom-reliability-kit/middleware-render-error-info",
+  "version": "0.0.0",
+  "description": "Express middleware to render error information in a way that makes debugging easier.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/middleware-render-error-info"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-render-error-info#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/log-error": "^1.3.1",
+    "@dotcom-reliability-kit/serialize-error": "^1.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13"
+  }
+}

--- a/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@dotcom-reliability-kit/middleware-render-error-info middleware(error, request, response, next) responds with an HTML representation of the error 1`] = `
+"<h1>MockSerializedError: mock serialized error message</h1>
+<pre>mock serialized error stack</pre>"
+`;

--- a/packages/middleware-render-error-info/test/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/lib/index.spec.js
@@ -1,0 +1,163 @@
+const createErrorRenderingMiddleware = require('../../lib/index');
+
+jest.mock('@dotcom-reliability-kit/serialize-error', () => jest.fn());
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+serializeError.mockReturnValue({
+	message: 'mock serialized error message',
+	name: 'MockSerializedError',
+	stack: 'mock serialized error stack',
+	statusCode: 456
+});
+
+jest.mock('@dotcom-reliability-kit/log-error', () => ({
+	logRecoverableError: jest.fn()
+}));
+const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+
+describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
+	let middleware;
+
+	beforeEach(() => {
+		process.env.NODE_ENV = 'development';
+		middleware = createErrorRenderingMiddleware();
+	});
+
+	describe('middleware(error, request, response, next)', () => {
+		let error;
+		let next;
+		let request;
+		let response;
+
+		beforeEach(() => {
+			error = new Error('mock error');
+			request = { isMockRequest: true };
+			response = {
+				send: jest.fn(),
+				set: jest.fn(),
+				status: jest.fn()
+			};
+			next = jest.fn();
+
+			middleware(error, request, response, next);
+		});
+
+		it('serializes the error', () => {
+			expect(serializeError).toBeCalledWith(error);
+		});
+
+		it('responds with the serialized error status code', () => {
+			expect(response.status).toBeCalledTimes(1);
+			expect(response.status).toBeCalledWith(456);
+		});
+
+		it('responds with a Content-Type header of "text/html"', () => {
+			expect(response.set).toBeCalledTimes(1);
+			expect(response.set).toBeCalledWith('content-type', 'text/html');
+		});
+
+		it('responds with an HTML representation of the error', () => {
+			expect(response.send).toBeCalledTimes(1);
+			const html = response.send.mock.calls[0][0];
+			expect(typeof html).toBe('string');
+			// We replace multiple line break characters with a single one, and
+			// remove all tab characters so that formatting whitespace changes
+			// in the markup don't break the tests
+			expect(
+				html
+					.replace(/[\r\n]+/g, '\n')
+					.replace(/\t+/g, '')
+					.trim()
+			).toMatchSnapshot();
+		});
+
+		it('does not call `next` with the original error', () => {
+			expect(next).toBeCalledTimes(0);
+		});
+
+		describe('when the serialized error does not have a `statusCode` property', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValue({
+					statusCode: null
+				});
+				response.status = jest.fn();
+
+				middleware(error, request, response, next);
+			});
+
+			it('responds with a 500 status code', () => {
+				expect(response.status).toBeCalledTimes(1);
+				expect(response.status).toBeCalledWith(500);
+			});
+		});
+
+		describe('when `process.env.NODE_ENV` is undefined', () => {
+			beforeEach(() => {
+				delete process.env.NODE_ENV;
+				middleware = createErrorRenderingMiddleware();
+				response = {
+					send: jest.fn(),
+					set: jest.fn(),
+					status: jest.fn()
+				};
+				next = jest.fn();
+				middleware(error, request, response, next);
+			});
+
+			it('behaves in the same way as when `NODE_ENV` is set to "development"', () => {
+				expect(serializeError).toBeCalledWith(error);
+				expect(response.status).toBeCalledTimes(1);
+				expect(response.set).toBeCalledTimes(1);
+				expect(response.send).toBeCalledTimes(1);
+			});
+		});
+
+		describe('when `process.env.NODE_ENV` is set to "production"', () => {
+			beforeEach(() => {
+				process.env.NODE_ENV = 'production';
+				middleware = createErrorRenderingMiddleware();
+				response = {
+					send: jest.fn(),
+					set: jest.fn(),
+					status: jest.fn()
+				};
+				next = jest.fn();
+				middleware(error, request, response, next);
+			});
+
+			it('does not render and send an error info page', () => {
+				expect(response.status).toBeCalledTimes(0);
+				expect(response.set).toBeCalledTimes(0);
+				expect(response.send).toBeCalledTimes(0);
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+
+		describe('when rendering the page fails', () => {
+			let renderingError;
+
+			beforeEach(() => {
+				renderingError = new Error('rendering failed');
+				response.send.mockImplementation(() => {
+					throw renderingError;
+				});
+				next = jest.fn();
+				middleware(error, request, response, next);
+			});
+
+			it('logs the rendering error as recoverable', () => {
+				expect(logRecoverableError).toBeCalledTimes(1);
+				expect(logRecoverableError).toBeCalledWith({
+					error: renderingError,
+					request
+				});
+			});
+
+			it('calls `next` with the original error', () => {
+				expect(next).toBeCalledWith(error);
+			});
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,6 +32,7 @@
 		"packages/errors": {},
 		"packages/log-error": {},
 		"packages/middleware-log-errors": {},
+		"packages/middleware-render-error-info": {},
 		"packages/serialize-error": {},
 		"packages/serialize-request": {}
 	}


### PR DESCRIPTION
This makes a start on FTDCS-184, adding a new middleware function which
renders an error information page for debugging. This is the absolute
bare-bones of the module so far and it only provides some basic error
information.

There are also some unanswered questions, mostly whether this will play
nicely with the n-raven and n-express error handlers. I think this will
need some testing once we have a basic 0.1.0 release of this package.

This does not include documentation yet, I think I'd rather work on that
once we've nailed down exactly what the behaviour is and whether we
include any config options.

The commit is tagged to release as 0.1.0, so this should be OK to merge
even though it's incomplete. That way we'll all be able to incrementally
add features rather than having a long-running PR.

---

I tested roughly with the example Express app, it currently looks like this:

<img width="1203" alt="Screenshot 2022-08-04 at 13 30 47" src="https://user-images.githubusercontent.com/138944/182858192-645e2784-eccc-4756-8d1b-e151cd13cded.png">

