### PR TITLE
feat: add new more specific error classes

### DIFF
--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -129,7 +129,7 @@ In this scenario we have the following possible errors which we know can make it
 
   * The fruit API does not have a fruit matching `request.params.name` and so the client throws an error with a `statusCode` property set to `404`
 
-Let's update our `catch` block to handle these cases (Note: this example uses `HttpError` from the [`@dotcom-reliability-kit/errors`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#readme) package):
+Let's update our `catch` block to handle these cases (Note: this example uses `UpstreamServiceError` and `UserInputError` from the [`@dotcom-reliability-kit/errors`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#readme) package):
 
 ```js
 // E.g. GET https://your-app/fruit/feijoa
@@ -144,8 +144,7 @@ app.get('/fruit/:name', async (request, response, next) => {
         // `error.code` is "ERR_ASSERTION". We throw a 400 error
         // in this case to indicate that the input was invalid
         if (error.code === 'ERR_ASSERTION') {
-            return next(new HttpError({
-                statusCode: 400,
+            return next(new UserInputError({
                 code: 'FRUIT_NAME_NOT_PROVIDED',
                 message: 'A fruit name was not provided'
             }));
@@ -154,7 +153,7 @@ app.get('/fruit/:name', async (request, response, next) => {
         // If the fruit was not found, we throw a new 404 error
         // with some added detail
         if (error.statusCode === 404) {
-            return next(new HttpError({
+            return next(new UserInputError({
                 statusCode: 404,
                 code: 'FRUIT_NOT_FOUND',
                 message: `The fruit ${request.params.name} was not found in the fruit API`
@@ -167,7 +166,7 @@ app.get('/fruit/:name', async (request, response, next) => {
         // received an invalid response from an upstream server.
         // We can also indicate the system which caused the error
         if (error.statusCode === 503) {
-            return next(new HttpError({
+            return next(new UpstreamServiceError({
                 statusCode: 502,
                 code: 'FRUIT_API_FAILED',
                 message: 'The fruit API was not reachable',
@@ -235,7 +234,7 @@ app.get('/people/:person/favourite-fruit', async (request, response, next) => {
             // We throw here rather than passing to `next` because it allows
             // us to handle all of that in one place – the final try/catch
             if (error.statusCode === 503) {
-                throw new HttpError({
+                throw new UpstreamServiceError({
                     statusCode: 502,
                     code: 'PERSON_API_FAILED',
                     message: 'The person API was not reachable',
@@ -255,7 +254,7 @@ app.get('/people/:person/favourite-fruit', async (request, response, next) => {
             // We throw here rather than passing to `next` because it allows
             // us to handle all of that in one place – the final try/catch
             if (error.statusCode === 503) {
-                throw new HttpError({
+                throw new UpstreamServiceError({
                     statusCode: 502,
                     code: 'FRUIT_API_FAILED',
                     message: 'The fruit API was not reachable',

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -10,6 +10,9 @@ A suite of error classes which help you throw the most appropriate error in any 
       * [`.isErrorMarkedAsOperational`](#operationalerroriserrormarkedasoperational)
     * [`HttpError`](#httperror)
       * [Why use this over `http-errors`?](#why-use-this-over-http-errors)
+    * [`DataStoreError`](#datastoreerror)
+    * [`UpstreamServiceError`](#upstreamserviceerror)
+    * [`UserInputError`](#userinputerror)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -38,7 +41,9 @@ The `OperationalError` class is the base class for most other error types. "Oper
 
 [Joyent's Error Handling docs](https://web.archive.org/web/20220223020910/https://www.joyent.com/node-js/production/design/errors) have a good explanation of Operational Errors.
 
-It works in the same way as a normal error, expecting a message:
+It's always best to use a more specific error, e.g. [`UpstreamServiceError`](#upstreamserviceerror), if one exists that suits your needs. So review the docs here to find the most suitable error.
+
+`OperationalError` can work in the same way as a normal error, expecting a message:
 
 ```js
 throw new OperationalError('example message');
@@ -132,6 +137,58 @@ error.code // HTTP_404
 
 The benefit of using this error rather than the excellent [http-errors](https://github.com/jshttp/http-errors#readme) library is that we extend `OperationalError` by default. This means that all HTTP errors you throw are considered "known errors" by the rest of our tooling. We also set a `code` property by default which results in less code in our monitoring dashboards – we don't need to check both `code` and `statusCode` properties to determine the type of error thrown.
 
+### `DataStoreError`
+
+The `DataStoreError` class extends `OperationalError` and represents an error which occurred while accessing a data store, e.g. MongoDB, PostgreSQL, or Redis. It has all of the features of operational errors, you can construct with just a message:
+
+```js
+throw new DataStoreError('Could not connect to Redis');
+```
+
+You can alternatively construct a data store error with a data object. You can use any of the properties defined in [`OperationalError`](#operationalerror):
+
+```js
+throw new DataStoreError({
+    code: 'REDIS_CONNECTION_FAILED',
+    message: 'Could not connect to Redis',
+});
+```
+
+### `UpstreamServiceError`
+
+The `UpstreamServiceError` class extends `HttpError` and represents an error which occurred while connecting to an upstream service, e.g. an FT or third-party API. It has all of the features of operational and HTTP errors, you can construct with just a message:
+
+```js
+throw new UpstreamServiceError('Content could not be fetched');
+```
+
+You can alternatively construct an upstream service error with a data object. You can use any of the properties defined in [`HttpError`](#httperror) and [`OperationalError`](#operationalerror):
+
+```js
+throw new UpstreamServiceError({
+    code: 'CONTENT_PIPELINE_FAILED',
+    message: 'Content could not be fetched, the content pipeline is responding with a 503 status',
+    statusCode: 503,
+    relatesToSystems: ['cp-content-pipeline-graphql']
+});
+```
+
+### `UserInputError`
+
+The `UserInputError` class extends `HttpError` and represents an error which occurred based on invalid user input, e.g. they inputted a malformed email address into a form. It has all of the features of operational and HTTP errors but defaults to a `400` status code. You can construct with just a message:
+
+```js
+throw new UserInputError('An invalid email address was input');
+```
+
+You can alternatively construct a user input error with a data object. You can use any of the properties defined in [`HttpError`](#httperror) and [`OperationalError`](#operationalerror):
+
+```js
+throw new UserInputError({
+    code: 'REGISTRATION_INFO_INVALID',
+    message: 'An invalid email address was input'
+});
+```
 
 ## Contributing
 

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -1,0 +1,29 @@
+/**
+ * @module @dotcom-reliability-kit/errors/lib/data-store-error
+ */
+
+const OperationalError = require('./operational-error');
+
+/**
+ * Class representing an error in an application's data store.
+ */
+class DataStoreError extends OperationalError {
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {string}
+	 */
+	name = 'DataStoreError';
+
+	/**
+	 * Create a data store error.
+	 *
+	 * @param {(string | OperationalError.OperationalErrorData & Record<string, any>)} [data = {}]
+	 *     The error message if it's a string, or full error information if an object.
+	 */
+	constructor(data = {}) {
+		super(data);
+	}
+}
+
+module.exports = DataStoreError;

--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -3,6 +3,9 @@
  */
 
 module.exports = {
+	DataStoreError: require('./data-store-error'),
 	HttpError: require('./http-error'),
-	OperationalError: require('./operational-error')
+	OperationalError: require('./operational-error'),
+	UpstreamServiceError: require('./upstream-service-error'),
+	UserInputError: require('./user-input-error')
 };

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -1,0 +1,36 @@
+/**
+ * @module @dotcom-reliability-kit/errors/lib/upstream-service-error
+ */
+
+const HttpError = require('./http-error');
+
+/**
+ * Class representing an error in an upstream service.
+ */
+class UpstreamServiceError extends HttpError {
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {string}
+	 */
+	name = 'UpstreamServiceError';
+
+	/**
+	 * Create an upstream service error.
+	 *
+	 * @param {(string | number | HttpError.HttpErrorData & import('./operational-error').OperationalErrorData & Record<string, any>)} [data = {}]
+	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
+	 *     information if an object.
+	 */
+	constructor(data = {}) {
+		if (typeof data === 'string') {
+			data = { message: data };
+		}
+		if (typeof data === 'number') {
+			data = { statusCode: data };
+		}
+		super(data);
+	}
+}
+
+module.exports = UpstreamServiceError;

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -1,0 +1,43 @@
+/**
+ * @module @dotcom-reliability-kit/errors/lib/user-input-error
+ */
+
+const HttpError = require('./http-error');
+
+/**
+ * Class representing an error caused by invalid user input.
+ */
+class UserInputError extends HttpError {
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {string}
+	 */
+	name = 'UserInputError';
+
+	/**
+	 * Create a user input error.
+	 *
+	 * @param {(string | HttpError.HttpErrorData & import('./operational-error').OperationalErrorData & Record<string, any>)} [data = {}]
+	 *     The error message if it's a string or full error information if an object.
+	 */
+	constructor(data = {}) {
+		if (typeof data === 'string') {
+			data = { message: data };
+		}
+
+		// Make sure that we don't modify the original data object
+		// by shallow-cloning it
+		data = { ...data };
+
+		// Default the status code
+		data.statusCode =
+			typeof data.statusCode === 'number'
+				? UserInputError.normalizeErrorStatusCode(data.statusCode)
+				: 400;
+
+		super(data);
+	}
+}
+
+module.exports = UserInputError;

--- a/packages/errors/test/unit/lib/data-store-error.spec.js
+++ b/packages/errors/test/unit/lib/data-store-error.spec.js
@@ -1,0 +1,124 @@
+const OperationalError = require('../../../lib/operational-error');
+const DataStoreError = require('../../../lib/data-store-error');
+
+describe('@dotcom-reliability-kit/errors/lib/data-store-error', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('exports a class', () => {
+		expect(DataStoreError).toBeInstanceOf(Function);
+		expect(() => {
+			DataStoreError();
+		}).toThrow(/class constructor/i);
+	});
+
+	it('extends the OperationalError class', () => {
+		expect(DataStoreError.prototype).toBeInstanceOf(OperationalError);
+	});
+
+	describe('new DataStoreError()', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new DataStoreError();
+		});
+
+		describe('.code', () => {
+			it('is set to "UNKNOWN"', () => {
+				expect(instance.code).toStrictEqual('UNKNOWN');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to a default value', () => {
+				expect(instance.message).toStrictEqual('An operational error occurred');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "DataStoreError"', () => {
+				expect(instance.name).toStrictEqual('DataStoreError');
+			});
+		});
+	});
+
+	describe('new DataStoreError(message)', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new DataStoreError('mock message');
+		});
+
+		describe('.code', () => {
+			it('is set to "UNKNOWN"', () => {
+				expect(instance.code).toStrictEqual('UNKNOWN');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the passed in message parameter', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "DataStoreError"', () => {
+				expect(instance.name).toStrictEqual('DataStoreError');
+			});
+		});
+	});
+
+	describe('new DataStoreError(data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			instance = new DataStoreError({
+				message: 'mock message',
+				code: 'mock_code',
+				extra: 'mock extra data'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an object containing the extra keys in `data`', () => {
+				expect(instance.data).toEqual({
+					extra: 'mock extra data'
+				});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "DataStoreError"', () => {
+				expect(instance.name).toStrictEqual('DataStoreError');
+			});
+		});
+	});
+});

--- a/packages/errors/test/unit/lib/index.spec.js
+++ b/packages/errors/test/unit/lib/index.spec.js
@@ -1,11 +1,23 @@
 const errors = require('../../..');
 
+jest.mock('../../../lib/data-store-error', () => 'mock-data-store-error');
 jest.mock('../../../lib/http-error', () => 'mock-http-error');
 jest.mock('../../../lib/operational-error', () => 'mock-operational-error');
+jest.mock(
+	'../../../lib/upstream-service-error',
+	() => 'mock-upstream-service-error'
+);
+jest.mock('../../../lib/user-input-error', () => 'mock-user-input-error');
 
 describe('@dotcom-reliability-kit/errors', () => {
 	it('exports an object', () => {
 		expect(errors).toBeInstanceOf(Object);
+	});
+
+	describe('.DataStoreError', () => {
+		it('aliases lib/data-store-error', () => {
+			expect(errors.DataStoreError).toStrictEqual('mock-data-store-error');
+		});
 	});
 
 	describe('.HttpError', () => {
@@ -17,6 +29,20 @@ describe('@dotcom-reliability-kit/errors', () => {
 	describe('.OperationalError', () => {
 		it('aliases lib/operational-error', () => {
 			expect(errors.OperationalError).toStrictEqual('mock-operational-error');
+		});
+	});
+
+	describe('.UpstreamServiceError', () => {
+		it('aliases lib/upstream-service-error', () => {
+			expect(errors.UpstreamServiceError).toStrictEqual(
+				'mock-upstream-service-error'
+			);
+		});
+	});
+
+	describe('.UserInputError', () => {
+		it('aliases lib/user-input-error', () => {
+			expect(errors.UserInputError).toStrictEqual('mock-user-input-error');
 		});
 	});
 });

--- a/packages/errors/test/unit/lib/upstream-service-error.spec.js
+++ b/packages/errors/test/unit/lib/upstream-service-error.spec.js
@@ -1,0 +1,245 @@
+const HttpError = require('../../../lib/http-error');
+const UpstreamServiceError = require('../../../lib/upstream-service-error');
+
+describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('exports a class', () => {
+		expect(UpstreamServiceError).toBeInstanceOf(Function);
+		expect(() => {
+			UpstreamServiceError();
+		}).toThrow(/class constructor/i);
+	});
+
+	it('extends the HttpError class', () => {
+		expect(UpstreamServiceError.prototype).toBeInstanceOf(HttpError);
+	});
+
+	describe('new UpstreamServiceError()', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UpstreamServiceError();
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_500"', () => {
+				expect(instance.code).toStrictEqual('HTTP_500');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UpstreamServiceError"', () => {
+				expect(instance.name).toStrictEqual('UpstreamServiceError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 500', () => {
+				expect(instance.statusCode).toStrictEqual(500);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new UpstreamServiceError(message)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UpstreamServiceError('mock message');
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_500"', () => {
+				expect(instance.code).toStrictEqual('HTTP_500');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the passed in message parameter', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UpstreamServiceError"', () => {
+				expect(instance.name).toStrictEqual('UpstreamServiceError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 500', () => {
+				expect(instance.statusCode).toStrictEqual(500);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 500 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new UpstreamServiceError(statusCode)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UpstreamServiceError(456);
+		});
+
+		describe('.code', () => {
+			it('is set to a code representing the normalized status code', () => {
+				expect(instance.code).toStrictEqual('HTTP_456');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UpstreamServiceError"', () => {
+				expect(instance.name).toStrictEqual('UpstreamServiceError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new UpstreamServiceError(data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UpstreamServiceError({
+				message: 'mock message',
+				code: 'mock_code',
+				statusCode: 567,
+				extra: 'mock extra data'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an object containing the extra keys in `data`', () => {
+				expect(instance.data).toEqual({
+					extra: 'mock extra data'
+				});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UpstreamServiceError"', () => {
+				expect(instance.name).toStrictEqual('UpstreamServiceError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the passed in status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+});

--- a/packages/errors/test/unit/lib/user-input-error.spec.js
+++ b/packages/errors/test/unit/lib/user-input-error.spec.js
@@ -1,0 +1,198 @@
+const HttpError = require('../../../lib/http-error');
+const UserInputError = require('../../../lib/user-input-error');
+
+jest.mock('http', () => ({
+	STATUS_CODES: {
+		400: 'mock 400 message',
+		456: 'mock 456 message',
+		500: 'mock 500 message'
+	}
+}));
+
+describe('@dotcom-reliability-kit/errors/lib/user-input-error', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('exports a class', () => {
+		expect(UserInputError).toBeInstanceOf(Function);
+		expect(() => {
+			UserInputError();
+		}).toThrow(/class constructor/i);
+	});
+
+	it('extends the HttpError class', () => {
+		expect(UserInputError.prototype).toBeInstanceOf(HttpError);
+	});
+
+	describe('new UserInputError()', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UserInputError();
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_400"', () => {
+				expect(instance.code).toStrictEqual('HTTP_400');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the default 400 code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UserInputError"', () => {
+				expect(instance.name).toStrictEqual('UserInputError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 400', () => {
+				expect(instance.statusCode).toStrictEqual(400);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 400 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new UserInputError(message)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UserInputError('mock message');
+		});
+
+		describe('.code', () => {
+			it('is set to "HTTP_400"', () => {
+				expect(instance.code).toStrictEqual('HTTP_400');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the passed in message parameter', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UserInputError"', () => {
+				expect(instance.name).toStrictEqual('UserInputError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to 400', () => {
+				expect(instance.statusCode).toStrictEqual(400);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the default 400 code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
+	describe('new UserInputError(data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UserInputError({
+				message: 'mock message',
+				code: 'mock_code',
+				statusCode: 567,
+				extra: 'mock extra data'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an object containing the extra keys in `data`', () => {
+				expect(instance.data).toEqual({
+					extra: 'mock extra data'
+				});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UserInputError"', () => {
+				expect(instance.name).toStrictEqual('UserInputError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the passed in status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+});


### PR DESCRIPTION
This adds some new error classes to the `errors` package which should
help apps provide more detailed error information with relatively little
effort. It adds in:

  * `DataStoreError`
  * `UpstreamServiceError`
  * `UserInputError`

I based these on [the needs of next-home-page](https://github.com/Financial-Times/next-home-page/blob/main/apps/home-page/lib/errors.ts), one of our more
recently-built apps which does error handling quite well. I also did
some digging across all of [the FT's repos](https://cs.github.com/?q=extends+Error+%28language%3AJavaScript+OR+language%3ATypeScript%29&scope=org%3AFinancial-Times&scopeName=Financial-Times) to get an idea of what error
classes our apps are defining themselves.

Resolves FTDCS-285.