### PR TITLE
chore: set a time and timezone for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,58 @@
 version: 2
 updates:
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/logos"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/errors"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/log-error"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/middleware-log-errors"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/middleware-render-error-info"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/serialize-error"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
   - package-ecosystem: "npm"
     directory: "/packages/serialize-request"
     schedule:
       interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"


### PR DESCRIPTION
I think we're getting these at night, I wonder if it's
better if it runs first thing – I often use the first half
hour of the day for chores like dependency bumps.