### PR TITLE
fix: make sure that ESM + TypeScript works

### DIFF
--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -99,3 +99,6 @@ module.exports = {
 		return systemCode;
 	}
 };
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -12,6 +12,12 @@ describe('@dotcom-reliability-kit/app-info', () => {
 		appInfo = require('../../../lib');
 	});
 
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(appInfo.default).toStrictEqual(appInfo);
+		});
+	});
+
 	describe('.commitHash', () => {
 		it('is set to `process.env.HEROKU_SLUG_COMMIT`', () => {
 			expect(appInfo.commitHash).toBe('mock-commit-hash');

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -27,3 +27,5 @@ class DataStoreError extends OperationalError {
 }
 
 module.exports = DataStoreError;
+
+module.exports.default = module.exports;

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -146,3 +146,5 @@ class HttpError extends OperationalError {
 }
 
 module.exports = HttpError;
+
+module.exports.default = module.exports;

--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -2,10 +2,10 @@
  * @module @dotcom-reliability-kit/errors
  */
 
-module.exports = {
-	DataStoreError: require('./data-store-error'),
-	HttpError: require('./http-error'),
-	OperationalError: require('./operational-error'),
-	UpstreamServiceError: require('./upstream-service-error'),
-	UserInputError: require('./user-input-error')
-};
+exports.DataStoreError = require('./data-store-error');
+exports.HttpError = require('./http-error');
+exports.OperationalError = require('./operational-error');
+exports.UpstreamServiceError = require('./upstream-service-error');
+exports.UserInputError = require('./user-input-error');
+
+exports.default = exports;

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -148,3 +148,5 @@ class OperationalError extends Error {
 }
 
 module.exports = OperationalError;
+
+module.exports.default = module.exports;

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -45,3 +45,5 @@ class UpstreamServiceError extends HttpError {
 }
 
 module.exports = UpstreamServiceError;
+
+module.exports.default = module.exports;

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -41,3 +41,5 @@ class UserInputError extends HttpError {
 }
 
 module.exports = UserInputError;
+
+module.exports.default = module.exports;

--- a/packages/errors/test/unit/lib/data-store-error.spec.js
+++ b/packages/errors/test/unit/lib/data-store-error.spec.js
@@ -121,4 +121,10 @@ describe('@dotcom-reliability-kit/errors/lib/data-store-error', () => {
 			});
 		});
 	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(DataStoreError.default).toStrictEqual(DataStoreError);
+		});
+	});
 });

--- a/packages/errors/test/unit/lib/http-error.spec.js
+++ b/packages/errors/test/unit/lib/http-error.spec.js
@@ -340,4 +340,10 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 			});
 		});
 	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(HttpError.default).toStrictEqual(HttpError);
+		});
+	});
 });

--- a/packages/errors/test/unit/lib/index.spec.js
+++ b/packages/errors/test/unit/lib/index.spec.js
@@ -10,8 +10,10 @@ jest.mock(
 jest.mock('../../../lib/user-input-error', () => 'mock-user-input-error');
 
 describe('@dotcom-reliability-kit/errors', () => {
-	it('exports an object', () => {
-		expect(errors).toBeInstanceOf(Object);
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(errors.default).toStrictEqual(errors);
+		});
 	});
 
 	describe('.DataStoreError', () => {

--- a/packages/errors/test/unit/lib/operational-error.spec.js
+++ b/packages/errors/test/unit/lib/operational-error.spec.js
@@ -234,4 +234,10 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 			).toStrictEqual('ABC_123_FOO_BAR');
 		});
 	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(OperationalError.default).toStrictEqual(OperationalError);
+		});
+	});
 });

--- a/packages/errors/test/unit/lib/upstream-service-error.spec.js
+++ b/packages/errors/test/unit/lib/upstream-service-error.spec.js
@@ -242,4 +242,10 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 			});
 		});
 	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(UpstreamServiceError.default).toStrictEqual(UpstreamServiceError);
+		});
+	});
 });

--- a/packages/errors/test/unit/lib/user-input-error.spec.js
+++ b/packages/errors/test/unit/lib/user-input-error.spec.js
@@ -1,3 +1,4 @@
+const { UpstreamServiceError } = require('../../../lib');
 const HttpError = require('../../../lib/http-error');
 const UserInputError = require('../../../lib/user-input-error');
 
@@ -193,6 +194,12 @@ describe('@dotcom-reliability-kit/errors/lib/user-input-error', () => {
 			it('is set to the status message for the passed in status code', () => {
 				expect(instance.statusMessage).toStrictEqual('mock status message');
 			});
+		});
+	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(UpstreamServiceError.default).toStrictEqual(UpstreamServiceError);
 		});
 	});
 });

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -121,8 +121,8 @@ function logUnhandledError({ error, includeHeaders, request }) {
 	});
 }
 
-module.exports = {
-	logHandledError,
-	logRecoverableError,
-	logUnhandledError
-};
+exports.logHandledError = logHandledError;
+exports.logRecoverableError = logRecoverableError;
+exports.logUnhandledError = logUnhandledError;
+
+exports.default = exports;

--- a/packages/log-error/test/unit/lib/index.spec.js
+++ b/packages/log-error/test/unit/lib/index.spec.js
@@ -1,8 +1,5 @@
-const {
-	logHandledError,
-	logRecoverableError,
-	logUnhandledError
-} = require('../../../lib/index');
+const logError = require('../../../lib');
+const { logHandledError, logRecoverableError, logUnhandledError } = logError;
 
 jest.mock('@financial-times/n-logger', () => ({
 	default: { log: jest.fn() }
@@ -37,6 +34,12 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		serializeError.mockClear();
 		serializeRequest.mockClear();
 		logger.log.mockClear();
+	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(logError.default).toStrictEqual(logError);
+		});
 	});
 
 	describe('logHandledError(options)', () => {

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -56,3 +56,5 @@ function createErrorLoggingMiddleware(options = {}) {
 }
 
 module.exports = createErrorLoggingMiddleware;
+
+module.exports.default = module.exports;

--- a/packages/middleware-log-errors/test/unit/lib/index.spec.js
+++ b/packages/middleware-log-errors/test/unit/lib/index.spec.js
@@ -12,6 +12,14 @@ describe('@dotcom-reliability-kit/middleware-log-errors', () => {
 		middleware = createErrorLoggingMiddleware();
 	});
 
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(createErrorLoggingMiddleware.default).toStrictEqual(
+				createErrorLoggingMiddleware
+			);
+		});
+	});
+
 	describe('middleware(error, request, response, next)', () => {
 		let error;
 		let next;

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -49,3 +49,5 @@ function createErrorRenderingMiddleware() {
 }
 
 module.exports = createErrorRenderingMiddleware;
+
+module.exports.default = module.exports;

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -49,6 +49,14 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 		middleware = createErrorRenderingMiddleware();
 	});
 
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(createErrorRenderingMiddleware.default).toStrictEqual(
+				createErrorRenderingMiddleware
+			);
+		});
+	});
+
 	describe('middleware(error, request, response, next)', () => {
 		let error;
 		let next;

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -120,3 +120,6 @@ function createSerializedError(properties) {
 }
 
 module.exports = serializeError;
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/serialize-error/test/unit/lib/index.spec.js
+++ b/packages/serialize-error/test/unit/lib/index.spec.js
@@ -1,6 +1,12 @@
 const serializeError = require('../../../lib/index');
 
 describe('@dotcom-reliability-kit/serialize-error', () => {
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(serializeError.default).toStrictEqual(serializeError);
+		});
+	});
+
 	describe('when called with an error object', () => {
 		let error;
 

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -171,3 +171,6 @@ function createSerializedRequest(properties) {
 }
 
 module.exports = serializeRequest;
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/serialize-request/test/unit/lib/index.spec.js
+++ b/packages/serialize-request/test/unit/lib/index.spec.js
@@ -1,6 +1,12 @@
 const serializeRequest = require('../../../lib/index');
 
 describe('@dotcom-reliability-kit/serialize-request', () => {
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(serializeRequest.default).toStrictEqual(serializeRequest);
+		});
+	});
+
 	describe('when called with an `http.IncomingMessage` object', () => {
 		let request;
 


### PR DESCRIPTION
We messed up here, and we didn't consider the use case of TypeScript written as ES Modules being compiled to CommonJS modules. When using the import signature:

```
import example from 'example';
```

the JavaScript compiled from the above TypeScript will always look for the `default` property on the module. This is different from Node.js native ESM which is what we tested with.

The solution is to alias `module.exports` as `module.exports.default` which ensures that this works in the same way for native ESM as well as compiled JavaScript from TypeScript.