### PR TITLE
feat: render full error information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10044,7 +10044,8 @@
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/log-error": "^1.3.1",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.0"
+        "@dotcom-reliability-kit/serialize-error": "^1.1.0",
+        "entities": "^4.3.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -10052,6 +10053,17 @@
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
+      }
+    },
+    "packages/middleware-render-error-info/node_modules/entities": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "packages/serialize-error": {
@@ -10844,7 +10856,15 @@
       "requires": {
         "@dotcom-reliability-kit/log-error": "^1.3.1",
         "@dotcom-reliability-kit/serialize-error": "^1.1.0",
-        "@types/express": "^4.17.13"
+        "@types/express": "^4.17.13",
+        "entities": "*"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+          "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
+        }
       }
     },
     "@dotcom-reliability-kit/serialize-error": {

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -3,6 +3,7 @@
  */
 
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+const renderErrorPage = require('./render-error-page');
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
 
 /**
@@ -29,7 +30,13 @@ function createErrorRenderingMiddleware() {
 				const serializedError = serializeError(error);
 				response.status(serializedError.statusCode || 500);
 				response.set('content-type', 'text/html');
-				return response.send(renderErrorPage(serializedError));
+				return response.send(
+					renderErrorPage({
+						request,
+						response,
+						serializedError
+					})
+				);
 			} catch (/** @type {any} */ renderingError) {
 				logRecoverableError({
 					error: renderingError,
@@ -39,22 +46,6 @@ function createErrorRenderingMiddleware() {
 		}
 		next(error);
 	};
-}
-
-/**
- * Render an HTML error info page.
- *
- * @access private
- * @param {serializeError.SerializedError} serializedError
- *     The error to render a page for.
- * @returns {string}
- *     Returns the rendered error page.
- */
-function renderErrorPage(serializedError) {
-	return `
-		<h1>${serializedError.name}: ${serializedError.message}</h1>
-		<pre>${serializedError.stack}</pre>
-	`;
 }
 
 module.exports = createErrorRenderingMiddleware;

--- a/packages/middleware-render-error-info/lib/render-error-page.css
+++ b/packages/middleware-render-error-info/lib/render-error-page.css
@@ -1,0 +1,60 @@
+
+/* Override to avoid super long pages and make pre elements scroll */
+pre {
+	max-height: 300px;
+	white-space: pre-wrap;
+}
+
+/* Override to add some spacing below alert messages in the main body of the page */
+.o-layout__main .o-message {
+	margin-bottom: var(--o-spacing-s4);
+}
+
+/* Override to add some spacing below sections in the main body of the page */
+.o-layout__main > section {
+	margin-bottom: var(--o-spacing-m12);
+}
+
+/* Styles for a key/value list. Description list styles are not provided by Origami */
+.kv-list {
+	display: grid;
+	grid-template-columns: 1fr 4fr;
+	margin: 0;
+}
+.kv-list__key {
+	padding-right: var(--o-spacing-s3);
+}
+.kv-list__label {
+	font-weight: 500;
+}
+.kv-list__value {
+	overflow: auto;
+	background-color: var(--o-colors-black-5);
+	padding: var(--o-spacing-s2);
+}
+.kv-list__key,
+.kv-list__value {
+	margin: 0;
+	padding-top: var(--o-spacing-s2);
+	padding-bottom: var(--o-spacing-s2);
+	border-bottom: 1px solid var(--o-colors-black-20);
+}
+.kv-list__key:first-child,
+.kv-list__value:nth-child(2) {
+	border-top: 1px solid var(--o-colors-black-20);
+}
+.kv-list__value pre {
+	margin: 0;
+	padding: 0;
+}
+
+/* Boolean value styling */
+.boolean {
+	font-weight: 600;
+}
+.boolean--positive {
+	color: var(--o-colors-jade);
+}
+.boolean--negative {
+	color: var(--o-colors-crimson);
+}

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -25,6 +25,7 @@ const renderLayout = require('./render-layout');
  *     Returns the rendered error page.
  */
 function renderErrorPage({ request, response, serializedError }) {
+	const appName = process.env.SYSTEM_CODE || 'application';
 	return renderLayout({
 		body: `
 			<h1 id="errors">Error information</h1>
@@ -33,7 +34,7 @@ function renderErrorPage({ request, response, serializedError }) {
 			${renderResponse(response)}
 		`,
 		request,
-		response
+		title: escape(`${serializedError.name} in ${appName}`)
 	});
 }
 

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -1,0 +1,388 @@
+/**
+ * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-error-page
+ */
+
+const renderLayout = require('./render-layout');
+
+/**
+ * @typedef {object} ErrorRenderingOptions
+ * @property {import('express').Request} request
+ *     An Express request object.
+ * @property {import('express').Response} response
+ *     An Express response object.
+ * @property {import('@dotcom-reliability-kit/serialize-error').SerializedError} serializedError
+ *     The error to render.
+ */
+
+/**
+ * Render an HTML error info page.
+ *
+ * @access private
+ * @param {ErrorRenderingOptions} options
+ *     Options which impact the rendering of the page.
+ * @returns {string}
+ *     Returns the rendered error page.
+ */
+function renderErrorPage({ request, response, serializedError }) {
+	return renderLayout({
+		body: `
+			<h1 id="errors">Error information</h1>
+			${renderError(serializedError)}
+			${renderRequest(request)}
+			${renderResponse(response)}
+		`,
+		request,
+		response
+	});
+}
+
+/**
+ * Render a serialized error to HTML.
+ *
+ * @access private
+ * @param {import('@dotcom-reliability-kit/serialize-error').SerializedError} error
+ *     The error information to render.
+ * @returns {string}
+ *     Returns the rendered error.
+ */
+function renderError(error) {
+	let warning = '';
+
+	if (!error.stack) {
+		warning = renderWarning({
+			title: 'A non-Error object was thrown.',
+			body: `
+				The thing that was thrown does not extend the Node.js built-in Error class.
+				This makes it much harder to debug the issue, as we cannot find the line numbers where
+				the error occurred. You'll need to search your source code for anywhere that a non-Error
+				appears after the "throw" keyword.
+				See the <a href="https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md#using-error-objects" target="_blank">using error objects guide</a> for more information.
+			`
+		});
+	} else if (!error.isOperational) {
+		warning = renderWarning({
+			title: 'This error is unexpected.',
+			body: `
+				It is not extending the <a href="https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#operationalerror" target="_blank">OperationalError</a>
+				class provided by Reliability Kit which indicates to us that we don't understand how to manage this error.
+				If this is not true, then consider catching this error and throwing an operational error.
+				See the <a href="https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md" target="_blank">throwing errors guide</a> for more information.
+			`
+		});
+	}
+
+	return renderSection({
+		id: `error-${error.code} ${error.message}`.replace(/[^a-z0-9_-]+/gi, '-'),
+		title: error.name,
+		body: warning,
+		fields: [
+			{
+				label: 'Message',
+				helpText: 'The human-readable message which describes this error',
+				value: error.message
+			},
+			{
+				label: 'Code',
+				helpText: 'The machine-readable code which identifies this error',
+				value: error.code,
+				formatter: renderCodeBlock
+			},
+			{
+				label: 'Status Code',
+				helpText: 'The HTTP status code this error should be served under',
+				value: error.statusCode,
+				formatter: renderCodeBlock
+			},
+			{
+				label: 'Is operational',
+				helpText:
+					'Whether this is a known or expected error (<a href="https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md#operational-errors" target="_blank">docs</a>)',
+				value: error.isOperational,
+				formatter: renderBoolean
+			},
+			{
+				label: 'Related systems',
+				helpText: 'Any Biz Ops systems which this error is related to',
+				value: error.relatesToSystems,
+				formatter: renderBizOpsSystems
+			},
+			...Object.entries(error.data).map(([key, value]) => {
+				return {
+					label: `Data (${key})`,
+					value,
+					formatter: renderAsJson
+				};
+			}),
+			{
+				label: 'Stack',
+				helpText:
+					'The full stack trace for the error, indicating where it was thrown',
+				value: error.stack,
+				formatter: renderCodeBlock
+			},
+			{
+				label: 'Cause',
+				helpText:
+					'The original thrown error which resulted in this operational error',
+				value: error.cause,
+				formatter: renderError
+			}
+		]
+	});
+}
+
+/**
+ * Render an HTTP request to HTML.
+ *
+ * @access private
+ * @param {import('express').Request} request
+ *     The request information to render.
+ * @returns {string}
+ *     Returns the rendered request.
+ */
+function renderRequest(request) {
+	return renderSection({
+		id: 'request',
+		title: 'HTTP Request',
+		fields: [
+			{
+				label: 'Method',
+				value: request.method,
+				formatter: renderCodeBlock
+			},
+			{
+				label: 'Path',
+				value: request.path,
+				formatter: renderCodeBlock
+			},
+			...Object.entries(request.query).map(([key, value]) => {
+				return {
+					label: `Query (${key})`,
+					value,
+					formatter: renderCodeBlock
+				};
+			}),
+			...Object.entries(request.headers).map(([key, value]) => {
+				return {
+					label: `Header (${key})`,
+					value,
+					formatter: renderCodeBlock
+				};
+			})
+		]
+	});
+}
+
+/**
+ * Render an HTTP response to HTML.
+ *
+ * @access private
+ * @param {import('express').Response} response
+ *     The responses information to render.
+ * @returns {string}
+ *     Returns the rendered response.
+ */
+function renderResponse(response) {
+	return renderSection({
+		id: 'response',
+		title: 'HTTP Response',
+		fields: [
+			{
+				label: 'Status Code',
+				value: response.statusCode,
+				formatter: renderCodeBlock
+			}
+		]
+	});
+}
+
+/**
+ * @typedef {object} Field
+ * @property {string} label
+ *     The text label to add to the definition title.
+ * @property {any} value
+ *     The value to associate with the label.
+ * @property {string} [helpText]
+ *     The help text to explain what the field is for.
+ * @property {(value: any) => string} [formatter]
+ *     A formatter function which accepts a value and returns a formatted string.
+ */
+
+/**
+ * Render a page section.
+ *
+ * @access private
+ * @param {object} section
+ *     The section information.
+ * @param {string} section.id
+ *     The section id.
+ * @param {string} section.title
+ *     The section title.
+ * @param {Array<Field>} section.fields
+ *     The fields to render in the section.
+ * @param {string} [section.body]
+ *     The section body content.
+ * @returns {string}
+ *     Returns the rendered section.
+ */
+function renderSection({ id, title, body, fields }) {
+	return `
+		<section class="o-layout__main__full-span">
+			<h2 id="${escape(id)}">${escape(title)}</h2>
+			${body ? body : ''}
+			<dl class="kv-list">
+				${fields.map(renderField).join('\n')}
+			</dl>
+		</section>
+	`;
+}
+
+/**
+ * Render a warning message.
+ *
+ * @access private
+ * @param {object} warning
+ *     The warning information.
+ * @param {string} warning.title
+ *     The warning title.
+ * @param {string} warning.body
+ *     The warning body content.
+ * @returns {string}
+ *     Returns the rendered warning.
+ */
+function renderWarning({ title, body }) {
+	return `
+		<div class="o-message o-message--notice o-message--warning-light" data-o-component="o-message" data-o-message-close="false">
+			<div class="o-message__container o-layout__unstyled-element">
+				<div class="o-message__content o-layout__unstyled-element">
+					<p class="o-message__content-main o-layout__unstyled-element">
+						<span class="o-message__content-highlight o-layout__unstyled-element">${title}</span><br/>${body}
+					</p>
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+/**
+ * Render a definition list title and value.
+ *
+ * @access private
+ * @param {Field} field
+ *     The field information.
+ * @returns {string}
+ *     Returns the rendered field.
+ */
+function renderField({ label, helpText, value, formatter = escape }) {
+	if (!value && value !== false) {
+		return '';
+	}
+	if (helpText) {
+		helpText = `<br/><small>${helpText}</small>`;
+	}
+	return `
+		<dt class="kv-list__key">
+			<span class="kv-list__label">${escape(label)}:</span>
+			${helpText || ''}
+		</dt>
+		<dd class="kv-list__value">${formatter(value)}</dd>
+	`;
+}
+
+/**
+ * Render a block of code.
+ *
+ * @access private
+ * @param {string} block
+ *     The value to wrap in a `<pre>` element.
+ * @returns {string}
+ *     Returns the rendered code block.
+ */
+function renderCodeBlock(block) {
+	return `<pre><code>${escape(block)}</code></pre>`;
+}
+
+/**
+ * Convert a boolean into a "Yes" or "No" string.
+ *
+ * @access private
+ * @param {boolean} boolean
+ *     The boolean to render.
+ * @param {string} trueModifier
+ *     The BEM modifier to use when the value is true.
+ * @param {string} falseModifier
+ *     The BEM modifier to use when the value is false.
+ * @returns {string}
+ *     Returns the rendered boolean.
+ */
+function renderBoolean(
+	boolean,
+	trueModifier = 'positive',
+	falseModifier = 'negative'
+) {
+	return boolean
+		? `<span class="boolean boolean--${trueModifier}">Yes</span>`
+		: `<span class="boolean boolean--${falseModifier}">No</span>`;
+}
+
+/**
+ * Render a list of systems, linking them to Biz Ops.
+ *
+ * @access private
+ * @param {Array<string>} systems
+ *     An array of system codes.
+ * @returns {string}
+ *     Returns the rendered systems.
+ */
+function renderBizOpsSystems(systems) {
+	return systems.length ? systems.map(renderBizOpsSystem).join(', ') : 'None';
+}
+
+/**
+ * Render a single Biz Ops system.
+ *
+ * @access private
+ * @param {string} systemCode
+ *     The system code to link to.
+ * @returns {string}
+ *     Returns the rendered system.
+ */
+function renderBizOpsSystem(systemCode) {
+	return `
+		<a
+			href="https://biz-ops.in.ft.com/System/${escape(systemCode)}"
+			target="_blank"
+		>${escape(systemCode)}</a>
+	`;
+}
+
+/**
+ * Render a value as JSON in a <pre> element.
+ *
+ * @access private
+ * @param {any} value
+ *     The value to stringify and render.
+ * @returns {string}
+ *     Returns the rendered JSON.
+ */
+function renderAsJson(value) {
+	return renderCodeBlock(JSON.stringify(value, null, 4));
+}
+
+/**
+ * Escape a value for use in HTML.
+ *
+ * @access private
+ * @param {any} value
+ *     The value to escape.
+ * @returns {string}
+ *     Returns the HTML-escaped value.
+ */
+function escape(value) {
+	return `${value}`
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+module.exports = renderErrorPage;

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -2,6 +2,7 @@
  * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-error-page
  */
 
+const entities = require('entities');
 const renderLayout = require('./render-layout');
 
 /**
@@ -379,10 +380,7 @@ function renderAsJson(value) {
  *     Returns the HTML-escaped value.
  */
 function escape(value) {
-	return `${value}`
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+	return entities.escapeUTF8(`${value}`);
 }
 
 module.exports = renderErrorPage;

--- a/packages/middleware-render-error-info/lib/render-layout.js
+++ b/packages/middleware-render-error-info/lib/render-layout.js
@@ -1,0 +1,127 @@
+/**
+ * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-layout
+ */
+
+const fs = require('fs');
+
+// We need a system code for the system. Most of our apps supply a SYSTEM_CODE
+// environment variable. If this is not possible then we fall back to the Origami
+// default: https://www.ft.com/__origami/service/build/v3/docs/api#get-v3-bundles-css
+const systemCode = '$$$-no-bizops-system-code-$$$';
+
+// Build service URLs don't change per-request so work them out here
+const buildServiceBaseUrl = 'https://www.ft.com/__origami/service/build/v3';
+const buildServiceParams = new URLSearchParams({
+	system_code: systemCode,
+	brand: 'internal',
+	components: [
+		'o-autoinit@^3.1.3',
+		'o-spacing@^3.2.1',
+		'o-colors@^6.4.2',
+		'o-layout@^5.2.3',
+		'o-header-services@^5.2.3',
+		'o-footer-services@^4.2.3',
+		'o-syntax-highlight@^4.2.3',
+		'o-message@^5.3.1'
+	].join(',')
+});
+const buildServiceCssBundle = `${buildServiceBaseUrl}/bundles/css?${buildServiceParams}`;
+const buildServiceJsBundle = `${buildServiceBaseUrl}/bundles/js?${buildServiceParams}`;
+
+// Load CSS syncronously, this is only run once during startup so won't
+// negatively impact the app performance while running
+const styles = fs.readFileSync(`${__dirname}/render-error-page.css`, 'utf-8');
+
+/**
+ * @typedef {object} LayoutRenderingOptions
+ * @property {string} body
+ *     The main body of the page.
+ * @property {import('express').Request} request
+ *     An Express request object.
+ * @property {import('express').Response} response
+ *     An Express response object.
+ */
+
+/**
+ * Render an HTML error info page.
+ *
+ * @access private
+ * @param {LayoutRenderingOptions} options
+ *     Options which impact the rendering of the page.
+ * @returns {string}
+ *     Returns the rendered error page.
+ */
+function renderLayout({ body, request }) {
+	return `
+		<!DOCTYPE html>
+		<html lang="en">
+			<head>
+				<meta charset="utf-8" />
+				<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+				<title>Error Info</title>
+				<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+				<link rel="stylesheet" type="text/css" href="${buildServiceCssBundle}" />
+				<style>${styles}</style>
+				<script defer="" src="${buildServiceJsBundle}"></script>
+			</head>
+			<body>
+				<div class="o-layout o-layout--docs" data-o-component="o-layout" data-o-layout-construct-nav="true">
+					<div class="o-layout__header">
+						<header class="o-header-services" data-o-component="o-header-services">
+							<div class="o-header-services__top">
+								<div class="o-header-services__logo"></div>
+								<div class="o-header-services__title">
+									<a class="o-header-services__product-name" href="${request.url}">
+										Reliability Kit Error Info Page
+									</a>
+								</div>
+							</div>
+						</header>
+						<div class="o-message o-message--alert o-message--error" data-o-component="o-message" data-o-message-close="false">
+							<div class="o-message__container">
+								<div class="o-message__content">
+									<p class="o-message__content-main">
+										<span class="o-message__content-highlight">Welcome to the Reliability Kit error info page.</span><br/>
+										This page has appeared because you're using the
+										<a href="https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-render-error-info#readme">@dotcom-reliability-kit/middleware-render-error-info</a>
+										package in your app.<br/>
+										Hopefully this will make it a lot easier for you to debug the cause of this error.<br/>
+										Don't panic: this only appears when you're running the app locally!
+									</p>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="o-layout__sidebar o-layout-typography"></div>
+					<main class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">${body}</main>
+					<div class="o-layout__footer">
+						<footer class="o-footer-services">
+							<div class="o-footer-services__container">
+								<div class="o-footer-services__wrapper o-footer-services__wrapper--top">
+									<a class="o-footer-services__icon-link o-footer-services__icon-link--github" href="https://github.com/Financial-Times/dotcom-reliability-kit#readme">Reliability Kit Documentation</a>
+									<a class="o-footer-services__icon-link o-footer-services__icon-link--slack" href="https://financialtimes.slack.com/archives/C02B89GEQHF">#dotcom-support</a>
+								</div>
+							</div>
+							<div class="o-footer-services__container">
+								<div class="o-footer-services__wrapper o-footer-services__wrapper--legal">
+									<div class="o-footer-services__links">
+									<a href="http://help.ft.com/help/legal-privacy/cookies/">Cookies</a>
+									<a href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/">Copyright</a>
+									<a href="http://help.ft.com/help/legal-privacy/privacy/">Privacy</a>
+									<a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms &amp; Conditions</a>
+									</div>
+									<p>
+										<span>&#xA9; THE FINANCIAL TIMES LTD ${new Date().getFullYear()}.</span> FT and
+										&apos;Financial Times&apos; are trademarks of The Financial Times Ltd.
+									</p>
+								</div>
+							</div>
+						</footer>
+					</div>
+				</div>
+			</body>
+		</html>
+	`;
+}
+
+module.exports = renderLayout;

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -17,7 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/log-error": "^1.3.1",
-    "@dotcom-reliability-kit/serialize-error": "^1.1.0"
+    "@dotcom-reliability-kit/serialize-error": "^1.1.0",
+    "entities": "^4.3.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13"

--- a/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
@@ -184,7 +184,7 @@ target=\\"_blank\\"
 <span class=\\"kv-list__label\\">Stack:</span>
 <br/><small>The full stack trace for the error, indicating where it was thrown</small>
 </dt>
-<dd class=\\"kv-list__value\\"><pre><code>mock serialized error stack</code></pre></dd>
+<dd class=\\"kv-list__value\\"><pre><code>mock serialized error stack &lt;script&gt;oops&lt;/script&gt;</code></pre></dd>
 
 <dt class=\\"kv-list__key\\">
 <span class=\\"kv-list__label\\">Cause:</span>

--- a/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
@@ -6,9 +6,9 @@ exports[`@dotcom-reliability-kit/middleware-render-error-info middleware(error, 
 <head>
 <meta charset=\\"utf-8\\" />
 <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\" />
-<title>Error Info</title>
+<title>MockSerializedError in mock-system-code</title>
 <meta name=\\"viewport\\" content=\\"initial-scale=1.0, width=device-width\\" />
-<link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=%24%24%24-no-bizops-system-code-%24%24%24&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\" />
+<link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=mock-system-code&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\" />
 <style>
 /* Override to avoid super long pages and make pre elements scroll */
 pre {
@@ -66,7 +66,7 @@ color: var(--o-colors-jade);
 color: var(--o-colors-crimson);
 }
 </style>
-<script defer=\\"\\" src=\\"https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=%24%24%24-no-bizops-system-code-%24%24%24&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\"></script>
+<script defer=\\"\\" src=\\"https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=mock-system-code&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\"></script>
 </head>
 <body>
 <div class=\\"o-layout o-layout--docs\\" data-o-component=\\"o-layout\\" data-o-layout-construct-nav=\\"true\\">

--- a/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/lib/__snapshots__/index.spec.js.snap
@@ -1,6 +1,345 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`@dotcom-reliability-kit/middleware-render-error-info middleware(error, request, response, next) responds with an HTML representation of the error 1`] = `
-"<h1>MockSerializedError: mock serialized error message</h1>
-<pre>mock serialized error stack</pre>"
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\" />
+<meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\" />
+<title>Error Info</title>
+<meta name=\\"viewport\\" content=\\"initial-scale=1.0, width=device-width\\" />
+<link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=%24%24%24-no-bizops-system-code-%24%24%24&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\" />
+<style>
+/* Override to avoid super long pages and make pre elements scroll */
+pre {
+max-height: 300px;
+white-space: pre-wrap;
+}
+/* Override to add some spacing below alert messages in the main body of the page */
+.o-layout__main .o-message {
+margin-bottom: var(--o-spacing-s4);
+}
+/* Override to add some spacing below sections in the main body of the page */
+.o-layout__main > section {
+margin-bottom: var(--o-spacing-m12);
+}
+/* Styles for a key/value list. Description list styles are not provided by Origami */
+.kv-list {
+display: grid;
+grid-template-columns: 1fr 4fr;
+margin: 0;
+}
+.kv-list__key {
+padding-right: var(--o-spacing-s3);
+}
+.kv-list__label {
+font-weight: 500;
+}
+.kv-list__value {
+overflow: auto;
+background-color: var(--o-colors-black-5);
+padding: var(--o-spacing-s2);
+}
+.kv-list__key,
+.kv-list__value {
+margin: 0;
+padding-top: var(--o-spacing-s2);
+padding-bottom: var(--o-spacing-s2);
+border-bottom: 1px solid var(--o-colors-black-20);
+}
+.kv-list__key:first-child,
+.kv-list__value:nth-child(2) {
+border-top: 1px solid var(--o-colors-black-20);
+}
+.kv-list__value pre {
+margin: 0;
+padding: 0;
+}
+/* Boolean value styling */
+.boolean {
+font-weight: 600;
+}
+.boolean--positive {
+color: var(--o-colors-jade);
+}
+.boolean--negative {
+color: var(--o-colors-crimson);
+}
+</style>
+<script defer=\\"\\" src=\\"https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=%24%24%24-no-bizops-system-code-%24%24%24&brand=internal&components=o-autoinit%40%5E3.1.3%2Co-spacing%40%5E3.2.1%2Co-colors%40%5E6.4.2%2Co-layout%40%5E5.2.3%2Co-header-services%40%5E5.2.3%2Co-footer-services%40%5E4.2.3%2Co-syntax-highlight%40%5E4.2.3%2Co-message%40%5E5.3.1\\"></script>
+</head>
+<body>
+<div class=\\"o-layout o-layout--docs\\" data-o-component=\\"o-layout\\" data-o-layout-construct-nav=\\"true\\">
+<div class=\\"o-layout__header\\">
+<header class=\\"o-header-services\\" data-o-component=\\"o-header-services\\">
+<div class=\\"o-header-services__top\\">
+<div class=\\"o-header-services__logo\\"></div>
+<div class=\\"o-header-services__title\\">
+<a class=\\"o-header-services__product-name\\" href=\\"undefined\\">
+Reliability Kit Error Info Page
+</a>
+</div>
+</div>
+</header>
+<div class=\\"o-message o-message--alert o-message--error\\" data-o-component=\\"o-message\\" data-o-message-close=\\"false\\">
+<div class=\\"o-message__container\\">
+<div class=\\"o-message__content\\">
+<p class=\\"o-message__content-main\\">
+<span class=\\"o-message__content-highlight\\">Welcome to the Reliability Kit error info page.</span><br/>
+This page has appeared because you're using the
+<a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-render-error-info#readme\\">@dotcom-reliability-kit/middleware-render-error-info</a>
+package in your app.<br/>
+Hopefully this will make it a lot easier for you to debug the cause of this error.<br/>
+Don't panic: this only appears when you're running the app locally!
+</p>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"o-layout__sidebar o-layout-typography\\"></div>
+<main class=\\"o-layout__main o-layout-typography\\" data-o-component=\\"o-syntax-highlight\\">
+<h1 id=\\"errors\\">Error information</h1>
+
+<section class=\\"o-layout__main__full-span\\">
+<h2 id=\\"error-MOCK_SERIALIZED_ERROR_CODE-mock-serialized-error-message\\">MockSerializedError</h2>
+
+<dl class=\\"kv-list\\">
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Message:</span>
+<br/><small>The human-readable message which describes this error</small>
+</dt>
+<dd class=\\"kv-list__value\\">mock serialized error message</dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Code:</span>
+<br/><small>The machine-readable code which identifies this error</small>
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>MOCK_SERIALIZED_ERROR_CODE</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Status Code:</span>
+<br/><small>The HTTP status code this error should be served under</small>
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>456</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Is operational:</span>
+<br/><small>Whether this is a known or expected error (<a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md#operational-errors\\" target=\\"_blank\\">docs</a>)</small>
+</dt>
+<dd class=\\"kv-list__value\\"><span class=\\"boolean boolean--positive\\">Yes</span></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Related systems:</span>
+<br/><small>Any Biz Ops systems which this error is related to</small>
+</dt>
+<dd class=\\"kv-list__value\\">
+<a
+href=\\"https://biz-ops.in.ft.com/System/mock-system-1\\"
+target=\\"_blank\\"
+>mock-system-1</a>
+, 
+<a
+href=\\"https://biz-ops.in.ft.com/System/mock-system-2\\"
+target=\\"_blank\\"
+>mock-system-2</a>
+</dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Data (booleanValue):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>true</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Data (stringValue):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>&quot;mock value&quot;</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Data (numberValue):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>123</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Data (arrayValue):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>[
+    &quot;mock&quot;,
+    &quot;array&quot;
+]</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Data (objectValue):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>{
+    &quot;isObject&quot;: true
+}</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Stack:</span>
+<br/><small>The full stack trace for the error, indicating where it was thrown</small>
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>mock serialized error stack</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Cause:</span>
+<br/><small>The original thrown error which resulted in this operational error</small>
+</dt>
+<dd class=\\"kv-list__value\\">
+<section class=\\"o-layout__main__full-span\\">
+<h2 id=\\"error-undefined-mock-caused-error-message\\">undefined</h2>
+
+<div class=\\"o-message o-message--notice o-message--warning-light\\" data-o-component=\\"o-message\\" data-o-message-close=\\"false\\">
+<div class=\\"o-message__container o-layout__unstyled-element\\">
+<div class=\\"o-message__content o-layout__unstyled-element\\">
+<p class=\\"o-message__content-main o-layout__unstyled-element\\">
+<span class=\\"o-message__content-highlight o-layout__unstyled-element\\">This error is unexpected.</span><br/>
+It is not extending the <a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#operationalerror\\" target=\\"_blank\\">OperationalError</a>
+class provided by Reliability Kit which indicates to us that we don't understand how to manage this error.
+If this is not true, then consider catching this error and throwing an operational error.
+See the <a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md\\" target=\\"_blank\\">throwing errors guide</a> for more information.
+
+</p>
+</div>
+</div>
+</div>
+
+<dl class=\\"kv-list\\">
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Message:</span>
+<br/><small>The human-readable message which describes this error</small>
+</dt>
+<dd class=\\"kv-list__value\\">mock caused error message</dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Is operational:</span>
+<br/><small>Whether this is a known or expected error (<a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md#operational-errors\\" target=\\"_blank\\">docs</a>)</small>
+</dt>
+<dd class=\\"kv-list__value\\"><span class=\\"boolean boolean--negative\\">No</span></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Related systems:</span>
+<br/><small>Any Biz Ops systems which this error is related to</small>
+</dt>
+<dd class=\\"kv-list__value\\">None</dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Stack:</span>
+<br/><small>The full stack trace for the error, indicating where it was thrown</small>
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>mock caused error stack</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Cause:</span>
+<br/><small>The original thrown error which resulted in this operational error</small>
+</dt>
+<dd class=\\"kv-list__value\\">
+<section class=\\"o-layout__main__full-span\\">
+<h2 id=\\"error-undefined-undefined\\">undefined</h2>
+
+<div class=\\"o-message o-message--notice o-message--warning-light\\" data-o-component=\\"o-message\\" data-o-message-close=\\"false\\">
+<div class=\\"o-message__container o-layout__unstyled-element\\">
+<div class=\\"o-message__content o-layout__unstyled-element\\">
+<p class=\\"o-message__content-main o-layout__unstyled-element\\">
+<span class=\\"o-message__content-highlight o-layout__unstyled-element\\">A non-Error object was thrown.</span><br/>
+The thing that was thrown does not extend the Node.js built-in Error class.
+This makes it much harder to debug the issue, as we cannot find the line numbers where
+the error occurred. You'll need to search your source code for anywhere that a non-Error
+appears after the \\"throw\\" keyword.
+See the <a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/throwing-errors.md#using-error-objects\\" target=\\"_blank\\">using error objects guide</a> for more information.
+
+</p>
+</div>
+</div>
+</div>
+
+<dl class=\\"kv-list\\">
+
+</dl>
+</section>
+</dd>
+
+</dl>
+</section>
+</dd>
+
+</dl>
+</section>
+
+
+<section class=\\"o-layout__main__full-span\\">
+<h2 id=\\"request\\">HTTP Request</h2>
+
+<dl class=\\"kv-list\\">
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Method:</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>mock request method</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Path:</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>mock request path</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Query (mock-request-query):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>yes</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Header (mock-request-header):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>yes</code></pre></dd>
+
+</dl>
+</section>
+
+
+<section class=\\"o-layout__main__full-span\\">
+<h2 id=\\"response\\">HTTP Response</h2>
+
+<dl class=\\"kv-list\\">
+
+</dl>
+</section>
+
+</main>
+<div class=\\"o-layout__footer\\">
+<footer class=\\"o-footer-services\\">
+<div class=\\"o-footer-services__container\\">
+<div class=\\"o-footer-services__wrapper o-footer-services__wrapper--top\\">
+<a class=\\"o-footer-services__icon-link o-footer-services__icon-link--github\\" href=\\"https://github.com/Financial-Times/dotcom-reliability-kit#readme\\">Reliability Kit Documentation</a>
+<a class=\\"o-footer-services__icon-link o-footer-services__icon-link--slack\\" href=\\"https://financialtimes.slack.com/archives/C02B89GEQHF\\">#dotcom-support</a>
+</div>
+</div>
+<div class=\\"o-footer-services__container\\">
+<div class=\\"o-footer-services__wrapper o-footer-services__wrapper--legal\\">
+<div class=\\"o-footer-services__links\\">
+<a href=\\"http://help.ft.com/help/legal-privacy/cookies/\\">Cookies</a>
+<a href=\\"http://help.ft.com/help/legal-privacy/copyright/copyright-policy/\\">Copyright</a>
+<a href=\\"http://help.ft.com/help/legal-privacy/privacy/\\">Privacy</a>
+<a href=\\"http://help.ft.com/help/legal-privacy/terms-conditions\\">Terms &amp; Conditions</a>
+</div>
+<p>
+<span>&#xA9; THE FINANCIAL TIMES LTD 2022.</span> FT and
+&apos;Financial Times&apos; are trademarks of The Financial Times Ltd.
+</p>
+</div>
+</div>
+</footer>
+</div>
+</div>
+</body>
+</html>"
 `;

--- a/packages/middleware-render-error-info/test/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/lib/index.spec.js
@@ -28,7 +28,7 @@ serializeError.mockReturnValue({
 	message: 'mock serialized error message',
 	name: 'MockSerializedError',
 	relatesToSystems: ['mock-system-1', 'mock-system-2'],
-	stack: 'mock serialized error stack',
+	stack: 'mock serialized error stack <script>oops</script>',
 	statusCode: 456
 });
 


### PR DESCRIPTION
This adds all the error information we need to the error info page. It
also introduces styling via Origami and some help text to explain to
engineers what each piece of error information is for.

## Feedback

I'm looking for general feedback on:

  * The approach. We agreed we'd like to avoid a build step or lots
    of additional dependencies. Is this approach still what we want
    now that we have some code to look at?

  * Is there any more useful (and easy to get hold of) information
    that we might want to display on this page?

  * Do we want to try and tackle `error.stack` parsing as part of
    this PR? Or should we aim to get this merged and add as a
    later feature?

## Potential Improvements

We could possibly move each of the `renderX` methods into their
own files, but this might be overkill. For now I split out the layout
as it's mostly static and made the `renderErrorPage` method far
harder to understand.

## How it looks

| With an `OperationalError` | With a non-operational error |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/138944/183399319-8038602a-579a-40b8-88d7-74ef69557df6.png" alt="Screengrab" width="400" /> | <img src="https://user-images.githubusercontent.com/138944/183399327-15303bf0-8680-4e44-b6b8-d1e684875cdd.png" alt="Screengrab" width="400" /> |