### PR TITLE
feat: add an experimental logger package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,16 @@ updates:
       prefix-development: "chore:"
 
   - package-ecosystem: "npm"
+    directory: "/packages/logger"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
+
+  - package-ecosystem: "npm"
     directory: "/packages/middleware-log-errors"
     schedule:
       interval: "daily"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,6 +3,7 @@
   "packages/crash-handler": "0.1.0",
   "packages/errors": "1.2.6",
   "packages/log-error": "1.3.8",
+  "packages/logger": "0.0.0",
   "packages/middleware-log-errors": "1.2.9",
   "packages/middleware-render-error-info": "1.1.7",
   "packages/serialize-error": "1.1.4",

--- a/jsconfig.build.json
+++ b/jsconfig.build.json
@@ -7,9 +7,6 @@
 		"noEmit": false,
 		"removeComments": true
 	},
-	"exclude": [
-		"**/test/**/*"
-	],
 	"include": [
 		"packages/**/*.js"
 	]

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -18,7 +18,8 @@
 	"exclude": [
 		"coverage",
 		"node_modules",
-		"**/*.spec.js"
+		"**/*.spec.js",
+		"**/test/**/*"
 	],
 	"include": [
 		"**/*.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -995,6 +995,10 @@
       "resolved": "packages/log-error",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/logger": {
+      "resolved": "packages/logger",
+      "link": true
+    },
     "node_modules/@dotcom-reliability-kit/logos": {
       "resolved": "resources/logos",
       "link": true
@@ -2166,6 +2170,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
     "node_modules/@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
@@ -2320,6 +2330,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/ungap__structured-clone": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.0.tgz",
+      "integrity": "sha512-eBWREUhVUGPze+bUW22AgUr05k8u+vETzuYdLYSvWqGTUe0KOf+zVnOB1qER5wMcw8V6D9Ar4DfJmVvD1yu0kQ==",
+      "dev": true
+    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -2341,6 +2357,11 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
+      "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
@@ -2348,6 +2369,17 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -2596,6 +2628,14 @@
       "dev": true,
       "dependencies": {
         "retry": "0.13.1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -4399,6 +4439,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -4554,6 +4602,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -7428,6 +7484,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7705,6 +7766,113 @@
         "node": ">=6"
       }
     },
+    "node_modules/pino": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.6.1.tgz",
+      "integrity": "sha512-fi+V2K98eMZjQ/uEHHSiMALNrz7HaFdKNYuyA3ZUrbH0f1e8sPFDmeRGzg7ZH2q4QDxGnJPOswmqlEaTAZeDPA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -7873,11 +8041,24 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -7974,6 +8155,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -8210,6 +8396,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -8516,6 +8710,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
+      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8777,6 +8979,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/sort-keys": {
@@ -9167,6 +9377,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -9940,6 +10158,25 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.14"
+      },
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "packages/logger": {
+      "name": "@dotcom-reliability-kit/logger",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+        "@ungap/structured-clone": "^1.0.1",
+        "pino": "^8.6.1"
+      },
+      "devDependencies": {
+        "@financial-times/n-logger": "^10.3.0",
+        "@types/events": "^3.0.0",
+        "@types/ungap__structured-clone": "^0.3.0"
       },
       "engines": {
         "node": "14.x || 16.x || 18.x",
@@ -10778,6 +11015,17 @@
         "@dotcom-reliability-kit/serialize-request": "^1.0.3",
         "@financial-times/n-logger": "^10.3.1",
         "@types/express": "^4.17.14"
+      }
+    },
+    "@dotcom-reliability-kit/logger": {
+      "version": "file:packages/logger",
+      "requires": {
+        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+        "@financial-times/n-logger": "^10.3.0",
+        "@types/events": "^3.0.0",
+        "@types/ungap__structured-clone": "^0.3.0",
+        "@ungap/structured-clone": "^1.0.1",
+        "pino": "^8.6.1"
       }
     },
     "@dotcom-reliability-kit/logos": {
@@ -11754,6 +12002,12 @@
         "@types/node": "*"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
@@ -11908,6 +12162,12 @@
         "@types/node": "*"
       }
     },
+    "@types/ungap__structured-clone": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.0.tgz",
+      "integrity": "sha512-eBWREUhVUGPze+bUW22AgUr05k8u+vETzuYdLYSvWqGTUe0KOf+zVnOB1qER5wMcw8V6D9Ar4DfJmVvD1yu0kQ==",
+      "dev": true
+    },
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -11929,11 +12189,24 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "@ungap/structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
+      "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
+    },
     "@xmldom/xmldom": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
       "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -12132,6 +12405,11 @@
       "requires": {
         "retry": "0.13.1"
       }
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -13459,6 +13737,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -13592,6 +13875,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -15709,6 +15997,11 @@
         "object-keys": "^1.1.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -15902,6 +16195,75 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pino": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.6.1.tgz",
+      "integrity": "sha512-fi+V2K98eMZjQ/uEHHSiMALNrz7HaFdKNYuyA3ZUrbH0f1e8sPFDmeRGzg7ZH2q4QDxGnJPOswmqlEaTAZeDPA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        },
+        "split2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -16020,11 +16382,21 @@
         }
       }
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
     },
     "prompts": {
       "version": "2.4.2",
@@ -16084,6 +16456,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -16264,6 +16641,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "redent": {
       "version": "3.0.0",
@@ -16470,6 +16852,11 @@
         "is-regex": "^1.1.4"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
+      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -16662,6 +17049,14 @@
           "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
           "dev": true
         }
+      }
+    },
+    "sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "sort-keys": {
@@ -16968,6 +17363,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
     },
     "through": {
       "version": "2.3.8",

--- a/packages/logger/.npmignore
+++ b/packages/logger/.npmignore
@@ -1,0 +1,5 @@
+!*.d.ts
+!*.d.ts.map
+CHANGELOG.md
+docs
+test

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -110,7 +110,7 @@ Base log data which is added to every log output made by the [logging methods](#
 const logger = new Logger({
     baseLogData: {
         app: {
-            region: process.env.REGION
+            version: '1.2.3'
         }
     }
 });
@@ -121,7 +121,7 @@ logger.info('This is a log');
 //     "level": "info",
 //     "message": "This is a log",
 //     "app": {
-//         "region": "EU"
+//         "version": '1.2.3'
 //     }
 // }
 ```
@@ -248,7 +248,7 @@ const logger = new Logger({
 });
 
 logger.addContext({
-    appRegion: process.env.REGION
+    myExtraData: 'extra data'
 });
 
 logger.info('Example');
@@ -257,7 +257,7 @@ logger.info('Example');
 //     "level": "info",
 //     "message": "Example",
 //     "appName": "my-app",
-//     "appRegion": "EU"
+//     "myExtraData": "extra data"
 // }
 ```
 
@@ -272,7 +272,7 @@ Add a `context` property to the logger's [base log data](#optionsbaselogdata). Y
 const logger = new Logger();
 
 logger.setContext({
-    appRegion: process.env.REGION
+    myExtraData: 'extra data'
 });
 
 logger.info('Example');
@@ -281,7 +281,7 @@ logger.info('Example');
 //     "level": "info",
 //     "message": "Example",
 //     "context": {
-//         "appRegion": "EU"
+//         "myExtraData": "extra data"
 //     }
 // }
 ```

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,345 @@
+
+## @dotcom-reliability-kit/logger
+
+> **Warning**
+> This Reliability Kit package is **experimental** and should not be used in critical production applications until we've reached a stable version (the latest major version is greater than `0`).
+
+A simple and fast logger based on [Pino](https://getpino.io/), with FT preferences baked in. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [Log levels](#log-levels)
+    * [`Logger`](#logger)
+    * [`Logger` configuration options](#logger-configuration-options)
+      * [`options.baseLogData`](#optionsbaselogdata)
+      * [`options.logLevel`](#optionsloglevel)
+      * [`options.withTimestamps`](#optionswithtimestamps)
+    * [`logger.log()` and shortcut methods](#loggerlog-and-shortcut-methods)
+    * [`logger.flush()`](#loggerflush)
+    * [`logger.createChildLogger()`](#loggercreatechildlogger)
+    * [Deprecated methods](#deprecated-methods)
+      * [`logger.addContext()`](#loggeraddcontext)
+      * [`logger.setContext()`](#loggersetcontext)
+      * [`logger.clearContext()`](#loggerclearcontext)
+    * [Local development usage](#local-development-usage)
+    * [Production usage](#production-usage)
+    * [Compatibility](#compatibility)
+      * [Migrating from n-logger](./docs/migration.md#migrating-from-n-logger)
+      * [Migrating from n-serverless-logger](./docs/migration.md#migrating-from-n-serverless-logger)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/logger` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/logger
+```
+
+Include in your code:
+
+```js
+import logger from '@dotcom-reliability-kit/logger';
+// or
+const logger = require('@dotcom-reliability-kit/logger');
+```
+
+Perform logging at different levels using methods with the same name:
+
+```js
+// Info-level log with a message
+logger.info('Saying hello');
+
+// Warning-level log with a message
+logger.warn('Everything’s mostly cool');
+
+// Error-level log with a message and additional data
+logger.error('Uh-oh', { field: 'some value' });
+
+// Info-level log with no message but some additional data
+logger.info({ event: 'UPDATE_NOTIFICATION', data: data });
+
+// Error-level log with an error object and additional data
+const error = new Error('Whoops!');
+logger.error('Uh-oh', error, { extra_field: 'boo' });
+```
+
+### Log levels
+
+Understanding log levels is key to using the logger. Setting a log level explains to the person debugging your application what level of information (or error severity) they're working with.
+
+The valid levels are:
+
+  * `debug`: The lowest log level. This is for high-volume information which isn't critical to monitoring and running the app, but may be useful when debugging in local development. E.g. logging transformed article information before rendering.
+
+  * `info`: The highest _informational_ log level. This is for key information which is important debugging an application in production. E.g. when the application is ready to recieve HTTP traffic.
+
+  * `warn`: The lowest _error_ log level. This is for when something _may_ cause an issue but it does not have a large impact on the end user. E.g. a deprecated method is being used which may be removed the next time a dependency is updated.
+
+  * `error`: The general _error_ log level. This is for when an error occurs which impacts the end user. E.g. an upstream service failed and so a page cannot be rendered.
+
+  * `fatal`: The highest _error_ log level. This is for when an error occurs and is severe enough that the application cannot recover. This should always be accompanied with the application process being exited.
+
+### `Logger`
+
+The default export of `@dotcom-reliability-kit/logger` is an instance of the `Logger` class with some sensible configurations. You can also create your own logger by importing this class and instantating it yourself with [some options](#logger-configuration-options).
+
+```js
+import { Logger } from '@dotcom-reliability-kit/logger';
+// or
+const { Logger } = require('@dotcom-reliability-kit/logger');
+
+const myLogger = new Logger({
+    // options go here
+});
+```
+
+### `Logger` configuration options
+
+Config options can be passed into the `Logger` constructor to change the behaviour of the logger.
+
+#### `options.baseLogData`
+
+Base log data which is added to every log output made by the [logging methods](#loggerlog-and-shortcut-methods). This allows you to add consistent data to a logger, e.g. information about the app. This must be an `Object` but it can have any properties. E.g.
+
+```js
+const logger = new Logger({
+    baseLogData: {
+        app: {
+            region: process.env.REGION
+        }
+    }
+});
+
+logger.info('This is a log');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "This is a log",
+//     "app": {
+//         "region": "EU"
+//     }
+// }
+```
+
+#### `options.logLevel`
+
+The maximum log level to output during logging. Logs at levels beneath this will be ignored. This option must be a `String` which is set to one of the [supported log levels](#log-levels).
+
+```js
+const logger = new Logger({
+    logLevel: 'warn'
+});
+
+logger.info('This is some info'); // Outputs: nothing
+logger.warn('This is a warning'); // Outputs: the message
+```
+
+It's also possible to set this option as an environment variable, which is how you configure the default logger. The following environment variables are read from:
+
+  * `LOG_LEVEL`: The preferred way to set log level in an environment variable
+  * `SPLUNK_LOG_LEVEL`: The legacy way to set log level, to maintain compatibility with [n-logger](https://github.com/Financial-Times/n-logger)
+
+#### `options.withTimestamps`
+
+Whether to send the timestamp that each log method was called. Because this module logs asynchronously the timestamp when the log is sent to Splunk is not necessarily accurate. Sending the timestamp as a `time` property on each log gives you accurate timings.
+
+Must be a `Boolean` and defaults to `true` for backwards-compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger). This is not _technically_ compatible with [n-logger](https://github.com/Financial-Times/n-logger) which is why the option to turn it off exists.
+
+```js
+const logger = new Logger({
+    withTimestamps: true
+});
+
+logger.info('This is a log');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "This is a log",
+//     "time": 1234567890
+// }
+```
+
+### `logger.log()` and shortcut methods
+
+The `log` method of a [`Logger`](#logger) can be used to send a JSON-formatted log to `stdout` with a message and additional information. This method requires a `level` parameter set to a valid [log level](#log-levels). It can accept any number of other arguments which must be either a `String`, and `Object`, or an instance of `Error`.
+
+```js
+logger.log('debug', 'This is a message', { extraData: 123 }, new Error('Oops'));
+```
+
+It's generally easier and less error-prone to use one of the shortcut methods rather than `log(level)`. There are shortcut methods for each of the log levels:
+
+  * `logger.debug(...logData)`: Log with a level of "debug"
+  * `logger.info(...logData)`: Log with a level of "info"
+  * `logger.error(...logData)`: Log with a level of "error"
+  * `logger.warn(...logData)`: Log with a level of "warn"
+  * `logger.fatal(...logData)`: Log with a level of "fatal"
+
+As well as the valid log levels, there are a couple of deprecated legacy levels. These are only present to maintain backwards-compatibility with [n-logger](https://github.com/Financial-Times/n-logger).
+
+> **Warning**
+> These methods are deprecated and will log a warning message the first time they're used.
+
+  * `logger.data(...logData)`: Aliases `logger.debug()`
+  * `logger.silly(...logData)`: Aliases `logger.debug()`
+  * `logger.verbose(...logData)`: Aliases `logger.debug()`
+
+### `logger.flush()`
+
+Most logs are queued up and sent asynchronously, as this keeps your application performant and minimises the impact of logging. Sometimes (very rarely) you may need to manually flush the queue of logs. You can do so by using the `flush` method:
+
+```js
+logger.flush();
+```
+
+Logs are automatically flushed if the application stops running, to ensure log information is not lost in the event of an application crash.
+
+### `logger.createChildLogger()`
+
+Create a new logger with the same config options as the current logger, but with additional [base log data](#optionsbaselogdata) merged in. This allows you to create loggers which add extra information depending on where in the codebase you are. You must pass an `Object` to set the base log data of the child logger.
+
+Express example where you have an application logger and a child logger for use within Express routes:
+
+```js
+const app = express();
+const appLogger = new Logger({
+    baseLogData: {
+        appName: 'my-app'
+    }
+});
+
+app.use((request, response) => {
+    request.log = appLogger.createChildLogger({
+        requestUrl: request.url
+    });
+});
+
+app.get('/mock-url', (request, response) => {
+    request.log.info('We got a request');
+    // Outputs:
+    // {
+    //     "level": "info",
+    //     "message": "We got a request",
+    //     "appName": "my-app",
+    //     "requestUrl": "/mock-url"
+    // }
+});
+```
+
+### Deprecated methods
+
+#### `logger.addContext()`
+
+Add additional [base log data](#optionsbaselogdata) to the logger via merging objects together. You must pass an `Object` which will be merged with the existing base log data.
+
+> **Warning**
+> This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with n-logger and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
+
+```js
+const logger = new Logger({
+    baseLogData: {
+        appName: 'my-app'
+    }
+});
+
+logger.addContext({
+    appRegion: process.env.REGION
+});
+
+logger.info('Example');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "Example",
+//     "appName": "my-app",
+//     "appRegion": "EU"
+// }
+```
+
+#### `logger.setContext()`
+
+Add a `context` property to the logger's [base log data](#optionsbaselogdata). You must pass an `Object` which will be added as a `context` property to all logs.
+
+> **Warning**
+> This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger) and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
+
+```js
+const logger = new Logger();
+
+logger.setContext({
+    appRegion: process.env.REGION
+});
+
+logger.info('Example');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "Example",
+//     "context": {
+//         "appRegion": "EU"
+//     }
+// }
+```
+
+#### `logger.clearContext()`
+
+Remove the `context` property from the logger's [base log data](#optionsbaselogdata).
+
+> **Warning**
+> This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger) and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
+
+```js
+const logger = new Logger({
+    baseLogData: {
+        context: {
+            appName: 'my-app'
+        }
+    }
+});
+
+logger.clearContext();
+
+logger.info('Example');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "Example"
+// }
+```
+
+### Local development usage
+
+`@dotcom-reliability-kit/logger` does not format or colourize logs, which can make reading them in local development more difficult. If reading raw JSON isn't your thing then we suggest using [pino-pretty](https://github.com/pinojs/pino-pretty#readme) in local development to colourize and format log lines.
+
+You can do this by installing pino-pretty as a development dependency:
+
+```sh
+npm install -D pino-pretty
+```
+
+and then piping your application start into the `pino-pretty` binary. The following ensures that the log message appears as the top highlighted line:
+
+```sh
+npm start | pino-pretty --messageKey message
+```
+
+### Production usage
+
+Using `@dotcom-reliability-kit/logger` in production requires that your application can handle logs to `stdout` and sends these logs to somewhere more permanent. On Heroku this means you're required to have [migrated to Log Drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains). On AWS Lambda it means you must be sending logs to CloudWatch.
+
+### Compatibility
+
+`@dotcom-reliability-kit/logger` is compatible with most use cases of [n-logger](https://github.com/Financial-Times/n-logger) and [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger). We tried hard to make migration as easy as possible from these libraries. The full list of differences are available in the [Migration Guide](./docs/migration.md) as well as tips on migrating.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/logger/docs/migration.md
+++ b/packages/logger/docs/migration.md
@@ -1,0 +1,204 @@
+
+# Migration guide for @dotcom-reliability-kit/logger
+
+This document outlines how to migrate to the latest version of the Reliability Kit logger. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will definitely require code changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change to the output of the library which may require extra steps
+:yellow_circle: | Deprecation       | A deprecated feature which will require code changes in the future
+
+## Table of contents
+
+  * [Migrating from n-logger](#migrating-from-n-logger)
+    * [Where logs get sent](#n-logger-where-logs-get-sent)
+    * [Error serialization changes](#n-logger-error-serialization-changes)
+    * [Log timestamps](#n-logger-log-timestamps)
+    * [Log level changes](#n-logger-log-level-changes)
+    * [Logger method changes](#n-logger-method-changes)
+    * [Environment variable changes](#n-logger-environment-variable-changes)
+  * [Migrating from n-serverless-logger](#migrating-from-n-serverless-logger)
+    * [Where logs get sent](#n-serverless-logger-where-logs-get-sent)
+    * [Error serialization changes](#n-serverless-logger-error-serialization-changes)
+    * [Logger property changes](#n-serverless-logger-property-changes)
+    * [Logger method changes](#n-serverless-logger-method-changes)
+    * [Environment variable changes](#n-serverless-logger-environment-variable-changes)
+  * [Migrating from n-mask-logger](#migrating-from-n-mask-logger)
+
+## Migrating from n-logger
+
+We tried to maintain as much compatibility with [n-logger](https://github.com/Financial-Times/n-logger) as possible to make switching relatively easy. This guide covers the differences and how to migrate your application.
+
+### n-logger: where logs get sent
+
+**:orange_circle: Possibly Breaking:** The Splunk HEC Logger has been removed. `@dotcom-reliability-kit/logger` does not directly log to Splunk, it logs to `process.stdout` and relies on your application forwarding these errors to Splunk. This is the same behaviour as n-logger with the `MIGRATE_TO_HEROKU_LOG_DRAINS` environment variable set.
+
+If your app is on Heroku and you've migrated to use Heroku Log Drains, then this change will not impact you. If you haven't [migrated to Heroku Log Drains](https://financialtimes.atlassian.net/l/cp/sUC4vnnN) yet then you'll need to do that before using this package.
+
+If your app runs on AWS Lambda then you need to ensure that logs are forwarded to Splunk.
+
+### n-logger: error serialization changes
+
+**:orange_circle: Possibly Breaking:** The format of errors has changed in the log outputs between n-logger and `@dotcom-reliability-kit/logger`. We now run instances of `Error` through the [serialize-error package](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme) which enriches the logs a lot more.
+
+This is technically not a backwards-compatible change, if you have dashboards which are based on the old error properties (`error_name`, `error_message`, `error_stack`) then you'll need to update these after migrating.
+
+The differences are:
+
+```js
+logger.info(new TypeError('Example Error'));
+```
+
+```diff
+{
+-    "error_name": "TypeError",
+-    "error_message": "Example Error",
+-    "error_stack": "..."
++    "error": {
++        "name": "TypeError",
++        "code": "UNKNOWN",
++        "message": "Example Error",
++        "stack": "...",
++        "isOperational": false,
++       // ...all other serialized properties
++    }
+}
+```
+
+### n-logger: log timestamps
+
+**:orange_circle: Possibly Breaking:** Because [Pino](https://getpino.io/) (the default underlying log transport) logs asynchronously, the time that it takes logs to reach `process.stdout` isn't predictable. That means that the time captured alongside logs may be slightly inaccurate, though they will all still be in the correct order.
+
+Now, by default, a `time` property is sent on every log to capture the exact time that a log method was called. If your app is already using a `time` property then this may be a breaking change.
+
+It's possible to switch off this behaviour for backwards-compatibility, set the [`withTimestamps` option](../README.md#optionswithtimestamps) to `false` in order to not capture log timestamps.
+
+### n-logger: log level changes
+
+**:yellow_circle: Deprecation:** The log levels which this logger supports are different to n-logger, [we've reduced and simplified the number of levels and made it clear what each is for](../README.md#log-levels). The older log level methods have been deprecated or removed as follows:
+
+  * `data`: This level is now an alias of `debug` and any logs sent with this method will be changed to have a level of `debug`. A warning will also be logged to explain the deprecation. While it's not essential yet, it's worth switching from `data` to `debug` explicitly in your code.
+
+  * `silly`: This level is now an alias of `debug` and any logs sent with this method will be changed to have a level of `debug`. A warning will also be logged to explain the deprecation. While it's not essential yet, it's worth switching from `silly` to `debug` explicitly in your code.
+
+  * `verbose`: This level is now an alias of `debug` and any logs sent with this method will be changed to have a level of `debug`. A warning will also be logged to explain the deprecation. While it's not essential yet, it's worth switching from `verbose` to `debug` explicitly in your code.
+
+### n-logger: method changes
+
+**:yellow_circle: Deprecation:** The `logger.addContext` method has been deprecated and will be removed in a later version of Reliability Kit logger. It currently works in exactly the same way as n-logger, so migration isn't strictly necessary but you'll get warning logs. [The README documents some alternatives](../README.md#loggeraddcontext).
+
+We want to avoid making modifications to a global logger as this can have unexpected consequences. It's better to create a new logger for your specific purpose, and you can now do so by creating child loggers:
+
+```js
+// The old way
+const logger = require('@dotcom-reliability-kit/logger').default;
+logger.addContext({ example: true });
+logger.info('Hello');
+// { "level": "info", "message": "Hello", "example": true }
+
+// The new way (#1): not modifying the default logger
+const logger = require('@dotcom-reliability-kit/logger').default;
+const childLogger = logger.createChildLogger({ example: true });
+childLogger.info('Hello');
+// { "level": "info", "message": "Hello", "example": true }
+
+// The new way (#2): creating a brand new logger with base data
+const { Logger } = require('@dotcom-reliability-kit/logger');
+const logger = new Logger({
+    baseLogData: { example: true }
+});
+logger.info('Hello');
+// { "level": "info", "message": "Hello", "example": true }
+```
+
+### n-logger: environment variable changes
+
+**:yellow_circle: Deprecation:** The following environment variables no longer do anything:
+
+  * **`MIGRATE_TO_HEROKU_LOG_DRAINS`:** This is no longer required as the Reliability Kit logger doesn't not work without log drains.
+
+  * **`SPLUNK_HEC_TOKEN`:** This is no longer required as the Reliability Kit logger does not directly connect to Splunk.
+
+  * **`CONSOLE_LOG_LEVEL`:** This has been replaced with a more generic `LOG_LEVEL` environment variable. This means that in local development you might see more logs until you reconfigure. This removal has no impact on production environments.
+
+  * **`CONSOLE_LOG_UNCOLORIZED`:** This is no longer required as the Reliability Kit logger does not colourize logs by default. See the [local development usage guide](../README.md#local-development-usage) if you want colourized logs when running locally.
+
+The following environment variables have been deprecated.
+
+  * **`SPLUNK_LOG_LEVEL`:** This environment variable will be used if a `LOG_LEVEL` environment variable is not present, however it may be removed in a later version of the Reliability Kit logger. It's best to migrate to `LOG_LEVEL` early.
+
+
+## Migrating from n-serverless-logger
+
+We tried to maintain as much compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger) as possible to make switching relatively easy. This guide covers the differences and how to migrate your application.
+
+### n-serverless-logger: where logs get sent
+
+**:red_circle: Breaking:** The Splunk logger has been removed. `@dotcom-reliability-kit/logger` does not directly log to Splunk, it logs to `process.stdout` and relies on your application forwarding these errors to Splunk. This is a breaking change.
+
+Your logs will still be sent to CloudWatch, but you'll need to ensure that these logs are forwarded to Splunk.
+
+### n-serverless-logger: error serialization changes
+
+**:orange_circle: Possibly Breaking:** The format of errors has changed in the log outputs between n-serverless-logger and `@dotcom-reliability-kit/logger`. We now run instances of `Error` through the [serialize-error package](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme) which enriches the logs a lot more.
+
+See the [error serialization changes for n-logger](#n-logger-error-serialization-changes) for more information.
+
+### n-serverless-logger: property changes
+
+**:red_circle: Breaking:** The `logger.withTimestamps` property is no longer accessible as it's no longer a trivial task to change the timestamp settings after a logger is constructed. Timestamps are included by default, if you need to disable them then you should create a new Logger instance with the configuration set:
+
+```js
+const { Logger } = require('@dotcom-reliability-kit/logger');
+const logger = new Logger({
+    withTimestamps: false
+});
+```
+
+### n-serverless-logger: method changes
+
+**:yellow_circle: Deprecation:** The `logger.setContext` and `logger.clearContext` methods have been deprecated and will be removed in a later version of Reliability Kit logger. They currently work in exactly the same way as n-serverless-logger, so migration isn't strictly necessary but you'll get warning logs. [The README documents some alternatives](../README.md#loggersetcontext).
+
+We want to avoid making modifications to a global logger as this can have unexpected consequences. It's better to create a new logger for your specific purpose, and you can now do so by creating child loggers:
+
+```js
+// The old way
+const logger = require('@dotcom-reliability-kit/logger').default;
+logger.setContext({ example: true });
+logger.info('Hello');
+// { "level": "info", "message": "Hello", "context": { "example": true } }
+
+// The new way (#1): not modifying the default logger
+const logger = require('@dotcom-reliability-kit/logger').default;
+const childLogger = logger.createChildLogger({ context: { example: true } });
+childLogger.info('Hello');
+// { "level": "info", "message": "Hello", "context": { "example": true } }
+
+// The new way (#2): creating a brand new logger with base data
+const { Logger } = require('@dotcom-reliability-kit/logger');
+const logger = new Logger({
+    baseLogData: { context: { example: true } }
+});
+logger.info('Hello');
+// { "level": "info", "message": "Hello", "context": { "example": true } }
+```
+
+### n-serverless-logger: environment variable changes
+
+**:yellow_circle: Deprecation:** The following environment variables no longer do anything:
+
+  * **`AWS_LAMBDA_FUNCTION_NAME`:** This is no longer required as the Reliability Kit logger does not directly connect to Splunk.
+
+  * **`SPLUNK_HEC_TOKEN`:** This is no longer required as the Reliability Kit logger does not directly connect to Splunk.
+
+  * **`SPLUNK_HEC_URL`:** This is no longer required as the Reliability Kit logger does not directly connect to Splunk.
+
+The following environment variables have been deprecated.
+
+  * **`SPLUNK_LOG_LEVEL`:** This environment variable will be used if a `LOG_LEVEL` environment variable is not present, however it may be removed in a later version of the Reliability Kit logger. It's best to migrate to `LOG_LEVEL` early.
+
+
+## Migrating from n-mask-logger
+
+**:construction: Under construction:** this part of the documentation relates to a planned feature.

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -1,0 +1,8 @@
+const Logger = require('./logger');
+
+module.exports = new Logger();
+
+module.exports.Logger = Logger;
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -1,0 +1,458 @@
+const pino = require('pino').default;
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+const { default: structuredClone } = require('@ungap/structured-clone');
+
+/**
+ * @typedef {"silly" | "data" | "debug" | "verbose" | "info" | "warn" | "error" | "fatal"} LogLevel
+ */
+
+/**
+ * @typedef {string | object | Error} LogData
+ */
+
+/**
+ * @typedef {object} LoggerOptions
+ * @property {LogData} [baseLogData = {}]
+ *     Base log data which is added to every log output.
+ * @property {LogLevel} [logLevel = "debug"]
+ *     The maximum log level to output during logging. Logs at levels
+ *     beneath this will be ignored.
+ * @property {boolean} [withTimestamps = true]
+ *     Whether to send the timestamp that each log method was called.
+ */
+
+/**
+ * @typedef {object} PrivateLoggerOptions
+ * @property {LogTransport} [_transport]
+ *     A transport used to perform logging. This is only for internal use.
+ */
+
+/**
+ * @typedef {object} LogTransport
+ * @property {string} [level]
+ *     A property used to set the transport log level.
+ * @property {(...args: any) => any} debug
+ *     Log debug level information.
+ * @property {(...args: any) => any} error
+ *     Log error level information.
+ * @property {(...args: any) => any} fatal
+ *     Log fatal level information.
+ * @property {(...args: any) => any} info
+ *     Log info level information.
+ * @property {(...args: any) => any} warn
+ *     Log warn level information.
+ * @property {() => {}} [flush]
+ *     Flush async logs ahead of time.
+ */
+
+/**
+ * @typedef {object} LogLevelInfo
+ * @property {LogLevel} logLevel
+ *     A canonical alternative level for a given level.
+ * @property {boolean} isDeprecated
+ *     Whether the original log level is deprecated.
+ */
+
+/**
+ * A map of log levels to the underlying log method that
+ * should be called when a log of that level is sent, as
+ * well as the deprecation status of the log level.
+ *
+ * @type {Object<string, LogLevelInfo>}
+ */
+const logLevelToTransportMethodMap = {
+	data: { logLevel: 'debug', isDeprecated: true },
+	debug: { logLevel: 'debug', isDeprecated: false },
+	default: { logLevel: 'info', isDeprecated: true },
+	error: { logLevel: 'error', isDeprecated: false },
+	fatal: { logLevel: 'fatal', isDeprecated: false },
+	info: { logLevel: 'info', isDeprecated: false },
+	silly: { logLevel: 'debug', isDeprecated: true },
+	verbose: { logLevel: 'debug', isDeprecated: true },
+	warn: { logLevel: 'warn', isDeprecated: false }
+};
+
+/**
+ * Class representing a logger.
+ */
+class Logger {
+	/**
+	 * @type {LogLevel}
+	 */
+	#logLevel = 'debug';
+
+	/**
+	 * @type {LogData}
+	 */
+	#baseLogData = {};
+
+	/**
+	 * @type {LogTransport}
+	 */
+	#logTransport;
+
+	/**
+	 * @type {Array<string>}
+	 */
+	#deprecatedMethodTracker = [];
+
+	/**
+	 * Create a logger.
+	 *
+	 * @param {LoggerOptions & PrivateLoggerOptions} [options = {}]
+	 *     Options to configure the logger.
+	 */
+	constructor(options = {}) {
+		// Default and set the base log data option
+		if (options.baseLogData) {
+			// TODO when we remove `setContext` and `clearContext` we can freeze this
+			// object with `Object.freeze` to prevent any editing after instantiation
+			this.#baseLogData = structuredClone(options.baseLogData);
+		}
+
+		// Default and set the log level option. We default the log level to the
+		// `LOG_LEVEL` environment variable and fall back to `SPLUNK_LOG_LEVEL`
+		// for backwards-compatibility with n-logger.
+		const logLevelOption =
+			options.logLevel || process.env.LOG_LEVEL || process.env.SPLUNK_LOG_LEVEL;
+		if (logLevelOption) {
+			const { logLevel } = Logger.getLogLevelInfo(logLevelOption);
+			this.#logLevel = logLevel;
+		}
+
+		// Default and set the timestamps option.
+		const withTimestamps = options.withTimestamps !== false;
+
+		if (options._transport) {
+			// If we have a configured transport, use it. This means
+			// that a child logger was created with an already-instantated
+			// Pino logger
+			this.#logTransport = options._transport;
+		} else {
+			// Otherwise set up Pino to replicate n-logger as closely as possible
+			/** @type {pino.LoggerOptions} */
+			const pinoOptions = {
+				base: {},
+				formatters: {
+					level(label) {
+						return { level: label };
+					}
+				},
+				messageKey: 'message', // This is for backwards compatibility with our existing logs
+				timestamp: withTimestamps
+			};
+			this.#logTransport = pino(pinoOptions);
+			this.#logTransport.level = this.#logLevel;
+		}
+	}
+
+	/**
+	 * @public
+	 * @type {LogData}
+	 */
+	get baseLogData() {
+		return this.#baseLogData;
+	}
+
+	/**
+	 * @public
+	 * @type {LogLevel}
+	 */
+	get logLevel() {
+		return this.#logLevel;
+	}
+
+	/**
+	 * @public
+	 * @type {LogTransport}
+	 */
+	get transport() {
+		return this.#logTransport;
+	}
+
+	/**
+	 * Create a child logger with additional base log data.
+	 *
+	 * @public
+	 * @param {LogData} baseLogData
+	 *     The base log data to add.
+	 * @returns {Logger}
+	 *     Returns a new child logger.
+	 */
+	createChildLogger(baseLogData) {
+		return new Logger({
+			_transport: this.transport,
+			baseLogData: Object.assign({}, this.#baseLogData, baseLogData),
+			logLevel: this.#logLevel
+		});
+	}
+
+	/**
+	 * Add additional log data to all subsequent log calls.
+	 *
+	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
+	 * @public
+	 * @param {LogData} extraLogData
+	 *     The additional data to add to all logs from this logger.
+	 * @returns {void}
+	 */
+	addContext(extraLogData) {
+		this.#baseLogData = Object.assign({}, this.#baseLogData, extraLogData);
+		if (!this.#deprecatedMethodTracker.includes('addContext')) {
+			this.#deprecatedMethodTracker.push('addContext');
+			this.transport.warn({
+				event: 'LOGGER_METHOD_DEPRECATED',
+				message: "The 'addContext' logger method is deprecated",
+				deprecatedMethod: 'addContext'
+			});
+		}
+	}
+
+	/**
+	 * Set the `context` property for all subsequent log calls.
+	 *
+	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
+	 * @public
+	 * @param {LogData} contextData
+	 *     The additional data to add to all log `context` properties.
+	 * @returns {void}
+	 */
+	setContext(contextData) {
+		this.#baseLogData.context = contextData;
+		if (!this.#deprecatedMethodTracker.includes('setContext')) {
+			this.#deprecatedMethodTracker.push('setContext');
+			this.transport.warn({
+				event: 'LOGGER_METHOD_DEPRECATED',
+				message: "The 'setContext' logger method is deprecated",
+				deprecatedMethod: 'setContext'
+			});
+		}
+	}
+
+	/**
+	 * Clear the `context` property for all subsequent log calls.
+	 *
+	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
+	 * @public
+	 * @returns {void}
+	 */
+	clearContext() {
+		delete this.#baseLogData.context;
+		if (!this.#deprecatedMethodTracker.includes('clearContext')) {
+			this.#deprecatedMethodTracker.push('clearContext');
+			this.transport.warn({
+				event: 'LOGGER_METHOD_DEPRECATED',
+				message: "The 'clearContext' logger method is deprecated",
+				deprecatedMethod: 'clearContext'
+			});
+		}
+	}
+
+	/**
+	 * Send a log.
+	 *
+	 * @public
+	 * @param {LogLevel} level
+	 *     The log level to output the log as.
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	log(level, ...logData) {
+		try {
+			const { logLevel, isDeprecated } = Logger.getLogLevelInfo(level);
+
+			// Zip and sanitize the log data
+			const sanitizedLogData = Logger.zipLogData(...logData, this.#baseLogData);
+			if (!sanitizedLogData.message) {
+				sanitizedLogData.message = null;
+			}
+
+			// Send the log
+			this.transport[logLevel](sanitizedLogData);
+
+			// If the log level is deprecated, then log a warning about that
+			if (isDeprecated && !this.#deprecatedMethodTracker.includes(level)) {
+				this.#deprecatedMethodTracker.push(level);
+				this.transport.warn({
+					event: 'LOG_LEVEL_DEPRECATED',
+					message: `The '${level}' log level is deprecated`,
+					deprecatedLevel: level,
+					suggestedLevel: logLevel
+				});
+			}
+		} catch (/** @type {any} */ error) {
+			// We allow use of `console.log` here to ensure that critical
+			// logging failures are caught and logged. This ensures that we
+			// know if an app has broken logging.
+			// eslint-disable-next-line no-console
+			console.log(
+				JSON.stringify({
+					level: 'error',
+					event: 'LOG_METHOD_FAILURE',
+					message: `Failed to log at level '${level}'`,
+					error: serializeError(error)
+				})
+			);
+		}
+	}
+
+	/**
+	 * Send a log with a level of "data".
+	 *
+	 * @deprecated Please use a log level of "debug" instead.
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	data(...logData) {
+		this.log('data', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "debug".
+	 *
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	debug(...logData) {
+		this.log('debug', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "error".
+	 *
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	error(...logData) {
+		this.log('error', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "fatal".
+	 *
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	fatal(...logData) {
+		this.log('fatal', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "info".
+	 *
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	info(...logData) {
+		this.log('info', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "silly".
+	 *
+	 * @deprecated Please use a log level of "debug" instead.
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	silly(...logData) {
+		this.log('silly', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "verbose".
+	 *
+	 * @deprecated Please use a log level of "debug" instead.
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	verbose(...logData) {
+		this.log('verbose', ...logData);
+	}
+
+	/**
+	 * Send a log with a level of "warn".
+	 *
+	 * @public
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {void}
+	 */
+	warn(...logData) {
+		this.log('warn', ...logData);
+	}
+
+	/**
+	 * Flush any asynchronous logs in the queue when an async transport is used.
+	 *
+	 * @public
+	 * @returns {void}
+	 */
+	flush() {
+		if (this.transport.flush) {
+			this.transport.flush();
+		}
+	}
+
+	/**
+	 * Get information on a given log level.
+	 *
+	 * @private
+	 * @param {string} level
+	 *     The log level to get information for.
+	 * @returns {LogLevelInfo}
+	 *     Returns information about the log level.
+	 */
+	static getLogLevelInfo(level) {
+		return (
+			logLevelToTransportMethodMap[level] ||
+			logLevelToTransportMethodMap.default
+		);
+	}
+
+	/**
+	 * Combine multiple log data into a single zipped object.
+	 *
+	 * @private
+	 * @param {...LogData} logData
+	 *     The log data.
+	 * @returns {Object<string, any>}
+	 *     Returns a single zipped object containing all log data.
+	 */
+	static zipLogData(...logData) {
+		// We reverse the log data to maintain compatibility with n-logger,
+		// which always uses the _first_ instance of a property or message
+		// rather than the last
+		const reversedLogData = logData.reverse();
+		return structuredClone(
+			reversedLogData.reduce((collect, item) => {
+				if (typeof item === 'string') {
+					return Object.assign(collect, { message: item });
+				}
+				if (item instanceof Error) {
+					return Object.assign(collect, { error: serializeError(item) });
+				}
+				return Object.assign(collect, item);
+			}, {})
+		);
+	}
+}
+
+module.exports = Logger;
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dotcom-reliability-kit/logger",
+  "version": "0.0.0",
+  "description": "A simple and fast logger based on Pino, with FT preferences baked in",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/logger"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: logger\"",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x || 18.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+    "@ungap/structured-clone": "^1.0.1",
+    "pino": "^8.6.1"
+  },
+  "devDependencies": {
+    "@financial-times/n-logger": "^10.3.0",
+    "@types/events": "^3.0.0",
+    "@types/ungap__structured-clone": "^0.3.0"
+  }
+}

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -1,0 +1,611 @@
+// These test cases illustrate where n-logger and reliability kit are the same
+// and where they differ. Look for "DIFFERENCE" comments in this file which
+// explain when there are differences between the two.
+//
+// These test cases are run in `compatibility.spec.js`.
+
+/**
+ * @typedef {object} CompatibilityTestCase
+ * @property {string} id
+ *     A unique identifier for the test case.
+ * @property {string} description
+ *     A short description for use in test output.
+ * @property {object} call
+ *     The method and arguments to call on each logging library.
+ * @property {string} call.method
+ *     The log method to call.
+ * @property {Array<any>} call.args
+ *     An array of arguments to call the method with.
+ * @property {object} expectedOutput
+ *     The outputs expected for each logging library.
+ * @property {Object<string, any>} [expectedOutput.nextLogger]
+ *     What the expected output is for n-logger when called with the given arguments.
+ * @property {Object<string, any>} [expectedOutput.reliabilityKit]
+ *     What the expected output is for Reliability Kit logger when called with the given arguments.
+ */
+
+/**
+ * @type {Array<CompatibilityTestCase>}
+ */
+module.exports = [
+	// Test cases based on the n-logger documentation
+	// https://github.com/Financial-Times/n-logger#usage
+	{
+		id: 'n-logger-docs-1',
+		description: '.log() with log level and message (n-logger docs)',
+		call: {
+			method: 'log',
+			args: ['info', 'Saying hello']
+		},
+		expectedOutput: {
+			nextLogger: { level: 'info', message: 'Saying hello' },
+			reliabilityKit: { level: 'info', message: 'Saying hello' }
+		}
+	},
+	{
+		id: 'n-logger-docs-2',
+		description: '.info() with message (n-logger docs)',
+		call: {
+			method: 'info',
+			args: ['Saying hello']
+		},
+		expectedOutput: {
+			nextLogger: { level: 'info', message: 'Saying hello' },
+			reliabilityKit: { level: 'info', message: 'Saying hello' }
+		}
+	},
+	{
+		id: 'n-logger-docs-3',
+		description: '.warn() with message (n-logger docs)',
+		call: {
+			method: 'warn',
+			args: ["Everything's mostly cool"]
+		},
+		expectedOutput: {
+			nextLogger: { level: 'warn', message: "Everything's mostly cool" },
+			reliabilityKit: { level: 'warn', message: "Everything's mostly cool" }
+		}
+	},
+	{
+		id: 'n-logger-docs-4',
+		description: '.error() with message and data (n-logger docs)',
+		call: {
+			method: 'error',
+			args: ['Uh-oh', { field: 'some value' }]
+		},
+		expectedOutput: {
+			nextLogger: { field: 'some value', level: 'error', message: 'Uh-oh' },
+			reliabilityKit: { field: 'some value', level: 'error', message: 'Uh-oh' }
+		}
+	},
+	{
+		id: 'n-logger-docs-5',
+		description: '.info() with data (n-logger docs)',
+		call: {
+			method: 'info',
+			args: [{ event: 'UPDATE_NOTIFICATION', data: { isMockData: true } }]
+		},
+		// DIFFERENCE:
+		// Reliability kit does not send the `message` as an empty string
+		// if one is not present – it explicitly sets it to `null`.
+		expectedOutput: {
+			nextLogger: {
+				data: { isMockData: true },
+				event: 'UPDATE_NOTIFICATION',
+				level: 'info',
+				message: ''
+			},
+			reliabilityKit: {
+				data: { isMockData: true },
+				event: 'UPDATE_NOTIFICATION',
+				level: 'info',
+				message: null
+			}
+		}
+	},
+	{
+		id: 'n-logger-docs-6',
+		description: '.error() with message, error, and data (n-logger docs)',
+		call: {
+			method: 'error',
+			args: ['Uh-oh', new Error('Whoops!'), { extra_field: 'boo' }]
+		},
+		// DIFFERENCE:
+		// Reliability kit uses the @dotcom-reliability-kit/serialize-error package
+		// when it encounters an error object. We deliberately wanted to improve the
+		// existing n-logger behaviour here because it doesn't give us the information
+		// we need.
+		expectedOutput: {
+			nextLogger: {
+				error_message: 'Whoops!',
+				error_name: 'Error',
+				extra_field: 'boo',
+				level: 'error',
+				message: 'Uh-oh'
+			},
+			reliabilityKit: {
+				error: {
+					cause: null,
+					code: 'UNKNOWN',
+					data: {},
+					isOperational: false,
+					message: 'Whoops!',
+					name: 'Error',
+					relatesToSystems: [],
+					statusCode: null
+				},
+				extra_field: 'boo',
+				level: 'error',
+				message: 'Uh-oh'
+			}
+		}
+	},
+
+	// Test cases based on the n-serverless-logger documentation
+	// https://github.com/Financial-Times/n-serverless-logger#usage
+	{
+		id: 'n-serverless-logger-docs-1',
+		description: '.info() with data (n-serverless-logger docs)',
+		call: {
+			method: 'info',
+			args: [
+				{
+					event: 'EVENT_RECEIVED',
+					message: 'I just ran.'
+				}
+			]
+		},
+		// DIFFERENCE:
+		// We can't directly test n-serverless-logger here because the
+		// output format is not JSON. We can test what we expect
+		// Reliability Kit and n-logger to do when given the same data.
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				event: 'EVENT_RECEIVED',
+				message: 'I just ran.'
+			},
+			reliabilityKit: {
+				level: 'info',
+				event: 'EVENT_RECEIVED',
+				message: 'I just ran.'
+			}
+		}
+	},
+
+	// Test cases for all non-deprecated methods
+	{
+		id: 'non-deprecated-debug',
+		description: '.debug() with message and data',
+		call: {
+			method: 'debug',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'debug',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'debug',
+				message: 'Test 1',
+				property: true
+			}
+		}
+	},
+	{
+		id: 'non-deprecated-error',
+		description: '.error() with message and data',
+		call: {
+			method: 'error',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'error',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'error',
+				message: 'Test 1',
+				property: true
+			}
+		}
+	},
+	{
+		id: 'non-deprecated-fatal',
+		description: '.fatal() with message and data',
+		call: {
+			method: 'fatal',
+			args: ['Test 1', { property: true }]
+		},
+		// DIFFERENCE:
+		// n-logger does not support fatal-level logging, so we get no
+		// output for this test
+		expectedOutput: {
+			reliabilityKit: {
+				level: 'fatal',
+				message: 'Test 1',
+				property: true
+			}
+		}
+	},
+	{
+		id: 'non-deprecated-info',
+		description: '.info() with message and data',
+		call: {
+			method: 'info',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test 1',
+				property: true
+			}
+		}
+	},
+	{
+		id: 'non-deprecated-warn',
+		description: '.warn() with message and data',
+		call: {
+			method: 'warn',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'warn',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'warn',
+				message: 'Test 1',
+				property: true
+			}
+		}
+	},
+
+	// Test cases for all deprecated methods
+	{
+		id: 'deprecated-data',
+		description: '.data() with message and data',
+		call: {
+			method: 'data',
+			args: ['Test 1', { property: true }]
+		},
+		// DIFFERENCE:
+		// n-logger does has a data method, however it never
+		// seems to output anything. We're mainly adding it to
+		// Reliability Kit logger in order to see where it's
+		// used to see if we can understand it better
+		expectedOutput: {
+			reliabilityKit: {
+				level: 'debug',
+				message: 'Test 1',
+				property: true
+			},
+			deprecation: {
+				level: 'warn',
+				event: 'LOG_LEVEL_DEPRECATED',
+				message: "The 'data' log level is deprecated",
+				deprecatedLevel: 'data',
+				suggestedLevel: 'debug'
+			}
+		}
+	},
+	{
+		id: 'deprecated-silly',
+		description: '.silly() with message and data',
+		call: {
+			method: 'silly',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'silly',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'debug',
+				message: 'Test 1',
+				property: true
+			},
+			deprecation: {
+				level: 'warn',
+				event: 'LOG_LEVEL_DEPRECATED',
+				message: "The 'silly' log level is deprecated",
+				deprecatedLevel: 'silly',
+				suggestedLevel: 'debug'
+			}
+		}
+	},
+	{
+		id: 'deprecated-verbose',
+		description: '.verbose() with message and data',
+		call: {
+			method: 'verbose',
+			args: ['Test 1', { property: true }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'verbose',
+				message: 'Test 1',
+				property: true
+			},
+			reliabilityKit: {
+				level: 'debug',
+				message: 'Test 1',
+				property: true
+			},
+			deprecation: {
+				level: 'warn',
+				event: 'LOG_LEVEL_DEPRECATED',
+				message: "The 'verbose' log level is deprecated",
+				deprecatedLevel: 'verbose',
+				suggestedLevel: 'debug'
+			}
+		}
+	},
+
+	// Test cases designed to ensure that edge-cases match up
+	{
+		id: 'edge-case-message-precedence',
+		description: '.info() with message in multiple places',
+		call: {
+			method: 'info',
+			args: ['Test 1', { message: 'Test 2' }, { message: 'Test 3' }, 'Test 4']
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test 1'
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test 1'
+			}
+		}
+	},
+	{
+		id: 'edge-case-property-precedence',
+		description: '.info() with properties in multiple places',
+		call: {
+			method: 'info',
+			args: ['Test Message', { testProp: '1' }, { testProp: '2' }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test Message',
+				testProp: '1'
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test Message',
+				testProp: '1'
+			}
+		}
+	},
+	{
+		id: 'edge-case-error-precedence',
+		description: '.info() with errors in multiple places',
+		call: {
+			method: 'info',
+			args: [
+				'Test Message',
+				new Error('Test 1'),
+				new TypeError('Test 2'),
+				{ error: 'Test 3' },
+				{ error_message: 'Test 4' }
+			]
+		},
+		// DIFFERENCE:
+		// Reliability kit uses the @dotcom-reliability-kit/serialize-error package
+		// when it encounters an error object, whereas n-logger serializes basic
+		// properties only
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test Message',
+				error_message: 'Test 1',
+				error_name: 'Error',
+				error: 'Test 3'
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test Message',
+				error: {
+					message: 'Test 1',
+					name: 'Error',
+					cause: null,
+					code: 'UNKNOWN',
+					data: {},
+					isOperational: false,
+					relatesToSystems: [],
+					statusCode: null
+				},
+				error_message: 'Test 4'
+			}
+		}
+	},
+	{
+		id: 'edge-case-message-after-data',
+		description: '.info() with a message defined after data',
+		call: {
+			method: 'info',
+			args: [{ testProp: '1' }, 'Test Message']
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test Message',
+				testProp: '1'
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test Message',
+				testProp: '1'
+			}
+		}
+	},
+	{
+		id: 'edge-case-error-as-property',
+		description: '.info() with an error as a property',
+		call: {
+			method: 'info',
+			args: ['Test Message', { issue: new Error('Test 1') }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Test Message',
+				issue: {}
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Test Message',
+				issue: {}
+			}
+		}
+	},
+
+	// Test cases based on real-world usage of n-logger
+	{
+		id: 'next-article-1',
+		description: '.error() with data and error (next-article)',
+		call: {
+			method: 'error',
+			args: [
+				{ event: 'CREATE_GIFT_LINK', contentUUID: 'mock-uuid' },
+				new Error('mock-error')
+			]
+		},
+		// DIFFERENCE:
+		// Reliability kit does not send the `message` as an empty string
+		// if one is not present – it explicitly sets it to `null`.
+		//
+		// DIFFERENCE:
+		// Reliability kit uses the @dotcom-reliability-kit/serialize-error package
+		// when it encounters an error object, whereas n-logger serializes basic
+		// properties only
+		expectedOutput: {
+			nextLogger: {
+				level: 'error',
+				message: '',
+				event: 'CREATE_GIFT_LINK',
+				contentUUID: 'mock-uuid',
+				error_name: 'Error',
+				error_message: 'mock-error'
+			},
+			reliabilityKit: {
+				level: 'error',
+				message: null,
+				event: 'CREATE_GIFT_LINK',
+				contentUUID: 'mock-uuid',
+				error: {
+					cause: null,
+					code: 'UNKNOWN',
+					data: {},
+					isOperational: false,
+					message: 'mock-error',
+					name: 'Error',
+					relatesToSystems: [],
+					statusCode: null
+				}
+			}
+		}
+	},
+	{
+		id: 'next-article-2',
+		description: '.info() with data (next-article)',
+		call: {
+			method: 'info',
+			args: [{ event: 'ALPHAVILLE_MARKETSLIVE_REDIRECT', url: 'mock-url' }]
+		},
+		// DIFFERENCE:
+		// Reliability kit does not send the `message` as an empty string
+		// if one is not present – it explicitly sets it to `null`.
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: '',
+				event: 'ALPHAVILLE_MARKETSLIVE_REDIRECT',
+				url: 'mock-url'
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: null,
+				event: 'ALPHAVILLE_MARKETSLIVE_REDIRECT',
+				url: 'mock-url'
+			}
+		}
+	},
+	{
+		id: 'next-express-1',
+		description: '.warn() with data (n-express)',
+		call: {
+			method: 'warn',
+			args: [
+				{
+					event: 'EXPRESS_START',
+					message: 'Express application example started',
+					app: 'example',
+					port: 1234,
+					nodeVersion: 'v16.17.0'
+				}
+			]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'warn',
+				event: 'EXPRESS_START',
+				message: 'Express application example started',
+				app: 'example',
+				port: 1234,
+				nodeVersion: 'v16.17.0'
+			},
+			reliabilityKit: {
+				level: 'warn',
+				event: 'EXPRESS_START',
+				message: 'Express application example started',
+				app: 'example',
+				port: 1234,
+				nodeVersion: 'v16.17.0'
+			}
+		}
+	},
+	{
+		id: 'next-stream-page-1',
+		description: '.error() with data and error property (next-stream-page)',
+		call: {
+			method: 'error',
+			args: [{ event: 'FAILED_TO_GET_FT_LIVE_EVENT', error: new Error('Oops') }]
+		},
+		// DIFFERENCE:
+		// Reliability kit does not send the `message` as an empty string
+		// if one is not present – it explicitly sets it to `null`.
+		expectedOutput: {
+			nextLogger: {
+				level: 'error',
+				event: 'FAILED_TO_GET_FT_LIVE_EVENT',
+				message: '',
+				error: {} // Empty object because this is invalid, it says so in the n-logger docs
+			},
+			reliabilityKit: {
+				level: 'error',
+				event: 'FAILED_TO_GET_FT_LIVE_EVENT',
+				message: null,
+				error: {} // Empty object because this is invalid, it says so in the n-logger docs
+			}
+		}
+	}
+];

--- a/packages/logger/test/end-to-end/compatibility.spec.js
+++ b/packages/logger/test/end-to-end/compatibility.spec.js
@@ -1,0 +1,66 @@
+const cleanLogForTesting = require('./helpers/clean-log-for-testing');
+const { exec } = require('child_process');
+const findLogWithPropertyValue = require('./helpers/find-log-with-property-value');
+const testCases = require('./compatibility-test-cases');
+const splitAndParseJsonLogs = require('./helpers/split-and-parse-json-logs');
+
+describe('@dotcom-reliability-kit/logger vs @financial-times/n-logger', () => {
+	const loggingScript = `${__dirname}/scripts/run-loggers-with-test-case.js`;
+
+	for (const { id, description, expectedOutput } of testCases) {
+		describe(description, () => {
+			let logs;
+
+			beforeAll((done) => {
+				// Execute a child process which performs logging with both
+				// n-logger and Reliability Kit
+				exec(`node ${loggingScript} ${id}`, (execError, stdout, stderr) => {
+					if (execError) {
+						return done(execError);
+					}
+					try {
+						logs = splitAndParseJsonLogs(`${stdout}\n${stderr}`);
+						done();
+					} catch (error) {
+						done(error);
+					}
+				});
+			});
+
+			if (expectedOutput.nextLogger) {
+				it('outputs the expected n-logger logs', () => {
+					const log = findLogWithPropertyValue(logs, '_logger', 'nextLogger');
+					expect(log).toBeTruthy();
+					const cleanLog = cleanLogForTesting(log);
+					expect(cleanLog).toEqual(expectedOutput.nextLogger);
+				});
+			}
+
+			if (expectedOutput.reliabilityKit) {
+				it('outputs the expected reliability-kit logs', () => {
+					const log = findLogWithPropertyValue(
+						logs,
+						'_logger',
+						'reliabilityKit'
+					);
+					expect(log).toBeTruthy();
+					const cleanLog = cleanLogForTesting(log);
+					expect(cleanLog).toEqual(expectedOutput.reliabilityKit);
+				});
+			}
+
+			if (expectedOutput.deprecation) {
+				it('outputs a deprecation message', () => {
+					const log = findLogWithPropertyValue(
+						logs,
+						'event',
+						'LOG_LEVEL_DEPRECATED'
+					);
+					expect(log).toBeTruthy();
+					const cleanLog = cleanLogForTesting(log);
+					expect(cleanLog).toEqual(expectedOutput.deprecation);
+				});
+			}
+		});
+	}
+});

--- a/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
+++ b/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
@@ -1,0 +1,27 @@
+/**
+ * Remove properties from a log object which cause
+ * issues in testing.
+ *
+ * @param {Object<string, any>} log
+ *     The log object to clean.
+ * @returns {Object<string, any>}
+ *     Returns the cleaned log.
+ */
+function cleanLogFortesting(log) {
+	// The `_logger` property is used to temporarily indicate which
+	// logger output a specific log. It's not required during testing.
+	delete log._logger;
+
+	// The error stack properties are not comparable, and won't be
+	// consistent between machines or local vs CI
+	delete log.error?.stack;
+	delete log.error_stack;
+
+	// The `time` property cannot be tested because it's always
+	// going to be different
+	delete log.time;
+
+	return log;
+}
+
+module.exports = cleanLogFortesting;

--- a/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
+++ b/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
@@ -1,0 +1,18 @@
+/**
+ * Find the first log in an array of logs which has the
+ * specified `property` set to `value`.
+ *
+ * @param {Array<object>} logs
+ *     The logs to search.
+ * @param {string} property
+ *     The property to search on.
+ * @param {any} value
+ *     The property value to find.
+ * @returns {Object<string, any>|null}
+ *     Returns the found log or null if one isn't found.
+ */
+function findLogWithPropertyValue(logs, property, value) {
+	return logs.find((log) => log[property] === value) || null;
+}
+
+module.exports = findLogWithPropertyValue;

--- a/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
+++ b/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
@@ -1,0 +1,17 @@
+/**
+ * Split a log string by line breaks and parse any JSON logs.
+ *
+ * @param {string} logString
+ *     The log string to parse.
+ * @returns {Array<Object<string, any>>}
+ *     Returns the parsed JSON logs as an array of log objects.
+ */
+function splitAndParseJsonLogs(logString) {
+	return logString
+		.trim()
+		.split(/\n+/g)
+		.filter((log) => log.trim())
+		.map((log) => JSON.parse(log));
+}
+
+module.exports = splitAndParseJsonLogs;

--- a/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
+++ b/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
@@ -1,0 +1,27 @@
+// These environment variables are required to make n-logger
+// output JSON logs which can be tested against Reliability Kit
+process.env.MIGRATE_TO_HEROKU_LOG_DRAINS = 'true';
+process.env.SPLUNK_LOG_LEVEL = 'silly';
+
+const nLogger = require('@financial-times/n-logger').default;
+const reliabilityKitLogger = require('../../../lib').default;
+const testCases = require('../compatibility-test-cases');
+
+// The test case ID is passed as an additional argument on the command.
+// We use this to find the test case in order to perform logging.
+const testCase = testCases.find(({ id }) => id === process.argv[2]);
+if (!testCase) {
+	process.exit(1);
+}
+
+const { method, args } = testCase.call;
+
+// Run n-logger
+if (nLogger[method]) {
+	nLogger[method](...args, { _logger: 'nextLogger' });
+}
+
+// Run reliability kit logger
+if (reliabilityKitLogger[method]) {
+	reliabilityKitLogger[method](...args, { _logger: 'reliabilityKit' });
+}

--- a/packages/logger/test/unit/lib/index.spec.js
+++ b/packages/logger/test/unit/lib/index.spec.js
@@ -1,0 +1,22 @@
+const logger = require('../../..');
+
+jest.mock('../../../lib/logger', () => jest.fn());
+const MockLogger = require('../../../lib/logger');
+
+describe('@dotcom-reliability-kit/logger', () => {
+	it('exports the logger instance', () => {
+		expect(logger).toBeInstanceOf(MockLogger);
+	});
+
+	describe('.Logger', () => {
+		it('aliases lib/logger', () => {
+			expect(logger.Logger).toStrictEqual(MockLogger);
+		});
+	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(logger.default).toStrictEqual(logger);
+		});
+	});
+});

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -1,0 +1,750 @@
+jest.mock('pino', () => ({
+	default: jest.fn(),
+	mockPinoLogger: {
+		flush: jest.fn(),
+		mockCanonicalLevel: jest.fn(),
+		mockDeprecatedCanonocalLevel: jest.fn(),
+		mockErroringLevel: jest.fn().mockImplementation(() => {
+			throw new Error('mock error');
+		}),
+		warn: jest.fn()
+	}
+}));
+const { default: pino, mockPinoLogger } = require('pino');
+pino.mockReturnValue(mockPinoLogger);
+
+jest.mock('@dotcom-reliability-kit/serialize-error', () => jest.fn());
+const serializeError = require('@dotcom-reliability-kit/serialize-error');
+
+// Set environment variables explicitly before importing the logger
+delete process.env.LOG_LEVEL;
+delete process.env.SPLUNK_LOG_LEVEL;
+
+const Logger = require('../../../lib/logger');
+
+describe('@dotcom-reliability-kit/logger/lib/logger', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('exports a class', () => {
+		expect(Logger).toBeInstanceOf(Function);
+		expect(() => {
+			Logger();
+		}).toThrow(/class constructor/i);
+	});
+
+	describe('new Logger(options)', () => {
+		let logger;
+
+		beforeEach(() => {
+			logger = new Logger();
+		});
+
+		it('creates a Pino logger', () => {
+			expect(pino).toBeCalledTimes(1);
+		});
+
+		it('configures the created Pino logger', () => {
+			const pinoOptions = pino.mock.calls[0][0];
+			expect(typeof pinoOptions).toStrictEqual('object');
+			expect(pinoOptions.base).toEqual({});
+			expect(pinoOptions.messageKey).toStrictEqual('message');
+			expect(pinoOptions.timestamp).toStrictEqual(true);
+
+			expect(typeof pinoOptions.formatters).toStrictEqual('object');
+			expect(typeof pinoOptions.formatters.level).toStrictEqual('function');
+			expect(pinoOptions.formatters.level('mock-level')).toEqual({
+				level: 'mock-level'
+			});
+		});
+
+		it('sets the Pino logger level to "debug"', () => {
+			expect(mockPinoLogger.level).toStrictEqual('debug');
+		});
+
+		describe('.baseLogData', () => {
+			it('is set to an empty object', () => {
+				expect(logger.baseLogData).toEqual({});
+			});
+		});
+
+		describe('.logLevel', () => {
+			it('is set to "debug"', () => {
+				expect(logger.logLevel).toEqual('debug');
+			});
+		});
+
+		describe('.transport', () => {
+			it('is set to the created Pino logger', () => {
+				expect(logger.transport).toStrictEqual(mockPinoLogger);
+			});
+		});
+
+		describe('.createChildLogger(baseLogData)', () => {
+			let childLogger;
+
+			beforeEach(() => {
+				jest.spyOn(Logger, 'getLogLevelInfo');
+				logger = new Logger({
+					baseLogData: {
+						isMockParentBaseData: true,
+						isMockChildBaseData: false
+					},
+					logLevel: 'mock parent level',
+					_transport: 'mock parent transport'
+				});
+				childLogger = logger.createChildLogger({
+					isMockChildBaseData: true
+				});
+			});
+
+			it('returns a new child logger with mixed in base log data', () => {
+				expect(childLogger).toBeInstanceOf(Logger);
+				expect(childLogger === logger).toBeFalsy();
+				expect(Logger.getLogLevelInfo).toBeCalledWith('mock parent level');
+				expect(childLogger.transport).toStrictEqual('mock parent transport');
+				expect(childLogger.baseLogData).toEqual({
+					isMockParentBaseData: true,
+					isMockChildBaseData: true
+				});
+			});
+		});
+
+		describe('.addContext(additionalLogData)', () => {
+			beforeEach(() => {
+				mockPinoLogger.warn.mockClear();
+				logger = new Logger({
+					baseLogData: {
+						isExistingBaseLogData: true,
+						isNewBaseLogData: false,
+						mockProperty: 1
+					}
+				});
+				logger.addContext({
+					isNewBaseLogData: true,
+					mockProperty: 2
+				});
+			});
+
+			it('merges the additional data into the `baseLogData` property', () => {
+				expect(logger.baseLogData).toEqual({
+					isExistingBaseLogData: true,
+					isNewBaseLogData: true,
+					mockProperty: 2
+				});
+			});
+
+			it('logs a deprecation warning', () => {
+				expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				expect(mockPinoLogger.warn).toBeCalledWith({
+					event: 'LOGGER_METHOD_DEPRECATED',
+					message: "The 'addContext' logger method is deprecated",
+					deprecatedMethod: 'addContext'
+				});
+			});
+
+			describe('when called a second time', () => {
+				beforeEach(() => {
+					logger.addContext({});
+				});
+
+				it('does not log a second deprecation warning', () => {
+					expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				});
+			});
+		});
+
+		describe('.setContext(contextData)', () => {
+			beforeEach(() => {
+				mockPinoLogger.warn.mockClear();
+				logger = new Logger({
+					baseLogData: {
+						isBaseLogData: true,
+						context: {
+							isBaseLogContextData: true,
+							mockProperty: 1
+						}
+					}
+				});
+				logger.setContext({
+					isContextData: true,
+					mockProperty: 2
+				});
+			});
+
+			it('sets the `baseLogData.context` property', () => {
+				expect(logger.baseLogData.context).toEqual({
+					isContextData: true,
+					mockProperty: 2
+				});
+			});
+
+			it('does not modify other `baseLogData` properties', () => {
+				expect(logger.baseLogData.isBaseLogData).toStrictEqual(true);
+			});
+
+			it('logs a deprecation warning', () => {
+				expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				expect(mockPinoLogger.warn).toBeCalledWith({
+					event: 'LOGGER_METHOD_DEPRECATED',
+					message: "The 'setContext' logger method is deprecated",
+					deprecatedMethod: 'setContext'
+				});
+			});
+
+			describe('when called a second time', () => {
+				beforeEach(() => {
+					logger.setContext({});
+				});
+
+				it('does not log a second deprecation warning', () => {
+					expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				});
+			});
+		});
+
+		describe('.clearContext(contextData)', () => {
+			beforeEach(() => {
+				mockPinoLogger.warn.mockClear();
+				logger = new Logger({
+					baseLogData: {
+						isBaseLogData: true,
+						context: {
+							isBaseLogContextData: true,
+							mockProperty: 1
+						}
+					}
+				});
+				logger.clearContext();
+			});
+
+			it('sets the `baseLogData.context` property to `undefined`', () => {
+				expect(logger.baseLogData.context).toBeUndefined();
+			});
+
+			it('does not modify other `baseLogData` properties', () => {
+				expect(logger.baseLogData.isBaseLogData).toStrictEqual(true);
+			});
+
+			it('logs a deprecation warning', () => {
+				expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				expect(mockPinoLogger.warn).toBeCalledWith({
+					event: 'LOGGER_METHOD_DEPRECATED',
+					message: "The 'clearContext' logger method is deprecated",
+					deprecatedMethod: 'clearContext'
+				});
+			});
+
+			describe('when called a second time', () => {
+				beforeEach(() => {
+					logger.clearContext({});
+				});
+
+				it('does not log a second deprecation warning', () => {
+					expect(mockPinoLogger.warn).toBeCalledTimes(1);
+				});
+			});
+		});
+
+		describe('.log(level, ...logData)', () => {
+			beforeEach(() => {
+				logger = new Logger({
+					baseLogData: {
+						mockBaseData: true
+					}
+				});
+				mockPinoLogger.mockCanonicalLevel.mockClear();
+				mockPinoLogger.warn.mockClear();
+				jest.spyOn(Logger, 'getLogLevelInfo').mockReturnValue({
+					logLevel: 'mockCanonicalLevel',
+					isDeprecated: false
+				});
+				jest.spyOn(Logger, 'zipLogData').mockReturnValue({
+					isMockZippedData: true,
+					message: 'mock zipped message'
+				});
+				logger.log('mockLevel', 'mock message', { mockData: true });
+			});
+
+			it('gets the log level information', () => {
+				expect(Logger.getLogLevelInfo).toBeCalledTimes(1);
+				expect(Logger.getLogLevelInfo).toBeCalledWith('mockLevel');
+			});
+
+			it('zips all the log data alongside the logger `baseLogData` property', () => {
+				expect(Logger.zipLogData).toBeCalledTimes(1);
+				expect(Logger.zipLogData).toBeCalledWith(
+					'mock message',
+					{
+						mockData: true
+					},
+					{
+						mockBaseData: true
+					}
+				);
+			});
+
+			it('calls the relevant log transport method for the level', () => {
+				expect(mockPinoLogger.mockCanonicalLevel).toBeCalledTimes(1);
+				expect(mockPinoLogger.mockCanonicalLevel).toBeCalledWith({
+					isMockZippedData: true,
+					message: 'mock zipped message'
+				});
+			});
+
+			it('does not log a warning', () => {
+				expect(mockPinoLogger.warn).toBeCalledTimes(0);
+			});
+
+			describe('when the log data does not include a message', () => {
+				beforeEach(() => {
+					mockPinoLogger.mockCanonicalLevel.mockClear();
+					jest.spyOn(Logger, 'zipLogData').mockReturnValue({
+						isMockZippedData: true
+					});
+					logger.log('mockLevel', 'mock message', { mockData: true });
+				});
+
+				it('calls the relevant log transport method with a null message property', () => {
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledTimes(1);
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledWith({
+						isMockZippedData: true,
+						message: null
+					});
+				});
+			});
+
+			describe('when the given level is deprecated', () => {
+				beforeEach(() => {
+					mockPinoLogger.mockDeprecatedCanonocalLevel.mockClear();
+					mockPinoLogger.warn.mockClear();
+					Logger.getLogLevelInfo.mockReturnValue({
+						logLevel: 'mockDeprecatedCanonocalLevel',
+						isDeprecated: true
+					});
+					logger.log('mockDeprecatedLevel', 'mock message', { mockData: true });
+				});
+
+				it('calls the relevant log transport method for the level', () => {
+					expect(mockPinoLogger.mockDeprecatedCanonocalLevel).toBeCalledTimes(
+						1
+					);
+					expect(mockPinoLogger.mockDeprecatedCanonocalLevel).toBeCalledWith({
+						isMockZippedData: true,
+						message: 'mock zipped message'
+					});
+				});
+
+				it('logs a deprecation warning', () => {
+					expect(mockPinoLogger.warn).toBeCalledTimes(1);
+					expect(mockPinoLogger.warn).toBeCalledWith({
+						event: 'LOG_LEVEL_DEPRECATED',
+						message: "The 'mockDeprecatedLevel' log level is deprecated",
+						deprecatedLevel: 'mockDeprecatedLevel',
+						suggestedLevel: 'mockDeprecatedCanonocalLevel'
+					});
+				});
+
+				describe('when a deprecated log level is used a second time', () => {
+					beforeEach(() => {
+						logger.log('mockDeprecatedLevel', 'mock message', {
+							mockData: true
+						});
+					});
+
+					it('does not log a second deprecation warning', () => {
+						expect(mockPinoLogger.warn).toBeCalledTimes(1);
+					});
+				});
+			});
+
+			describe('when an error occurs during logging', () => {
+				beforeEach(() => {
+					serializeError.mockClear();
+					serializeError.mockReturnValue({
+						isMockSerializedError: true
+					});
+					jest.spyOn(console, 'log').mockImplementation(() => {});
+					Logger.getLogLevelInfo.mockReturnValue({
+						logLevel: 'mockErroringLevel',
+						isDeprecated: true
+					});
+					logger.log('mockErroringLevel', 'mock message', { mockData: true });
+				});
+
+				it('logs the error information as JSON using `console.log`', () => {
+					// eslint-disable-next-line no-console
+					expect(console.log).toBeCalledTimes(1);
+					// eslint-disable-next-line no-console
+					expect(console.log).toBeCalledWith(
+						JSON.stringify({
+							level: 'error',
+							event: 'LOG_METHOD_FAILURE',
+							message: "Failed to log at level 'mockErroringLevel'",
+							error: {
+								isMockSerializedError: true
+							}
+						})
+					);
+				});
+			});
+		});
+
+		const logMethods = [
+			'data',
+			'debug',
+			'error',
+			'fatal',
+			'info',
+			'silly',
+			'verbose',
+			'warn'
+		];
+		for (const levelMethod of logMethods) {
+			// eslint-disable-next-line no-loop-func
+			describe(`.${levelMethod}(...logData)`, () => {
+				beforeEach(() => {
+					logger.log = jest.fn();
+					logger[levelMethod]('mock message', { mockData: true });
+				});
+
+				it(`calls .log() with a level of '${levelMethod}'`, () => {
+					expect(logger.log).toBeCalledTimes(1);
+				});
+			});
+		}
+
+		describe('.flush()', () => {
+			beforeEach(() => {
+				logger.flush();
+			});
+
+			it('calls the `flush` method of the log transport', () => {
+				expect(mockPinoLogger.flush).toBeCalledTimes(1);
+				expect(mockPinoLogger.flush).toBeCalledWith();
+			});
+
+			describe('when the log transport has no `flush` method', () => {
+				beforeEach(() => {
+					logger = new Logger({
+						_transport: {}
+					});
+					mockPinoLogger.flush = jest.fn();
+					logger.flush();
+				});
+
+				it('does nothing', () => {
+					expect(mockPinoLogger.flush).toBeCalledTimes(0);
+				});
+			});
+		});
+
+		describe('when the `baseLogData` option is set', () => {
+			let baseLogData;
+
+			beforeEach(() => {
+				baseLogData = {
+					isMockBaseData: true,
+					mockSubObject: { isMockSubObject: true }
+				};
+				logger = new Logger({
+					baseLogData
+				});
+			});
+
+			describe('.baseLogData', () => {
+				it('is set to the value of the `baseLogData` option', () => {
+					expect(logger.baseLogData).toEqual({
+						isMockBaseData: true,
+						mockSubObject: { isMockSubObject: true }
+					});
+				});
+
+				it('is a deep cloned copy of the original option', () => {
+					baseLogData.a = 1;
+					baseLogData.mockSubObject.a = 1;
+					expect(logger.baseLogData.a).toBeUndefined();
+					expect(logger.baseLogData.mockSubObject.a).toBeUndefined();
+				});
+			});
+		});
+
+		describe('when a `transport` option is set', () => {
+			beforeEach(() => {
+				pino.mockClear();
+				logger = new Logger({
+					_transport: 'mock transport'
+				});
+			});
+
+			it('does not create a Pino logger', () => {
+				expect(pino).toBeCalledTimes(0);
+			});
+
+			describe('.transport', () => {
+				it('is set to the value of the `transport` option', () => {
+					expect(logger.transport).toStrictEqual('mock transport');
+				});
+			});
+		});
+
+		describe('when the `withTimestamps` option is set to `false`', () => {
+			beforeEach(() => {
+				pino.mockReset();
+				pino.mockReturnValue(mockPinoLogger);
+				logger = new Logger({
+					withTimestamps: false
+				});
+			});
+
+			it('turns off timestamps in the created Pino logger', () => {
+				const pinoOptions = pino.mock.calls[0][0];
+				expect(pinoOptions.timestamp).toStrictEqual(false);
+			});
+		});
+
+		describe('when the `logLevel` option is set', () => {
+			beforeEach(() => {
+				process.env.LOG_LEVEL = 'mockEnvLogLevel';
+				process.env.SPLUNK_LOG_LEVEL = 'mockEnvSplunkLogLevel';
+				jest.spyOn(Logger, 'getLogLevelInfo').mockReturnValue({
+					logLevel: 'mockCanonicalLevel'
+				});
+				logger = new Logger({
+					logLevel: 'mockLevel'
+				});
+			});
+
+			it('gets the log level information', () => {
+				expect(Logger.getLogLevelInfo).toBeCalledTimes(1);
+				expect(Logger.getLogLevelInfo).toBeCalledWith('mockLevel');
+			});
+
+			it('sets the Pino logger level to the `logLevel` of the log level information', () => {
+				expect(mockPinoLogger.level).toStrictEqual('mockCanonicalLevel');
+			});
+
+			describe('.logLevel', () => {
+				it('is set to the `logLevel` of the log level information', () => {
+					expect(logger.logLevel).toStrictEqual('mockCanonicalLevel');
+				});
+			});
+		});
+
+		describe('when a `LOG_LEVEL` environment variable is set', () => {
+			beforeEach(() => {
+				process.env.LOG_LEVEL = 'mockEnvLogLevel';
+				process.env.SPLUNK_LOG_LEVEL = 'mockEnvSplunkLogLevel';
+				jest.spyOn(Logger, 'getLogLevelInfo').mockReturnValue({
+					logLevel: 'mockCanonicalLevel'
+				});
+				logger = new Logger();
+			});
+
+			it('gets the log level information based on the environment variable', () => {
+				expect(Logger.getLogLevelInfo).toBeCalledTimes(1);
+				expect(Logger.getLogLevelInfo).toBeCalledWith('mockEnvLogLevel');
+			});
+		});
+
+		describe('when a `SPLUNK_LOG_LEVEL` environment variable is set', () => {
+			beforeEach(() => {
+				delete process.env.LOG_LEVEL;
+				process.env.SPLUNK_LOG_LEVEL = 'mockEnvSplunkLogLevel';
+				jest.spyOn(Logger, 'getLogLevelInfo').mockReturnValue({
+					logLevel: 'mockCanonicalLevel'
+				});
+				logger = new Logger();
+			});
+
+			it('gets the log level information based on the environment variable', () => {
+				expect(Logger.getLogLevelInfo).toBeCalledTimes(1);
+				expect(Logger.getLogLevelInfo).toBeCalledWith('mockEnvSplunkLogLevel');
+			});
+		});
+	});
+
+	describe('Logger.getLogLevelInfo(level)', () => {
+		describe('when `level` is "data"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('data')).toEqual({
+					logLevel: 'debug',
+					isDeprecated: true
+				});
+			});
+		});
+
+		describe('when `level` is "debug"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('debug')).toEqual({
+					logLevel: 'debug',
+					isDeprecated: false
+				});
+			});
+		});
+
+		describe('when `level` is "error"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('error')).toEqual({
+					logLevel: 'error',
+					isDeprecated: false
+				});
+			});
+		});
+
+		describe('when `level` is "fatal"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('fatal')).toEqual({
+					logLevel: 'fatal',
+					isDeprecated: false
+				});
+			});
+		});
+
+		describe('when `level` is "info"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('info')).toEqual({
+					logLevel: 'info',
+					isDeprecated: false
+				});
+			});
+		});
+
+		describe('when `level` is "silly"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('silly')).toEqual({
+					logLevel: 'debug',
+					isDeprecated: true
+				});
+			});
+		});
+
+		describe('when `level` is "verbose"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('verbose')).toEqual({
+					logLevel: 'debug',
+					isDeprecated: true
+				});
+			});
+		});
+
+		describe('when `level` is "warn"', () => {
+			it('returns the expected log level information', () => {
+				expect(Logger.getLogLevelInfo('warn')).toEqual({
+					logLevel: 'warn',
+					isDeprecated: false
+				});
+			});
+		});
+
+		describe('when `level` is invalid', () => {
+			it('returns default log level information', () => {
+				expect(Logger.getLogLevelInfo('unknown')).toEqual({
+					logLevel: 'info',
+					isDeprecated: true
+				});
+			});
+		});
+	});
+
+	describe('Logger.zipLogData(...logData)', () => {
+		it('zips multiple log data items into a single object', () => {
+			expect(Logger.zipLogData({ a: 1 }, { b: 2 }, { c: 3 })).toEqual({
+				a: 1,
+				b: 2,
+				c: 3
+			});
+		});
+
+		it('returns a deep cloned copy of the resulting object', () => {
+			const object1 = { a: 1, sub: { a: true } };
+			const object2 = { b: 2, sub: { b: true } };
+			const zip = Logger.zipLogData(object1, object2);
+			expect(zip).not.toStrictEqual(object1);
+			expect(zip).not.toStrictEqual(object2);
+			expect(object1.b).toBeUndefined();
+			expect(object2.a).toBeUndefined();
+			object1.newProperty = true;
+			object1.sub.newProperty = true;
+			object2.newProperty = true;
+			object2.sub.newProperty = true;
+			expect(zip.newProperty).toBeUndefined();
+			expect(zip.sub.newProperty).toBeUndefined();
+		});
+
+		describe('when there are property conflicts between objects', () => {
+			it('prioritizes the first instance of that property', () => {
+				expect(Logger.zipLogData({ a: 1 }, { a: 2 }, { a: 3 })).toEqual({
+					a: 1
+				});
+			});
+		});
+
+		describe('when one of the log data items is a string', () => {
+			it('adds it as a `message` property', () => {
+				expect(Logger.zipLogData('mock message', { a: 1 })).toEqual({
+					message: 'mock message',
+					a: 1
+				});
+			});
+
+			describe('when there are multiple strings', () => {
+				it('prioritizes the first', () => {
+					expect(Logger.zipLogData('message 1', 'message 2')).toEqual({
+						message: 'message 1'
+					});
+				});
+			});
+		});
+
+		describe('when one of the log data items is an error object', () => {
+			it('serializes it and adds it as an `error` property', () => {
+				serializeError.mockClear();
+				serializeError.mockReturnValueOnce('mock serialized error');
+				const error = new Error('mock error');
+
+				expect(Logger.zipLogData(error)).toEqual({
+					error: 'mock serialized error'
+				});
+				expect(serializeError).toBeCalledTimes(1);
+				expect(serializeError).toBeCalledWith(error);
+			});
+
+			describe('when there are multiple errors', () => {
+				it('prioritizes the first', () => {
+					serializeError.mockImplementation((error) => {
+						return `mock serialized ${error.message}`;
+					});
+					const error1 = new Error('error 1');
+					const error2 = new Error('error 2');
+					expect(Logger.zipLogData(error1, error2)).toEqual({
+						error: 'mock serialized error 1'
+					});
+				});
+			});
+		});
+
+		describe('when a mix of data types is used', () => {
+			it('correctly zips all of them', () => {
+				serializeError.mockReturnValueOnce('mock serialized error');
+				const error = new Error('mock error');
+
+				expect(
+					Logger.zipLogData('mock message', error, { a: 1 }, { b: 2 })
+				).toEqual({
+					message: 'mock message',
+					error: 'mock serialized error',
+					a: 1,
+					b: 2
+				});
+			});
+		});
+	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(Logger.default).toStrictEqual(Logger);
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,7 @@
 		"packages/crash-handler": {},
 		"packages/errors": {},
 		"packages/log-error": {},
+		"packages/logger": {},
 		"packages/middleware-log-errors": {},
 		"packages/middleware-render-error-info": {},
 		"packages/serialize-error": {},


### PR DESCRIPTION
> **Note**
> This is an experimental piece of work which may never make it into production. There's no agreed timeline for migrating things to this new logger - we want to be careful about introducing too many Reliability Kit migrations at once.

This adds a new experimental package which aims to be a near drop-in replacement for n-logger and a replacement for n-serverless-logger with a little work. I spent a lot of time working on a suite of end-to-end tests to ensure that it's as compatible as possible.

I think the next step will be to release a beta version of this package (v0.1.0) so that we can test it in some non-critical applications.

I tried to approach the build of this in the same way I would a package that'd definitely go into production, because writing tests and documentation after the fact is always difficult. Despite it looking relatively polished, this can be picked apart and rethought as much as we need to.

Reviewing
---------

This review can happen more slowly than others because we're adding something experimental without having planned the approach as a team. I worked on this in 10% time because I was interested in the problem space and wanted a downtime project where I could focus a lot on testing.

I think it'd also be good to get some feedback from people outside of the CP Reliability team because they're closer to how their apps do logging.

Areas to focus on are:

  * Are the migration guides clear enough. Using these alone, do you think you could migrate an application away from n-logger or n-serverless-logger?

  * Do you agree with the deprecation decisions and where there _is_ a breaking change between libraries?

  * Are the end-to-end tests thorough enough? I think these are the most important part of the library because they help us be sure that we're as compatible as possible. My intention is that if we find use cases for n-logger which we're _not_ compatible with then we should add a new test case.

Some fun stats
--------------

I'm quite pleased already with the difference between this and n-logger plus n-serverless-logger (both of which it replaces) in terms of some code metrics. These aren't perfect measurements but they do give an idea of what the maintenance difference is.

stat | n-logger | n-serverless-logger | new package | diff
-----|----------|---------------------|-------------|-----
lines (source) | `230` | `221` | `177` | `-274`
lines (tests) | `612` | `140` | `1292` | `+540`
lines (comments) | `47` | `33` | `378` | `+298`
ratio (source:tests) | `1:3` | `1:2` | `1:7` | -
ratio (source:comment) | `5:1` | `7:1` | `1:2` | -

Next steps
----------

  1. Release a beta version of this package and test it in some non-critical applications that this team owns

  2. Provide a migration path for n-mask-logger, because I think this work is only worth doing if we can deprecate all three logging modules. I have some ideas for how we could do this but didn't want this branch to get any bigger before we have some more eyes on it
