### PR TITLE
feat: conceal sensitive values in middleware-render-error-info display

### DIFF
--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -5,6 +5,17 @@
 const entities = require('entities');
 const renderLayout = require('./render-layout');
 
+const X_API_KEY_REQUEST_PROPERTY_NAME = 'x-api-key';
+const COOKIE_REQUEST_PROPERTY_NAME = 'cookie';
+
+const CONCEALED_REQUEST_PROPERTY_NAMES = new Set([
+	X_API_KEY_REQUEST_PROPERTY_NAME,
+	COOKIE_REQUEST_PROPERTY_NAME
+]);
+
+const CONCEALED_VALUE_MESSAGE =
+	'** This value is likely sensitive and should be examined via other tools **';
+
 /**
  * @typedef {object} ErrorRenderingOptions
  * @property {import('express').Request} request
@@ -160,14 +171,18 @@ function renderRequest(request) {
 			...Object.entries(request.query).map(([key, value]) => {
 				return {
 					label: `Query (${key})`,
-					value,
+					value: CONCEALED_REQUEST_PROPERTY_NAMES.has(key.toLowerCase())
+						? CONCEALED_VALUE_MESSAGE
+						: value,
 					formatter: renderCodeBlock
 				};
 			}),
 			...Object.entries(request.headers).map(([key, value]) => {
 				return {
 					label: `Header (${key})`,
-					value,
+					value: CONCEALED_REQUEST_PROPERTY_NAMES.has(key.toLowerCase())
+						? CONCEALED_VALUE_MESSAGE
+						: value,
 					formatter: renderCodeBlock
 				};
 			})

--- a/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
@@ -297,10 +297,22 @@ See the <a href=\\"https://github.com/Financial-Times/dotcom-reliability-kit/blo
 <dd class=\\"kv-list__value\\"><pre><code>yes</code></pre></dd>
 
 <dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Query (x-api-key):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>** This value is likely sensitive and should be examined via other tools **</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
 <span class=\\"kv-list__label\\">Header (mock-request-header):</span>
 
 </dt>
 <dd class=\\"kv-list__value\\"><pre><code>yes</code></pre></dd>
+
+<dt class=\\"kv-list__key\\">
+<span class=\\"kv-list__label\\">Header (cookie):</span>
+
+</dt>
+<dd class=\\"kv-list__value\\"><pre><code>** This value is likely sensitive and should be examined via other tools **</code></pre></dd>
 
 </dl>
 </section>

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -58,10 +58,12 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 				method: 'mock request method',
 				path: 'mock request path',
 				query: {
-					'mock-request-query': 'yes'
+					'mock-request-query': 'yes',
+					'x-api-key': 'foo' // 'x-api-key' is a concealed request property name
 				},
 				headers: {
-					'mock-request-header': 'yes'
+					'mock-request-header': 'yes',
+					cookie: 'bar' // 'cookie' is a concealed request property name
 				}
 			};
 			response = {


### PR DESCRIPTION
FTDCS-274

Jira card: https://financialtimes.atlassian.net/jira/software/c/projects/FTDCS/boards/1426?modal=detail&selectedIssue=FTDCS-274

> We realised after building it that it’s very easy in [middleware-render-error-info](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-render-error-info#readme) to forget that it’s displaying sensitive information. It’s reasonable to think that someone might share a screen-grab of this page while debugging something and that’s an issue if we display things like API keys or cookie values in the clear.
> I think there are a few options with different levels of difficulty:
> - Obfuscate the value for these fields (we’d need to decide on a list, and I’m sure we could miss some sensitive headers). We could do this by x-ing out half the data?
> - Don’t show the value for these fields at all, instead display a note saying that it’s hidden for security reasons
> - Instead of showing the values for these fields by default, put them in a [details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) element which is collapsed by default and include a note not to screen-grab while they’re expanded.
>
> I’m happy with any of these options. Interested if there are others, or if we think this isn’t a big enough risk to address with code.

I opted for the second option. The first presented the complexity of calculating how much of a given string to obscure (you could hypothetically have short but sensitive value where obscuring half would still be insufficient) and the third still had the potential for users to accidentally capture sensitive details in a screenshot.

I applied the concealment to both the request query params and headers as there is always the possibility, however ill-advised, an `x-api-key` is passed in the query params.

I have also lowercased the values before comparison to account for varying casing of values, e.g. `x-api-key`, `X-Api-Key` are both used because header names are not case sensitive.

<img width="746" alt="Screenshot 2022-08-11 at 16 58 39" src="https://user-images.githubusercontent.com/10484515/184177534-252b03c0-1954-468c-bcec-b9b5151df37f.png">