### PR TITLE
docs: clarify middleware mounting order

### DIFF
--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -29,7 +29,9 @@ const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors
 
 ### `createErrorLogger`
 
-The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). It must be added to your Express app _after_ all your application routes:
+The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger).
+
+:warning: this middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware:
 
 ```js
 const app = express();

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -29,7 +29,7 @@ const renderErrorInfoPage = require('@dotcom-reliability-kit/middleware-render-e
 
 The `renderErrorInfoPage` function can be used to generate Express middleware which renders an error debugging page. The error page will only ever display in a non-production environment, that is when the `NODE_ENV` environment variable is either **empty** or set to **`"development"`**.
 
-It must be added to your Express app _after_ all your application routes:
+:warning: this middleware **must** be added to your Express app _after_ all your application routes – you won't get rendered errors for any routes which are mounted after this middleware:
 
 ```js
 const app = express();


### PR DESCRIPTION
This bolds and highlights that middleware order matters, which should result in less confusion about where to mount the middleware. It also adds a short explanation of _why_ the order matters, rather than just dictating a rule without explanation.

It looks like this:

<img width="1037" alt="Screenshot 2022-09-22 at 11 31 58" src="https://user-images.githubusercontent.com/138944/191724696-4d730465-04e9-49cd-b6fb-f4b2e116ff55.png">

<img width="1036" alt="Screenshot 2022-09-22 at 11 32 11" src="https://user-images.githubusercontent.com/138944/191724708-6a2b799f-6e28-445b-a0b8-41a6aaf2aa4f.png">
