### PR TITLE
chore: additional relatesToSystems documentation and tests

### DIFF
--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -228,7 +228,9 @@ throw new OperationalError({
 });
 ```
 
-You might create an `OperationalError` instance in reaction to an error that has been caught. The root cause error and all the diagnostic information it contains can be included in the `OperationalError` instance by setting it as the value of the `cause` property:
+You might create an `OperationalError` instance in reaction to an error that has been caught. The root cause error and all the diagnostic information it contains can be included in the `OperationalError` instance by setting it as the value of the `cause` property.
+
+If the error is caused by interfacing with external systems, the names of those systems can be included as the value of the `relatesToSystems` property.
 
 ```js
 try {
@@ -237,6 +239,7 @@ try {
     throw new OperationalError({
         message: `A "${fruitName}" is not a valid fruit`,
         code: 'INVALID_FRUIT',
+        relatesToSystems: ['fruit-api'],
         cause: error
     });
 }

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -5,6 +5,7 @@ A suite of error classes which help you throw the most appropriate error in any 
 
   * [Usage](#usage)
     * [`OperationalError`](#operationalerror)
+      * [`.relatesToSystems`](#operationalerrorrelatestosystems)
       * [`.cause`](#operationalerrorcause)
       * [`.isErrorMarkedAsOperational`](#operationalerroriserrormarkedasoperational)
     * [`HttpError`](#httperror)

--- a/packages/errors/test/lib/operational-error.spec.js
+++ b/packages/errors/test/lib/operational-error.spec.js
@@ -103,6 +103,12 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 			});
 		});
 
+		describe('.relatesToSystems', () => {
+			it('is set to an empty array', () => {
+				expect(instance.relatesToSystems).toStrictEqual([]);
+			});
+		});
+
 		describe('.cause', () => {
 			it('is set to null', () => {
 				expect(instance.cause).toStrictEqual(null);

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -10,6 +10,7 @@ A utility function to serialize an error object in a way that's friendly to logg
       * [`SerializedError.code`](#serializederrorcode)
       * [`SerializedError.message`](#serializederrormessage)
       * [`SerializedError.isOperational`](#serializederrorisoperational)
+      * [`SerializedError.relatesToSystems`](#serializederrorrelatestosystems)
       * [`SerializedError.cause`](#serializederrorcause)
       * [`SerializedError.stack`](#serializederrorstack)
       * [`SerializedError.statusCode`](#serializederrorstatuscode)

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -12,6 +12,8 @@
  *     A human readable message which describes the error.
  * @property {boolean} isOperational
  *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
+ * @property {Array<string>} relatesToSystems
+ *     An array of FT system codes which are related to this error.
  * @property {(Error | null)} cause
  *     The root cause error instance.
  * @property {(string | null)} stack

--- a/packages/serialize-error/test/lib/index.spec.js
+++ b/packages/serialize-error/test/lib/index.spec.js
@@ -181,6 +181,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'An error occurred',
 				isOperational: false,
+				relatesToSystems: [],
 				cause: null,
 				stack: null,
 				statusCode: null,
@@ -220,6 +221,24 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				error.isOperational = true;
 				expect(serializeError(error)).toMatchObject({
 					isOperational: true
+				});
+			});
+		});
+
+		describe('when the error has a `relatesToSystems` property', () => {
+			it('includes the related systems in the error', () => {
+				error.relatesToSystems = ['system-one'];
+				expect(serializeError(error)).toMatchObject({
+					relatesToSystems: ['system-one']
+				});
+			});
+
+			describe('when the `relatesToSystems` property is not an array', () => {
+				it('is set to the default empty array', () => {
+					error.relatesToSystems = 'system-one';
+					expect(serializeError(error)).toMatchObject({
+						relatesToSystems: []
+					});
 				});
 			});
 		});
@@ -279,6 +298,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'mock message',
 				isOperational: false,
+				relatesToSystems: [],
 				cause: null,
 				stack: null,
 				statusCode: null,
@@ -295,6 +315,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: '123',
 				isOperational: false,
+				relatesToSystems: [],
 				cause: null,
 				stack: null,
 				statusCode: null,
@@ -311,6 +332,7 @@ describe('@dotcom-reliability-kit/serialize-error', () => {
 				code: 'UNKNOWN',
 				message: 'mock,message',
 				isOperational: false,
+				relatesToSystems: [],
 				cause: null,
 				stack: null,
 				statusCode: null,


### PR DESCRIPTION
When doing the work in this PR https://github.com/Financial-Times/dotcom-reliability-kit/pull/98, I noticed that the `relatesToSystems` property was missing from some documentation, JSDocs, and tests.

This PR includes it in those places.