### PR TITLE
docs: correct a mistake in commit type prefixes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -134,7 +134,7 @@ The prefix is used to calculate the semver release level:
 | --------- | ------------------------------------------------------ | ------------- |
 | feat      | a feature has been added                               | `minor`       |
 | fix       | a bug has been patched                                 | `patch`       |
-| docs      | a change to documentation                              | none          |
+| docs      | a change to documentation                              | `patch`       |
 | chore     | repo maintenance and support tasks                     | none          |
 
 Indicate a breaking change by placing an `!` between the type name and the colon, e.g.


### PR DESCRIPTION
The `docs` commit prefix _does_ trigger a patch release
which I think is what we want (docs changes should make
it to npm right?)

[Evidence: see `docs` isn't hidden in the config](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/release-please-config.json#L4-L23).