### PR TITLE
fix: refactor to centralise environment variables

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/app-info": "0.0.0",
   "packages/errors": "1.2.1",
   "packages/log-error": "1.3.3",
   "packages/middleware-log-errors": "1.2.4",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ We maintain documentation in this repo:
 
   * **The package README files** in this monorepo contain technical documentation. They can be found in the [`packages` folder](./packages/). A brief outline of what each package does is listed here:
 
+    * **[@dotcom-reliability-kit/app-info](./packages/app-info/#readme):**<br/>
+      A utility to get application information (e.g. the system code) in a consistent way
+
     * **[@dotcom-reliability-kit/errors](./packages/errors/#readme):**<br/>
       A suite of error classes which help you throw the most appropriate error in any situation
 

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -11,13 +11,14 @@ const {
 	OperationalError
 } = require('@dotcom-reliability-kit/errors');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+const { systemCode } = require('@dotcom-reliability-kit/app-info');
 
 // Create an n-express application. Reliability Kit will work
 // with any Express application but we're using n-express to
 // better match our existing Customer Products apps.
 const app = express({
 	demo: true,
-	systemCode: process.env.SYSTEM_CODE || 'reliability-kit-express-example',
+	systemCode: systemCode || 'reliability-kit-express-example',
 	withBackendAuthentication: false,
 	withServiceMetrics: false
 });

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,13 +16,14 @@
     "npm": "7.x || 8.x"
   },
   "scripts": {
-    "start": "node ."
+    "start": "SYSTEM_CODE='$$$-no-bizops-system-code-$$$' node ."
   },
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "*",
-    "@dotcom-reliability-kit/log-error": "*",
-    "@dotcom-reliability-kit/middleware-log-errors": "*",
-    "@dotcom-reliability-kit/middleware-render-error-info": "*",
+    "@dotcom-reliability-kit/app-info": "^0.0.0",
+    "@dotcom-reliability-kit/errors": "^1.2.1",
+    "@dotcom-reliability-kit/log-error": "^1.3.3",
+    "@dotcom-reliability-kit/middleware-log-errors": "^1.2.4",
+    "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.2",
     "@financial-times/n-express": "^25.2.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,46 +41,15 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "*",
-        "@dotcom-reliability-kit/log-error": "*",
-        "@dotcom-reliability-kit/middleware-log-errors": "*",
-        "@dotcom-reliability-kit/middleware-render-error-info": "*",
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
+        "@dotcom-reliability-kit/errors": "^1.2.1",
+        "@dotcom-reliability-kit/log-error": "^1.3.3",
+        "@dotcom-reliability-kit/middleware-log-errors": "^1.2.4",
+        "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.2",
         "@financial-times/n-express": "^25.2.1"
       },
       "engines": {
         "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "examples/express/node_modules/@dotcom-reliability-kit/log-error": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-0.1.0.tgz",
-      "integrity": "sha512-jEW9qxWE1ASptamvkrtS/CCmwS65wb8Ifj03MMnZwqOXTQtzPsWvs9bzcsThLAizpmXsQHA1YQNiXGyDCOkPSw==",
-      "dependencies": {
-        "@dotcom-reliability-kit/serialize-error": "^0.1.1",
-        "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-        "@financial-times/n-logger": ">=6.0.0 <11.0.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "examples/express/node_modules/@dotcom-reliability-kit/serialize-error": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-0.1.1.tgz",
-      "integrity": "sha512-VcLYzf6+MhqV3WyKDoIvq2WkWA109VIlMnyAmbxB1gVbLQ9OUZCfbTaRwmHBopDz/FDbLqzho+JPsaYeYSpvRw==",
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "examples/express/node_modules/@dotcom-reliability-kit/serialize-request": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-0.1.0.tgz",
-      "integrity": "sha512-KaKDkZEKKtygYJFI2mIq+lkenqF5dKPV0qG8MSPUoj8uNN3yOi1tpz5e968M/kKOxTXEHBBb0MJwPNIL41j0jw==",
-      "engines": {
-        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -1012,6 +981,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@dotcom-reliability-kit/app-info": {
+      "resolved": "packages/app-info",
+      "link": true
     },
     "node_modules/@dotcom-reliability-kit/errors": {
       "resolved": "packages/errors",
@@ -9927,6 +9900,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/app-info": {
+      "name": "@dotcom-reliability-kit/app-info",
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
       "version": "1.2.1",
@@ -9941,6 +9923,7 @@
       "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
         "@dotcom-reliability-kit/serialize-error": "^1.1.1",
         "@dotcom-reliability-kit/serialize-request": "^1.0.0",
         "@financial-times/n-logger": "^10.2.0"
@@ -9955,7 +9938,7 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/log-error": "^1.3.3"
@@ -9972,9 +9955,10 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
         "@dotcom-reliability-kit/log-error": "^1.3.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.0",
         "entities": "^4.3.1"
@@ -10722,44 +10706,27 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@dotcom-reliability-kit/app-info": {
+      "version": "file:packages/app-info"
+    },
     "@dotcom-reliability-kit/errors": {
       "version": "file:packages/errors"
     },
     "@dotcom-reliability-kit/example-express": {
       "version": "file:examples/express",
       "requires": {
-        "@dotcom-reliability-kit/errors": "*",
-        "@dotcom-reliability-kit/log-error": "*",
-        "@dotcom-reliability-kit/middleware-log-errors": "*",
-        "@dotcom-reliability-kit/middleware-render-error-info": "*",
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
+        "@dotcom-reliability-kit/errors": "^1.2.1",
+        "@dotcom-reliability-kit/log-error": "^1.3.3",
+        "@dotcom-reliability-kit/middleware-log-errors": "^1.2.4",
+        "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.2",
         "@financial-times/n-express": "^25.2.1"
-      },
-      "dependencies": {
-        "@dotcom-reliability-kit/log-error": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-0.1.0.tgz",
-          "integrity": "sha512-jEW9qxWE1ASptamvkrtS/CCmwS65wb8Ifj03MMnZwqOXTQtzPsWvs9bzcsThLAizpmXsQHA1YQNiXGyDCOkPSw==",
-          "requires": {
-            "@dotcom-reliability-kit/serialize-error": "^0.1.1",
-            "@dotcom-reliability-kit/serialize-request": "^0.1.0",
-            "@financial-times/n-logger": ">=6.0.0 <11.0.0"
-          }
-        },
-        "@dotcom-reliability-kit/serialize-error": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-0.1.1.tgz",
-          "integrity": "sha512-VcLYzf6+MhqV3WyKDoIvq2WkWA109VIlMnyAmbxB1gVbLQ9OUZCfbTaRwmHBopDz/FDbLqzho+JPsaYeYSpvRw=="
-        },
-        "@dotcom-reliability-kit/serialize-request": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-0.1.0.tgz",
-          "integrity": "sha512-KaKDkZEKKtygYJFI2mIq+lkenqF5dKPV0qG8MSPUoj8uNN3yOi1tpz5e968M/kKOxTXEHBBb0MJwPNIL41j0jw=="
-        }
       }
     },
     "@dotcom-reliability-kit/log-error": {
       "version": "file:packages/log-error",
       "requires": {
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
         "@dotcom-reliability-kit/serialize-error": "^1.1.1",
         "@dotcom-reliability-kit/serialize-request": "^1.0.0",
         "@financial-times/n-logger": "^10.2.0",
@@ -10787,6 +10754,7 @@
     "@dotcom-reliability-kit/middleware-render-error-info": {
       "version": "file:packages/middleware-render-error-info",
       "requires": {
+        "@dotcom-reliability-kit/app-info": "^0.0.0",
         "@dotcom-reliability-kit/log-error": "^1.3.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.0",
         "@types/express": "^4.17.13",

--- a/packages/app-info/.npmignore
+++ b/packages/app-info/.npmignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+docs
+test

--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -1,0 +1,70 @@
+
+## @dotcom-reliability-kit/app-info
+
+A utility to get application information (e.g. the system code) in a consistent way. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`appInfo.commitHash`](#appinfocommithash)
+    * [`appInfo.environment`](#appinfoenvironment)
+    * [`appInfo.region`](#appinforegion)
+    * [`appInfo.releaseDate`](#appinforeleasedate)
+    * [`appInfo.releaseVersion`](#appinforeleaseversion)
+    * [`appInfo.systemCode`](#appinfosystemcode)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/app-info` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/app-info
+```
+
+Include in your code:
+
+```js
+import appInfo from '@dotcom-reliability-kit/app-info';
+// or
+const appInfo = require('@dotcom-reliability-kit/app-info');
+```
+
+The `appInfo` object has several properties which can be used to access application information.
+
+### `appInfo.commitHash`
+
+Get the commit hash that the application last deployed. This will be a string (if `process.env.HEROKU_SLUG_COMMIT` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+
+### `appInfo.environment`
+
+Get the application environment, normally either `development` or `production`. This will be a string, using `process.env.NODE_ENV` and defaulting to `development`.
+
+### `appInfo.region`
+
+Get the application Heroku region. This will be a string (if `process.env.REGION` is defined) or `null` otherwise.
+
+### `appInfo.releaseDate`
+
+Get the application Heroku release date. This will be a string (if `process.env.HEROKU_RELEASE_CREATED_AT` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+
+### `appInfo.releaseVersion`
+
+Get the application Heroku release version. This will be a string (if `process.env.HEROKU_RELEASE_VERSION` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+
+### `appInfo.systemCode`
+
+Get the application's [Biz Ops](https://biz-ops.in.ft.com/) system code. This will be a string (if `process.env.SYSTEM_CODE` is defined), if not then it will be read from the `name` property of `$CWD/package.json`, if neither of these exist then it will be set to `null`.
+
+If the system code is read from the application's `package.json` file then it will be stripped of any `"ft-"` prefix – this is a legacy name and our app system codes do not begin with it.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -1,0 +1,101 @@
+/**
+ * @module @dotcom-reliability-kit/app-info
+ */
+
+const path = require('path');
+
+/**
+ * Get the application system code from a package.json file.
+ *
+ * @param {string} directoryPath
+ *     The directory to look for a package.json file in.
+ * @returns {(string | null)}
+ *     Returns a system code if one is found in `process.env`.
+ */
+function getSystemCodeFromPackage(directoryPath) {
+	try {
+		const manifest = require(path.join(directoryPath, 'package.json'));
+		return typeof manifest?.name === 'string'
+			? normalizePackageName(manifest.name)
+			: null;
+	} catch (error) {}
+	return null;
+}
+
+/**
+ * Normalize the name property of a package.json file.
+ *
+ * @param {string} name
+ *     The name to normalize.
+ * @returns {string}
+ *     Returns a normalized copy of the package name.
+ */
+function normalizePackageName(name) {
+	// Remove a prefix of "ft-", this is a hangover and we have plenty of
+	// apps which use this prefix but their system code does not include
+	// it. E.g. MyFT API has a system code of "next-myft-api", but a
+	// package.json `name` field of "ft-next-myft-api"
+	//    - https://biz-ops.in.ft.com/System/next-myft-api
+	//    - https://github.com/Financial-Times/next-myft-api/blob/main/package.json
+	//
+	return name.replace(/^ft-/, '');
+}
+
+const systemCode =
+	process.env.SYSTEM_CODE || getSystemCodeFromPackage(process.cwd()) || null;
+
+module.exports = {
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {(string | null)}
+	 */
+	get commitHash() {
+		return process.env.HEROKU_SLUG_COMMIT || null;
+	},
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {string}
+	 */
+	get environment() {
+		return process.env.NODE_ENV || 'development';
+	},
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {(string | null)}
+	 */
+	get region() {
+		return process.env.REGION || null;
+	},
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {(string | null)}
+	 */
+	get releaseDate() {
+		return process.env.HEROKU_RELEASE_CREATED_AT || null;
+	},
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {(string | null)}
+	 */
+	get releaseVersion() {
+		return process.env.HEROKU_RELEASE_VERSION || null;
+	},
+
+	/**
+	 * @readonly
+	 * @access public
+	 * @type {(string | null)}
+	 */
+	get systemCode() {
+		return systemCode;
+	}
+};

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dotcom-reliability-kit/app-info",
+  "version": "0.0.0",
+  "description": "A utility to get application info in a consistent way.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/app-info"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/app-info#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: app-info\"",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x || 18.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib"
+}

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -1,0 +1,182 @@
+describe('@dotcom-reliability-kit/app-info', () => {
+	let appInfo;
+
+	beforeEach(() => {
+		jest.spyOn(process, 'cwd').mockReturnValue('/mock-cwd');
+		process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
+		process.env.HEROKU_RELEASE_VERSION = 'mock-release-version';
+		process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
+		process.env.NODE_ENV = 'mock-environment';
+		process.env.REGION = 'mock-region';
+		process.env.SYSTEM_CODE = 'mock-system-code';
+		appInfo = require('../../../lib');
+	});
+
+	describe('.commitHash', () => {
+		it('is set to `process.env.HEROKU_SLUG_COMMIT`', () => {
+			expect(appInfo.commitHash).toBe('mock-commit-hash');
+		});
+
+		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.HEROKU_SLUG_COMMIT;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to null', () => {
+				expect(appInfo.commitHash).toBe(null);
+			});
+		});
+	});
+
+	describe('.environment', () => {
+		it('is set to `process.env.NODE_ENV`', () => {
+			expect(appInfo.environment).toBe('mock-environment');
+		});
+
+		describe('when `process.env.NODE_ENV` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.NODE_ENV;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to "development"', () => {
+				expect(appInfo.environment).toBe('development');
+			});
+		});
+	});
+
+	describe('.region', () => {
+		it('is set to `process.env.REGION`', () => {
+			expect(appInfo.region).toBe('mock-region');
+		});
+
+		describe('when `process.env.REGION` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.REGION;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to null', () => {
+				expect(appInfo.region).toBe(null);
+			});
+		});
+	});
+
+	describe('.releaseDate', () => {
+		it('is set to `process.env.HEROKU_RELEASE_CREATED_AT`', () => {
+			expect(appInfo.releaseDate).toBe('mock-release-date');
+		});
+
+		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.HEROKU_RELEASE_CREATED_AT;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to null', () => {
+				expect(appInfo.releaseDate).toBe(null);
+			});
+		});
+	});
+
+	describe('.releaseVersion', () => {
+		it('is set to `process.env.HEROKU_RELEASE_VERSION`', () => {
+			expect(appInfo.releaseVersion).toBe('mock-release-version');
+		});
+
+		describe('when `process.env.HEROKU_RELEASE_VERSION` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.HEROKU_RELEASE_VERSION;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to null', () => {
+				expect(appInfo.releaseVersion).toBe(null);
+			});
+		});
+	});
+
+	describe('.systemCode', () => {
+		it('is set to `process.env.SYSTEM_CODE`', () => {
+			expect(appInfo.systemCode).toBe('mock-system-code');
+		});
+
+		describe('when `process.env.SYSTEM_CODE` is not defined but a package.json exists', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				jest.mock(
+					'/mock-cwd/package.json',
+					() => ({ name: 'mock-package-name' }),
+					{ virtual: true }
+				);
+				delete process.env.SYSTEM_CODE;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to the package.json name in the current working directory', () => {
+				expect(appInfo.systemCode).toBe('mock-package-name');
+			});
+
+			describe('when the package.json `name` property begins with "ft-"', () => {
+				beforeEach(() => {
+					jest.resetModules();
+					jest.mock(
+						'/mock-cwd/package.json',
+						() => ({ name: 'ft-mock-package-name' }),
+						{ virtual: true }
+					);
+					appInfo = require('../../../lib');
+				});
+
+				it('is set to the package.json name with the "ft-" removed', () => {
+					expect(appInfo.systemCode).toBe('mock-package-name');
+				});
+			});
+
+			describe('when the package.json has a non-string `name` property', () => {
+				beforeEach(() => {
+					jest.resetModules();
+					jest.mock('/mock-cwd/package.json', () => ({ name: 123 }), {
+						virtual: true
+					});
+					appInfo = require('../../../lib');
+				});
+
+				it('is set to `null`', () => {
+					expect(appInfo.systemCode).toBe(null);
+				});
+			});
+
+			describe('when the package.json is not an object', () => {
+				beforeEach(() => {
+					jest.resetModules();
+					jest.mock('/mock-cwd/package.json', () => null, { virtual: true });
+					appInfo = require('../../../lib');
+				});
+
+				it('is set to `null`', () => {
+					expect(appInfo.systemCode).toBe(null);
+				});
+			});
+		});
+
+		describe('when `process.env.SYSTEM_CODE` is not defined and a package.json does not exist', () => {
+			beforeEach(() => {
+				jest.unmock('/mock-cwd/package.json');
+				jest.resetModules();
+				delete process.env.SYSTEM_CODE;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to `null`', () => {
+				expect(appInfo.systemCode).toBe(null);
+			});
+		});
+	});
+});

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -2,6 +2,7 @@
  * @module @dotcom-reliability-kit/log-error
  */
 
+const appInfo = require('@dotcom-reliability-kit/app-info');
 const logger = require('@financial-times/n-logger').default;
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
 const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
@@ -39,11 +40,11 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
 		message: extractErrorMessage(serializedError),
 		error: serializedError,
 		app: {
-			commit: process.env.HEROKU_SLUG_COMMIT || null,
-			name: process.env.SYSTEM_CODE || null,
+			commit: appInfo.commitHash,
+			name: appInfo.systemCode,
 			nodeVersion: process.versions.node,
-			region: process.env.REGION || null,
-			releaseDate: process.env.HEROKU_RELEASE_CREATED_AT || null
+			region: appInfo.region,
+			releaseDate: appInfo.releaseDate
 		}
 	};
 	if (request) {

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -16,6 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
+    "@dotcom-reliability-kit/app-info": "^0.0.0",
     "@dotcom-reliability-kit/serialize-error": "^1.1.1",
     "@dotcom-reliability-kit/serialize-request": "^1.0.0",
     "@financial-times/n-logger": "^10.2.0"

--- a/packages/log-error/test/unit/lib/index.spec.js
+++ b/packages/log-error/test/unit/lib/index.spec.js
@@ -22,7 +22,17 @@ jest.mock('@dotcom-reliability-kit/serialize-request', () =>
 );
 const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
 
+jest.mock('@dotcom-reliability-kit/app-info', () => ({}));
+const appInfo = require('@dotcom-reliability-kit/app-info');
+
 describe('@dotcom-reliability-kit/log-error', () => {
+	beforeEach(() => {
+		appInfo.commitHash = 'mock-commit-hash';
+		appInfo.region = 'mock-region';
+		appInfo.releaseDate = 'mock-release-date';
+		appInfo.systemCode = 'mock-system-code';
+	});
+
 	afterEach(() => {
 		serializeError.mockClear();
 		serializeRequest.mockClear();
@@ -34,10 +44,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
-			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
-			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
-			process.env.REGION = 'mock-region';
-			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
 			request = { isMockRequest: true };
 
@@ -73,9 +79,9 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 		});
 
-		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
+		describe('when a system code is not defined', () => {
 			beforeEach(() => {
-				delete process.env.SYSTEM_CODE;
+				appInfo.systemCode = null;
 				logHandledError({ error, request });
 			});
 
@@ -104,114 +110,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 						nodeVersion: process.versions.node,
 						region: 'mock-region',
 						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.REGION` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.REGION;
-				logHandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without an app region', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'HANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: null,
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_SLUG_COMMIT;
-				logHandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a commit hash', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'HANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: null,
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_RELEASE_CREATED_AT;
-				logHandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a release date', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'HANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: null
 					}
 				});
 			});
@@ -351,10 +249,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
-			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
-			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
-			process.env.REGION = 'mock-region';
-			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
 			request = { isMockRequest: true };
 
@@ -387,150 +281,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					region: 'mock-region',
 					releaseDate: 'mock-release-date'
 				}
-			});
-		});
-
-		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.SYSTEM_CODE;
-				logRecoverableError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without an app name', () => {
-				expect(logger.log).toBeCalledWith('warn', {
-					event: 'RECOVERABLE_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: null,
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.REGION` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.REGION;
-				logRecoverableError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without an app region', () => {
-				expect(logger.log).toBeCalledWith('warn', {
-					event: 'RECOVERABLE_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: null,
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_SLUG_COMMIT;
-				logRecoverableError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a commit hash', () => {
-				expect(logger.log).toBeCalledWith('warn', {
-					event: 'RECOVERABLE_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: null,
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_RELEASE_CREATED_AT;
-				logRecoverableError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a release date', () => {
-				expect(logger.log).toBeCalledWith('warn', {
-					event: 'RECOVERABLE_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: null
-					}
-				});
 			});
 		});
 
@@ -668,10 +418,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		let request;
 
 		beforeEach(() => {
-			process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
-			process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
-			process.env.REGION = 'mock-region';
-			process.env.SYSTEM_CODE = 'mock-system-code';
 			error = new Error('mock error');
 			request = { isMockRequest: true };
 
@@ -704,150 +450,6 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					region: 'mock-region',
 					releaseDate: 'mock-release-date'
 				}
-			});
-		});
-
-		describe('when `process.env.SYSTEM_CODE` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.SYSTEM_CODE;
-				logUnhandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without an app name', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'UNHANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: null,
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.REGION` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.REGION;
-				logUnhandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without an app region', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'UNHANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: null,
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_SLUG_COMMIT;
-				logUnhandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a commit hash', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'UNHANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: null,
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: 'mock-release-date'
-					}
-				});
-			});
-		});
-
-		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
-			beforeEach(() => {
-				delete process.env.HEROKU_RELEASE_CREATED_AT;
-				logUnhandledError({ error, request });
-			});
-
-			it('serializes the error', () => {
-				expect(serializeError).toBeCalledWith(error);
-			});
-
-			it('serializes the request', () => {
-				expect(serializeRequest).toBeCalledWith(request, {
-					includeHeaders: undefined
-				});
-			});
-
-			it('logs without a release date', () => {
-				expect(logger.log).toBeCalledWith('error', {
-					event: 'UNHANDLED_ERROR',
-					message: 'MockError: mock error',
-					error: {
-						name: 'MockError',
-						message: 'mock error'
-					},
-					request: 'mock-serialized-request',
-					app: {
-						commit: 'mock-commit-hash',
-						name: 'mock-system-code',
-						nodeVersion: process.versions.node,
-						region: 'mock-region',
-						releaseDate: null
-					}
-				});
 			});
 		});
 

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -2,6 +2,7 @@
  * @module @dotcom-reliability-kit/middleware-render-error-info
  */
 
+const appInfo = require('@dotcom-reliability-kit/app-info');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const renderErrorPage = require('./render-error-page');
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
@@ -19,8 +20,7 @@ function createErrorRenderingMiddleware() {
 	// will need to make this middleware play nicely with
 	// Sentry/n-raven – right now it will render a page and skip
 	// any later middleware so Sentry will never run.
-	const performRendering =
-		process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
+	const performRendering = appInfo.environment === 'development';
 
 	return function errorRenderingMiddleware(error, request, response, next) {
 		if (performRendering) {

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -2,6 +2,7 @@
  * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-error-page
  */
 
+const appInfo = require('@dotcom-reliability-kit/app-info');
 const entities = require('entities');
 const renderLayout = require('./render-layout');
 
@@ -36,7 +37,7 @@ const CONCEALED_VALUE_MESSAGE =
  *     Returns the rendered error page.
  */
 function renderErrorPage({ request, response, serializedError }) {
-	const appName = process.env.SYSTEM_CODE || 'application';
+	const appName = appInfo.systemCode || 'application';
 	return renderLayout({
 		body: `
 			<h1 id="errors">Error information</h1>

--- a/packages/middleware-render-error-info/lib/render-layout.js
+++ b/packages/middleware-render-error-info/lib/render-layout.js
@@ -2,6 +2,7 @@
  * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-layout
  */
 
+const appInfo = require('@dotcom-reliability-kit/app-info');
 const fs = require('fs');
 
 const buildServiceBaseUrl = 'https://www.ft.com/__origami/service/build/v3';
@@ -126,7 +127,7 @@ function getBuildServiceUrl(type) {
 		// We need a system code for the system. Most of our apps supply a SYSTEM_CODE
 		// environment variable. If this is not possible then we fall back to the Origami
 		// default: https://www.ft.com/__origami/service/build/v3/docs/api#get-v3-bundles-css
-		system_code: process.env.SYSTEM_CODE || '$$$-no-bizops-system-code-$$$',
+		system_code: appInfo.systemCode || '$$$-no-bizops-system-code-$$$',
 		brand: 'internal',
 		components: buildServiceComponents.join(',')
 	});

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -16,6 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
+    "@dotcom-reliability-kit/app-info": "^0.0.0",
     "@dotcom-reliability-kit/log-error": "^1.3.3",
     "@dotcom-reliability-kit/serialize-error": "^1.1.0",
     "entities": "^4.3.1"

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -37,12 +37,15 @@ jest.mock('@dotcom-reliability-kit/log-error', () => ({
 }));
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 
+jest.mock('@dotcom-reliability-kit/app-info', () => ({}));
+const appInfo = require('@dotcom-reliability-kit/app-info');
+
 describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 	let middleware;
 
 	beforeEach(() => {
-		process.env.NODE_ENV = 'development';
-		process.env.SYSTEM_CODE = 'mock-system-code';
+		appInfo.environment = 'development';
+		appInfo.systemCode = 'mock-system-code';
 		middleware = createErrorRenderingMiddleware();
 	});
 
@@ -110,9 +113,9 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 			expect(next).toBeCalledTimes(0);
 		});
 
-		describe('when the `SYSTEM_CODE` environment variable is not set', () => {
+		describe('when the system code is not set', () => {
 			beforeEach(() => {
-				delete process.env.SYSTEM_CODE;
+				appInfo.systemCode = null;
 				middleware = createErrorRenderingMiddleware();
 				response.send = jest.fn();
 				middleware(error, request, response, next);
@@ -159,31 +162,9 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 			});
 		});
 
-		describe('when `process.env.NODE_ENV` is undefined', () => {
+		describe('when the environment is set to "production"', () => {
 			beforeEach(() => {
-				delete process.env.NODE_ENV;
-				middleware = createErrorRenderingMiddleware();
-				response = {
-					status: 'mock response status',
-					send: jest.fn(),
-					set: jest.fn(),
-					status: jest.fn()
-				};
-				next = jest.fn();
-				middleware(error, request, response, next);
-			});
-
-			it('behaves in the same way as when `NODE_ENV` is set to "development"', () => {
-				expect(serializeError).toBeCalledWith(error);
-				expect(response.status).toBeCalledTimes(1);
-				expect(response.set).toBeCalledTimes(1);
-				expect(response.send).toBeCalledTimes(1);
-			});
-		});
-
-		describe('when `process.env.NODE_ENV` is set to "production"', () => {
-			beforeEach(() => {
-				process.env.NODE_ENV = 'production';
+				appInfo.environment = 'production';
 				middleware = createErrorRenderingMiddleware();
 				response = {
 					status: 'mock response status',

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,7 @@
 		"node-workspace"
 	],
 	"packages": {
+		"packages/app-info": {},
 		"packages/errors": {},
 		"packages/log-error": {},
 		"packages/middleware-log-errors": {},


### PR DESCRIPTION
This tucks away nearly all of our environment variable access into a new
module named app-info. This means we're no longer repeating some logic
across the other modules and can remove a lot of tests (despite adding a
new package and a bunch of documentation, this decreases the overall
lines of code by ~60).

This also adds a feature: we're now not only looking at the
`SYSTEM_CODE` environment variable, we're also attempting to load the
`package.json` file in the current working directory and normalising the
name to get a default system code. This nearly* matches the behaviour in
n-express.

A benefit of this work is that if we need to use the system code in
other places (which I think is likely, e.g. if we wrap any of the
tooling for OpenTelemetry). We could also replace usage of all these
environment variables across our other libraries and apps so that
there's a single source of truth for getting the app's system code.

---

*The system code sanitisation only removes a prefix of `ft-` which
doesn't quite match the [n-express behaviour](https://github.com/Financial-Times/n-express/blob/main/src/lib/normalize-name.js). There are two things in
this that I don't think we need any more:

  1. The n-express library is designed to normalise a _name_ and not a
     system code, so it removes the `next-` prefix as well. We don't
     want to do this as many of our system codes _do_ begin with `next-`

  2. The n-express library removes a suffix of `-vXXX` (`X` being any
     number). From what I can tell, at some point we intended to version
     package names but this is not used in any of our current apps.
     https://github.com/Financial-Times/n-express/commit/a598c601040aabbc35e06efc1cd0713cf692d1b5