### PR TITLE
chore: add a dependabot config for Express example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       timezone: "Europe/London"
 
   - package-ecosystem: "npm"
+    directory: "/examples/express"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
+  - package-ecosystem: "npm"
     directory: "/logos"
     schedule:
       interval: "daily"


### PR DESCRIPTION
I extracted this from #143 where it was added by mistake.
This ensures that the Express example has dependencies
updated too.