### PR TITLE
chore: start testing in Node.js 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>
     parameters:
       node-version:
-        default: "16.15"
+        default: "16.15" # We default to the highest active LTS
         type: string
 
   workspace_root: &workspace_root ~/project
@@ -151,25 +151,27 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - release-please:
           filters:
             <<: *filters_only_main
           requires:
+            # We release on the highest active LTS version of
+            # Node.js that we support
             - test-v16.15
             - lint-v16.15
 
@@ -181,7 +183,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - test:
           filters:
             <<: *filters_release_build
@@ -190,7 +192,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -199,12 +201,14 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_release_build
           requires:
+            # We release on the highest active LTS version of
+            # Node.js that we support
             - lint-v16.15
             - test-v16.15
 
@@ -216,7 +220,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -225,7 +229,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -234,12 +238,14 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - prepublish:
           context: npm-publish-token
           filters:
             <<: *filters_prerelease_build
           requires:
+            # We release on the highest active LTS version of
+            # Node.js that we support
             - lint-v16.15
             - test-v16.15
 
@@ -255,7 +261,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -263,4 +269,4 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.15", "14.19" ]
+              node-version: [ "18.7", "16.15", "14.19" ]

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "scripts": {

--- a/logos/package.json
+++ b/logos/package.json
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -48,7 +48,7 @@
         "@financial-times/n-express": "^25.1.1"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -97,7 +97,7 @@
         "@types/svgo": "^2.6.3"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10000,7 +10000,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10017,7 +10017,7 @@
         "@types/express": "^4.17.13"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10034,7 +10034,7 @@
         "node-fetch": "^2.6.7"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10051,7 +10051,7 @@
         "@types/express": "^4.17.13"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10071,7 +10071,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10083,7 +10083,7 @@
         "@types/express": "^4.17.13"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "volta": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: errors\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: log-error\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-log-errors\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-error\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-request\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "14.x || 16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",


### PR DESCRIPTION
Node.js 18 isn't in active Long-Term-Support yet, but I think it's worth
starting to test against it as it becomes an LTS version of Node.js in
October 2022. This ensures that once we're ready to move apps to v18 our
modules will work as expected.