### PR TITLE
docs: use GitHub's note/warning highlights

### DIFF
--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -86,7 +86,8 @@ app.get('/', async (request, response, next) => {
 
 This way of handling async errors will also be [built-in in Express v5](https://expressjs.com/en/guide/migrating-5.html#rejected-promises).
 
-**Note: the rest of the examples in this documentation assume that you're _not_ including `express-async-errors`. If you do use this library then you can simplify a lot when you're implementing in your own app.**
+> **Note**
+> The rest of the examples in this documentation assume that you're _not_ including `express-async-errors`. If you do use this library then you can simplify a lot when you're implementing in your own app.
 
 ### Registering error handlers
 

--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -42,7 +42,8 @@ Errors can contain a lot of information about what happened, but passing an erro
 
 Extracting the information we do want can result in a lot of boilerplate code littered around our systems. To aid this, Reliability Kit provides a couple of packages to help with this task.
 
-**Note:** the code examples in this section are illustrative to help understand what we're doing under the hood. For our recommended implementation of error logging, see the [One way of logging](#one-way-of-logging) section.
+> **Note**
+> The code examples in this section are illustrative to help understand what we're doing under the hood. For our recommended implementation of error logging, see the [One way of logging](#one-way-of-logging) section.
 
 [`@dotcom-reliability-kit/serialize-error`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme)  provides a `serializeError` function which accepts an error object and converts it to a plain object with all of the data extracted for logging. If you were logging something manually you could get all error information like this:
 

--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -78,7 +78,8 @@ app.get('/pokemon/:name', async (request, response, next) => {
 });
 ```
 
-**Note:** we do provide many more error classes in Reliability Kit, and it's always good to use the most specific one. Most of our examples use `OperationalError` for simplicity (and to not overload you with information), but the section on [error classes](#error-classes) covers some of these other error types.
+> **Note**
+> We do provide many more error classes in Reliability Kit, and it's always good to use the most specific one. Most of our examples use `OperationalError` for simplicity (and to not overload you with information), but the section on [error classes](#error-classes) covers some of these other error types.
 
 ### Operational errors in library code
 

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -169,7 +169,8 @@ logRecoverableError({
 });
 ```
 
-**Note:** there's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
+> **Note**
+> There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 
 #### `options.request`
 

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -31,7 +31,8 @@ const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors
 
 The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger).
 
-:warning: this middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware:
+> **Warning**
+> This middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware.
 
 ```js
 const app = express();
@@ -71,7 +72,8 @@ This will automatically [serialize error objects](https://github.com/Financial-T
 }
 ```
 
-**Note:** if you're also using [n-raven v6.1+](https://github.com/Financial-Times/n-raven) in your application then the Raven error logging will be deactivated so that you don't get double-logged errors.
+> **Note**
+> If you're also using [n-raven v6.1+](https://github.com/Financial-Times/n-raven) in your application then the Raven error logging will be deactivated so that you don't get double-logged errors.
 
 ### Configuration options
 
@@ -98,7 +100,8 @@ app.use(createErrorLogger({
 }));
 ```
 
-**Note:** there's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
+> **Note**
+> There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 
 
 ## Contributing

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -29,7 +29,8 @@ const renderErrorInfoPage = require('@dotcom-reliability-kit/middleware-render-e
 
 The `renderErrorInfoPage` function can be used to generate Express middleware which renders an error debugging page. The error page will only ever display in a non-production environment, that is when the `NODE_ENV` environment variable is either **empty** or set to **`"development"`**.
 
-:warning: this middleware **must** be added to your Express app _after_ all your application routes – you won't get rendered errors for any routes which are mounted after this middleware:
+> **Warning**
+> This middleware **must** be added to your Express app _after_ all your application routes – you won't get rendered errors for any routes which are mounted after this middleware.
 
 ```js
 const app = express();
@@ -37,7 +38,8 @@ const app = express();
 app.use(renderErrorInfoPage());
 ```
 
-**Note:** if you're using [@dotcom-reliability-kit/middleware-log-errors](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#readme) in your app, it's best to mount the error page middleware _after_ the logging middleware. Otherwise the error will never be logged in local development, which may cause some confusion.
+> **Note**
+> If you're using [@dotcom-reliability-kit/middleware-log-errors](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#readme) in your app, it's best to mount the error page middleware _after_ the logging middleware. Otherwise the error will never be logged in local development, which may cause some confusion.
 
 Once you've mounted the middleware, if you're working locally you should now see a detailed error page when you encounter an error in your app (assuming you're [relying on the Express error handler to serve errors](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/handling-errors.md#bubbling-up-in-express)):
 


### PR DESCRIPTION
GitHub has supported special rendering of note and warning messages in Markdown for a while based on [this discussion](https://github.com/community/community/discussions/16925).

It's nice to have it consistently rendered like this so I've switched out the markup across all our documentation.

Here are some example screen shots from the docs:

![Screenshot 2022-10-03 at 08 32 12](https://user-images.githubusercontent.com/138944/193523557-34f84eaf-d8b7-42c7-8405-6dfb7b8e1678.png)

![Screenshot 2022-10-03 at 08 32 45](https://user-images.githubusercontent.com/138944/193523565-850c193c-6a9a-41f1-9f2c-d304dec299c6.png)

