### PR TITLE
fix: default UpstreamServiceError to HTTP 502

### DIFF
--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -161,13 +161,12 @@ app.get('/fruit/:name', async (request, response, next) => {
         }
 
         // If the fruit API was down, let's throw an error which
-        // better describes what's happened. We switch the status
-        // code to 502 because that matches what's happening – we
-        // received an invalid response from an upstream server.
+        // better describes what's happened. UpstreamServiceError switches
+        // the status code to 502 because that matches what's happening –
+        // we received an invalid response from an upstream server.
         // We can also indicate the system which caused the error
         if (error.statusCode === 503) {
             return next(new UpstreamServiceError({
-                statusCode: 502,
                 code: 'FRUIT_API_FAILED',
                 message: 'The fruit API was not reachable',
                 relatesToSystems: ['fruit-api']
@@ -235,7 +234,6 @@ app.get('/people/:person/favourite-fruit', async (request, response, next) => {
             // us to handle all of that in one place – the final try/catch
             if (error.statusCode === 503) {
                 throw new UpstreamServiceError({
-                    statusCode: 502,
                     code: 'PERSON_API_FAILED',
                     message: 'The person API was not reachable',
                     relatesToSystems: ['person-api']
@@ -255,7 +253,6 @@ app.get('/people/:person/favourite-fruit', async (request, response, next) => {
             // us to handle all of that in one place – the final try/catch
             if (error.statusCode === 503) {
                 throw new UpstreamServiceError({
-                    statusCode: 502,
                     code: 'FRUIT_API_FAILED',
                     message: 'The fruit API was not reachable',
                     relatesToSystems: ['fruit-api']

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -162,6 +162,8 @@ The `UpstreamServiceError` class extends `HttpError` and represents an error whi
 throw new UpstreamServiceError('Content could not be fetched');
 ```
 
+The HTTP status code defaults to a [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502). This indicates that while connecting to an upstream service, your system has received a response that it cannot serve to an end user.
+
 You can alternatively construct an upstream service error with a data object. You can use any of the properties defined in [`HttpError`](#httperror) and [`OperationalError`](#operationalerror):
 
 ```js

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -29,6 +29,17 @@ class UpstreamServiceError extends HttpError {
 		if (typeof data === 'number') {
 			data = { statusCode: data };
 		}
+
+		// Make sure that we don't modify the original data object
+		// by shallow-cloning it
+		data = { ...data };
+
+		// Default the status code
+		data.statusCode =
+			typeof data.statusCode === 'number'
+				? UpstreamServiceError.normalizeErrorStatusCode(data.statusCode)
+				: 502;
+
 		super(data);
 	}
 }

--- a/packages/errors/test/unit/lib/upstream-service-error.spec.js
+++ b/packages/errors/test/unit/lib/upstream-service-error.spec.js
@@ -28,8 +28,8 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.code', () => {
-			it('is set to "HTTP_500"', () => {
-				expect(instance.code).toStrictEqual('HTTP_500');
+			it('is set to "HTTP_502"', () => {
+				expect(instance.code).toStrictEqual('HTTP_502');
 			});
 		});
 
@@ -40,7 +40,7 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.message', () => {
-			it('is set to the status message for the default 500 code', () => {
+			it('is set to the status message for the default 502 code', () => {
 				expect(instance.message).toStrictEqual('mock status message');
 			});
 		});
@@ -52,8 +52,8 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.statusCode', () => {
-			it('is set to 500', () => {
-				expect(instance.statusCode).toStrictEqual(500);
+			it('is set to 502', () => {
+				expect(instance.statusCode).toStrictEqual(502);
 			});
 		});
 
@@ -65,7 +65,7 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.statusMessage', () => {
-			it('is set to the status message for the default 500 code', () => {
+			it('is set to the status message for the default 502 code', () => {
 				expect(instance.statusMessage).toStrictEqual('mock status message');
 			});
 		});
@@ -82,8 +82,8 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.code', () => {
-			it('is set to "HTTP_500"', () => {
-				expect(instance.code).toStrictEqual('HTTP_500');
+			it('is set to "HTTP_502"', () => {
+				expect(instance.code).toStrictEqual('HTTP_502');
 			});
 		});
 
@@ -106,8 +106,8 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.statusCode', () => {
-			it('is set to 500', () => {
-				expect(instance.statusCode).toStrictEqual(500);
+			it('is set to 502', () => {
+				expect(instance.statusCode).toStrictEqual(502);
 			});
 		});
 
@@ -119,7 +119,7 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 
 		describe('.statusMessage', () => {
-			it('is set to the status message for the default 500 code', () => {
+			it('is set to the status message for the default 502 code', () => {
 				expect(instance.statusMessage).toStrictEqual('mock status message');
 			});
 		});


### PR DESCRIPTION
We agreed that a 502 is a more sensible default than a 500

- https://github.com/Financial-Times/dotcom-debug-user/pull/139#discussion_r946863853
- [Slack](https://financialtimes.slack.com/archives/CPNKK12S1/p1660661442019349)