### PR TITLE
fix: return named functions in middleware

### DIFF
--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -34,7 +34,7 @@ function createErrorLoggingMiddleware(options = {}) {
 		}
 	}
 
-	return (error, request, response, next) => {
+	return function errorLoggingMiddleware(error, request, response, next) {
 		// We add a paranoid try/catch here because it'd be really embarassing
 		// if the error logging middleware threw an unhandled error, wouldn't it
 		try {

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -22,7 +22,7 @@ function createErrorRenderingMiddleware() {
 	const performRendering =
 		process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
 
-	return (error, request, response, next) => {
+	return function errorRenderingMiddleware(error, request, response, next) {
 		if (performRendering) {
 			// It's unlikely that this will fail but we want to be sure
 			// that any rendering errors are caught properly


### PR DESCRIPTION
We're looking into Open Telemetry at the moment and realised that
unnamed functions (especially as middleware) make it difficult to follow
traces easily. This addresses the only places we're currently using
anonymous functions.