### PR TITLE
chore: don't trigger releases for chores

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,7 @@
 		{
 			"type": "chore",
 			"section": "Miscellaneous",
-			"hidden": false
+			"hidden": true
 		}
 	],
 	"prerelease": true,


### PR DESCRIPTION
This is part 1 of a fix, and it's down to me misconfiguring Release Please quite early on. We don't want `chore` commits to trigger a release and this will address that.