### PR TITLE
Publish TypeScript type definitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,9 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
             ${HOME}/.npmrc
       - run:
+          name: Build packages
+          command: npm run build
+      - run:
           name: NPM publish
           command: ./scripts/circleci-publish.sh
 
@@ -138,6 +141,9 @@ jobs:
           name: Set npm auth token
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
             ${HOME}/.npmrc
+      - run:
+          name: Build packages
+          command: npm run build
       - run:
           name: NPM publish
           command: ./scripts/circleci-publish.sh --tag=prerelease

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.d.ts
+*.d.ts.map
 logos/dist
 node_modules/
 coverage

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,6 +22,7 @@ We're glad you want to contribute to Reliability Kit!
     * [Pull request scope](#pull-request-scope)
     * [Merging pull requests](#merging-pull-requests)
   * [Releasing](#releasing)
+    * [Generated files](#generated-files)
     * [Correcting releases](#correcting-releases)
 
 
@@ -213,6 +214,16 @@ When a commit with the `feat` or `fix` [commit type prefix](#commit-type-prefixe
 If the PR is left alone, it will continue to be updated with new releases as more commits appear on the `main` branch.
 
 Before approving and merging the release PR, make sure you review it. You need to check the package versions that it updates to make sure you’re only releasing the things you expect.
+
+### Generated files
+
+Before publishing npm packages we do generate TypeScript type declaration files (`.d.ts`) so that TypeScript-based project which use Reliability Kit will get correct type hinting.
+
+If a release has caused issues with Type hinting or TypeScript-based projects compiling, then you can inspect the generated files by running the build command locally and viewing the `.d.ts` files in your editor:
+
+```
+npm run build
+```
 
 ### Correcting releases
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -217,7 +217,7 @@ Before approving and merging the release PR, make sure you review it. You need t
 
 ### Generated files
 
-Before publishing npm packages we do generate TypeScript type declaration files (`.d.ts`) so that TypeScript-based project which use Reliability Kit will get correct type hinting.
+Before publishing npm packages we do generate TypeScript type declaration files (`.d.ts`) so that TypeScript-based projects which use Reliability Kit will get correct type hinting.
 
 If a release has caused issues with Type hinting or TypeScript-based projects compiling, then you can inspect the generated files by running the build command locally and viewing the `.d.ts` files in your editor:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,6 +26,8 @@ The combination of the above allows us to work on and publish the packages in th
 
 In terms of TypeScript, the key benefits are having type safety and type hinting in your editor. We can achieve both of these without writing TypeScript. Using [JavaScript with JSDoc comments to document types](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html), VSCode (used by the majority of our engineers) offers the same level of type hinting as it does with TypeScript. It's also possible to run the TypeScript type checker against JavaScript code to verify that everything is type safe (e.g. using `tsc --checkJS`).
 
+In order to be useful for TypeScript projects, we do still need to publish our modules with TypeScript type declaration files (`.d.ts`). We made this an automated step during publishing and when authoring modules you should still write JavaScript and JSDoc.
+
 ### CommonJS
 
 If we wanted to support ES Modules (which _is_ the future direction I think we'll all go in) then we'd need to choose between one of the following, neither of which seems preferable to just sticking with CommonJS for now.

--- a/jsconfig.build.json
+++ b/jsconfig.build.json
@@ -1,0 +1,17 @@
+{
+	"extends": "./jsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"emitDeclarationOnly": true,
+		"noEmit": false,
+		"removeComments": true,
+		"useDefineForClassFields": true,
+	},
+	"exclude": [
+		"**/test/**/*"
+	],
+	"include": [
+		"packages/**/*.js"
+	]
+}

--- a/jsconfig.build.json
+++ b/jsconfig.build.json
@@ -5,8 +5,7 @@
 		"declarationMap": true,
 		"emitDeclarationOnly": true,
 		"noEmit": false,
-		"removeComments": true,
-		"useDefineForClassFields": true,
+		"removeComments": true
 	},
 	"exclude": [
 		"**/test/**/*"

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,7 @@
 		"allowJs": true,
 		"checkJs": true,
 		"module": "commonjs",
+		"noEmit": true,
 		"resolveJsonModule": true,
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"allowJs": true,
 		"checkJs": true,
 		"module": "commonjs",
 		"noEmit": true,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "create-package": "./scripts/create-package.js",
     "lint": "npm run lint:eslint && npm run lint:tsc",
     "lint:eslint": "eslint .",
-    "lint:tsc": "tsc --project ./jsconfig.json",
+    "lint:tsc": "npm run clean && tsc --project ./jsconfig.json",
+    "clean": "npm run clean:types",
+    "clean:types": "find ./packages -name \"*.d.ts*\" | xargs rm",
+    "build": "npm run clean && npm run build:types",
+    "build:types": "tsc --project ./jsconfig.build.json",
     "test": "jest --silent",
     "prepare": "husky install",
     "postinstall": "npm run build:logos"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-package": "./scripts/create-package.js",
     "lint": "npm run lint:eslint && npm run lint:tsc",
     "lint:eslint": "eslint .",
-    "lint:tsc": "tsc --noEmit --project ./jsconfig.json",
+    "lint:tsc": "tsc --project ./jsconfig.json",
     "test": "jest --silent",
     "prepare": "husky install",
     "postinstall": "npm run build:logos"

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/app-info
- */
-
 const path = require('path');
 
 /**
@@ -44,61 +40,51 @@ function normalizePackageName(name) {
 const systemCode =
 	process.env.SYSTEM_CODE || getSystemCodeFromPackage(process.cwd()) || null;
 
-module.exports = {
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {(string | null)}
-	 */
+/**
+ * @typedef {object} AppInfo
+ * @property {string | null} commitHash
+ *     The application commit hash.
+ * @property {string} environment
+ *     The application environment.
+ * @property {string | null} region
+ *     The region the application is running in.
+ * @property {string | null} releaseDate
+ *     The date and time that the application was last released at.
+ * @property {string | null} releaseVersion
+ *     The last released version of the application.
+ * @property {string | null} systemCode
+ *     The application system code.
+ */
+
+/**
+ * @type {AppInfo}
+ */
+const appInfo = {
 	get commitHash() {
 		return process.env.HEROKU_SLUG_COMMIT || null;
 	},
 
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {string}
-	 */
 	get environment() {
 		return process.env.NODE_ENV || 'development';
 	},
 
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {(string | null)}
-	 */
 	get region() {
 		return process.env.REGION || null;
 	},
 
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {(string | null)}
-	 */
 	get releaseDate() {
 		return process.env.HEROKU_RELEASE_CREATED_AT || null;
 	},
 
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {(string | null)}
-	 */
 	get releaseVersion() {
 		return process.env.HEROKU_RELEASE_VERSION || null;
 	},
 
-	/**
-	 * @readonly
-	 * @access public
-	 * @type {(string | null)}
-	 */
 	get systemCode() {
 		return systemCode;
 	}
 };
 
-// @ts-ignore
+module.exports = appInfo;
+
 module.exports.default = module.exports;

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -40,51 +40,50 @@ function normalizePackageName(name) {
 const systemCode =
 	process.env.SYSTEM_CODE || getSystemCodeFromPackage(process.cwd()) || null;
 
-/**
- * @typedef {object} AppInfo
- * @property {string | null} commitHash
- *     The application commit hash.
- * @property {string} environment
- *     The application environment.
- * @property {string | null} region
- *     The region the application is running in.
- * @property {string | null} releaseDate
- *     The date and time that the application was last released at.
- * @property {string | null} releaseVersion
- *     The last released version of the application.
- * @property {string | null} systemCode
- *     The application system code.
- */
+module.exports = {
+	/**
+	 * The application commit hash.
+	 *
+	 * @type {string | null}
+	 */
+	commitHash: process.env.HEROKU_SLUG_COMMIT || null,
 
-/**
- * @type {AppInfo}
- */
-const appInfo = {
-	get commitHash() {
-		return process.env.HEROKU_SLUG_COMMIT || null;
-	},
+	/**
+	 * The application environment.
+	 *
+	 * @type {string}
+	 */
+	environment: process.env.NODE_ENV || 'development',
 
-	get environment() {
-		return process.env.NODE_ENV || 'development';
-	},
+	/**
+	 * The region the application is running in.
+	 *
+	 * @type {string | null}
+	 */
+	region: process.env.REGION || null,
 
-	get region() {
-		return process.env.REGION || null;
-	},
+	/**
+	 * The date and time that the application was last released at.
+	 *
+	 * @type {string | null}
+	 */
+	releaseDate: process.env.HEROKU_RELEASE_CREATED_AT || null,
 
-	get releaseDate() {
-		return process.env.HEROKU_RELEASE_CREATED_AT || null;
-	},
+	/**
+	 * The last released version of the application.
+	 *
+	 * @type {string | null}
+	 */
+	releaseVersion: process.env.HEROKU_RELEASE_VERSION || null,
 
-	get releaseVersion() {
-		return process.env.HEROKU_RELEASE_VERSION || null;
-	},
-
-	get systemCode() {
-		return systemCode;
-	}
+	/**
+	 * The application system code.
+	 *
+	 * @type {string | null}
+	 */
+	systemCode
 };
 
-module.exports = appInfo;
-
+// @ts-ignore
 module.exports.default = module.exports;
+Object.freeze(module.exports);

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -44,6 +44,7 @@ module.exports = {
 	/**
 	 * The application commit hash.
 	 *
+	 * @readonly
 	 * @type {string | null}
 	 */
 	commitHash: process.env.HEROKU_SLUG_COMMIT || null,
@@ -51,6 +52,7 @@ module.exports = {
 	/**
 	 * The application environment.
 	 *
+	 * @readonly
 	 * @type {string}
 	 */
 	environment: process.env.NODE_ENV || 'development',
@@ -58,6 +60,7 @@ module.exports = {
 	/**
 	 * The region the application is running in.
 	 *
+	 * @readonly
 	 * @type {string | null}
 	 */
 	region: process.env.REGION || null,
@@ -65,6 +68,7 @@ module.exports = {
 	/**
 	 * The date and time that the application was last released at.
 	 *
+	 * @readonly
 	 * @type {string | null}
 	 */
 	releaseDate: process.env.HEROKU_RELEASE_CREATED_AT || null,
@@ -72,6 +76,7 @@ module.exports = {
 	/**
 	 * The last released version of the application.
 	 *
+	 * @readonly
 	 * @type {string | null}
 	 */
 	releaseVersion: process.env.HEROKU_RELEASE_VERSION || null,
@@ -79,6 +84,7 @@ module.exports = {
 	/**
 	 * The application system code.
 	 *
+	 * @readonly
 	 * @type {string | null}
 	 */
 	systemCode

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/errors/lib/data-store-error
- */
-
 const OperationalError = require('./operational-error');
 
 /**

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -6,7 +6,7 @@ const OperationalError = require('./operational-error');
 class DataStoreError extends OperationalError {
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	name = 'DataStoreError';

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -22,28 +22,28 @@ const STATUS_CODES = require('http').STATUS_CODES;
 class HttpError extends OperationalError {
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	name = 'HttpError';
 
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {number}
 	 */
 	statusCode = 500;
 
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	statusMessage = STATUS_CODES[500];
 
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {number}
 	 */
 	get status() {
@@ -95,7 +95,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Reserved keys that should not appear in `HttpError.prototype.data`.
 	 *
-	 * @access private
+	 * @protected
 	 * @type {Array<string>}
 	 */
 	static reservedKeys = [
@@ -107,7 +107,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Normalize an HTTP status code.
 	 *
-	 * @access private
+	 * @protected
 	 * @param {number} statusCode
 	 *     The HTTP status code to normalize.
 	 * @returns {number}
@@ -124,7 +124,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Get the HTTP message for a given status code.
 	 *
-	 * @access private
+	 * @private
 	 * @param {number} statusCode
 	 *     The HTTP status code to get a message for.
 	 * @returns {string}

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/errors/lib/http-error
- */
-
 const OperationalError = require('./operational-error');
 
 /**

--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -1,7 +1,9 @@
-exports.DataStoreError = require('./data-store-error');
-exports.HttpError = require('./http-error');
-exports.OperationalError = require('./operational-error');
-exports.UpstreamServiceError = require('./upstream-service-error');
-exports.UserInputError = require('./user-input-error');
+module.exports = {
+	DataStoreError: require('./data-store-error'),
+	HttpError: require('./http-error'),
+	OperationalError: require('./operational-error'),
+	UpstreamServiceError: require('./upstream-service-error'),
+	UserInputError: require('./user-input-error')
+};
 
-exports.default = exports;
+module.exports.default = module.exports;

--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/errors
- */
-
 exports.DataStoreError = require('./data-store-error');
 exports.HttpError = require('./http-error');
 exports.OperationalError = require('./operational-error');

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -16,7 +16,7 @@
 class OperationalError extends Error {
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	name = 'OperationalError';
@@ -25,7 +25,7 @@ class OperationalError extends Error {
 	 * Whether the error is operational.
 	 *
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {boolean}
 	 */
 	isOperational = true;
@@ -34,7 +34,7 @@ class OperationalError extends Error {
 	 * A machine-readable error code which identifies the specific type of error.
 	 *
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	code = 'UNKNOWN';
@@ -44,7 +44,7 @@ class OperationalError extends Error {
 	 * If this error is caused by one or more dependencies, include their system code here.
 	 *
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {Array<string>}
 	 */
 	relatesToSystems = [];
@@ -53,7 +53,7 @@ class OperationalError extends Error {
 	 * The root cause error instance.
 	 *
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {Error|null}
 	 */
 	cause = null;
@@ -62,7 +62,7 @@ class OperationalError extends Error {
 	 * Additional error information.
 	 *
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {Object<string, any>}
 	 */
 	data = {};
@@ -106,7 +106,7 @@ class OperationalError extends Error {
 	/**
 	 * Reserved keys that should not appear in `OperationalError.prototype.data`.
 	 *
-	 * @access private
+	 * @protected
 	 * @type {Array<string>}
 	 */
 	static reservedKeys = ['code', 'message', 'relatesToSystems', 'cause'];
@@ -129,7 +129,7 @@ class OperationalError extends Error {
 	/**
 	 * Normalize a machine-readable error code.
 	 *
-	 * @access private
+	 * @private
 	 * @param {string} code
 	 *     The error code to normalize.
 	 * @returns {string}

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -1,8 +1,4 @@
 /**
- * @module @dotcom-reliability-kit/errors/lib/operational-error
- */
-
-/**
  * @typedef {object} OperationalErrorData
  * @property {string} [code]
  *     A machine-readable error code which identifies the specific type of error.

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -6,7 +6,7 @@ const HttpError = require('./http-error');
 class UpstreamServiceError extends HttpError {
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	name = 'UpstreamServiceError';

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/errors/lib/upstream-service-error
- */
-
 const HttpError = require('./http-error');
 
 /**

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/errors/lib/user-input-error
- */
-
 const HttpError = require('./http-error');
 
 /**

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -6,7 +6,7 @@ const HttpError = require('./http-error');
 class UserInputError extends HttpError {
 	/**
 	 * @readonly
-	 * @access public
+	 * @public
 	 * @type {string}
 	 */
 	name = 'UserInputError';

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -117,8 +117,10 @@ function logUnhandledError({ error, includeHeaders, request }) {
 	});
 }
 
-exports.logHandledError = logHandledError;
-exports.logRecoverableError = logRecoverableError;
-exports.logUnhandledError = logUnhandledError;
+module.exports = {
+	logHandledError,
+	logRecoverableError,
+	logUnhandledError
+};
 
-exports.default = exports;
+module.exports.default = module.exports;

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -24,7 +24,7 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
 /**
  * Log an error object with optional request information.
  *
- * @access private
+ * @private
  * @param {ErrorLoggingOptions & InternalErrorLoggingOptions} options
  *     The data to log.
  * @returns {void}
@@ -53,7 +53,7 @@ function logError({ error, event, includeHeaders, level = 'error', request }) {
 /**
  * Get a human readable error message from a serialized error object.
  *
- * @access private
+ * @private
  * @param {serializeError.SerializedError} serializedError
  *     The serialized error to get a message for.
  * @returns {string}
@@ -68,7 +68,7 @@ function extractErrorMessage(serializedError) {
 /**
  * Log a handled error.
  *
- * @access public
+ * @public
  * @param {ErrorLoggingOptions} options
  *     The data to log.
  * @returns {void}
@@ -85,7 +85,7 @@ function logHandledError({ error, includeHeaders, request }) {
 /**
  * Log a recoverable error.
  *
- * @access public
+ * @public
  * @param {ErrorLoggingOptions} options
  *     The data to log.
  * @returns {void}
@@ -103,7 +103,7 @@ function logRecoverableError({ error, includeHeaders, request }) {
 /**
  * Log an unhandled error.
  *
- * @access public
+ * @public
  * @param {ErrorLoggingOptions} options
  *     The data to log.
  * @returns {void}

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/log-error
- */
-
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const logger = require('@financial-times/n-logger').default;
 const serializeError = require('@dotcom-reliability-kit/serialize-error');

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/middleware-log-errors
- */
-
 const { logHandledError } = require('@dotcom-reliability-kit/log-error');
 
 /**

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -9,7 +9,7 @@ const { logHandledError } = require('@dotcom-reliability-kit/log-error');
 /**
  * Create a middleware function to log errors.
  *
- * @access public
+ * @public
  * @param {ErrorLoggingOptions} [options = {}]
  *     Options to configure the middleware.
  * @returns {import('express').ErrorRequestHandler}

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -6,7 +6,7 @@ const serializeError = require('@dotcom-reliability-kit/serialize-error');
 /**
  * Create a middleware function to render an error info page.
  *
- * @access public
+ * @public
  * @returns {import('express').ErrorRequestHandler}
  *     Returns error info rendering middleware.
  */

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/middleware-render-error-info
- */
-
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const renderErrorPage = require('./render-error-page');

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -26,7 +26,7 @@ const CONCEALED_VALUE_MESSAGE =
 /**
  * Render an HTML error info page.
  *
- * @access private
+ * @private
  * @param {ErrorRenderingOptions} options
  *     Options which impact the rendering of the page.
  * @returns {string}
@@ -49,7 +49,7 @@ function renderErrorPage({ request, response, serializedError }) {
 /**
  * Render a serialized error to HTML.
  *
- * @access private
+ * @private
  * @param {import('@dotcom-reliability-kit/serialize-error').SerializedError} error
  *     The error information to render.
  * @returns {string}
@@ -144,7 +144,7 @@ function renderError(error) {
 /**
  * Render an HTTP request to HTML.
  *
- * @access private
+ * @private
  * @param {import('express').Request} request
  *     The request information to render.
  * @returns {string}
@@ -190,7 +190,7 @@ function renderRequest(request) {
 /**
  * Render an HTTP response to HTML.
  *
- * @access private
+ * @private
  * @param {import('express').Response} response
  *     The responses information to render.
  * @returns {string}
@@ -225,7 +225,7 @@ function renderResponse(response) {
 /**
  * Render a page section.
  *
- * @access private
+ * @private
  * @param {object} section
  *     The section information.
  * @param {string} section.id
@@ -254,7 +254,7 @@ function renderSection({ id, title, body, fields }) {
 /**
  * Render a warning message.
  *
- * @access private
+ * @private
  * @param {object} warning
  *     The warning information.
  * @param {string} warning.title
@@ -281,7 +281,7 @@ function renderWarning({ title, body }) {
 /**
  * Render a definition list title and value.
  *
- * @access private
+ * @private
  * @param {Field} field
  *     The field information.
  * @returns {string}
@@ -306,7 +306,7 @@ function renderField({ label, helpText, value, formatter = escape }) {
 /**
  * Render a block of code.
  *
- * @access private
+ * @private
  * @param {string} block
  *     The value to wrap in a `<pre>` element.
  * @returns {string}
@@ -319,7 +319,7 @@ function renderCodeBlock(block) {
 /**
  * Convert a boolean into a "Yes" or "No" string.
  *
- * @access private
+ * @private
  * @param {boolean} boolean
  *     The boolean to render.
  * @param {string} trueModifier
@@ -342,7 +342,7 @@ function renderBoolean(
 /**
  * Render a list of systems, linking them to Biz Ops.
  *
- * @access private
+ * @private
  * @param {Array<string>} systems
  *     An array of system codes.
  * @returns {string}
@@ -355,7 +355,7 @@ function renderBizOpsSystems(systems) {
 /**
  * Render a single Biz Ops system.
  *
- * @access private
+ * @private
  * @param {string} systemCode
  *     The system code to link to.
  * @returns {string}
@@ -373,7 +373,7 @@ function renderBizOpsSystem(systemCode) {
 /**
  * Render a value as JSON in a <pre> element.
  *
- * @access private
+ * @private
  * @param {any} value
  *     The value to stringify and render.
  * @returns {string}
@@ -386,7 +386,7 @@ function renderAsJson(value) {
 /**
  * Escape a value for use in HTML.
  *
- * @access private
+ * @private
  * @param {any} value
  *     The value to escape.
  * @returns {string}

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-error-page
- */
-
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const entities = require('entities');
 const renderLayout = require('./render-layout');

--- a/packages/middleware-render-error-info/lib/render-layout.js
+++ b/packages/middleware-render-error-info/lib/render-layout.js
@@ -1,7 +1,3 @@
-/**
- * @module @dotcom-reliability-kit/middleware-render-error-info/lib/render-layout
- */
-
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const fs = require('fs');
 

--- a/packages/middleware-render-error-info/lib/render-layout.js
+++ b/packages/middleware-render-error-info/lib/render-layout.js
@@ -30,7 +30,7 @@ const styles = fs.readFileSync(`${__dirname}/render-error-page.css`, 'utf-8');
 /**
  * Render an HTML error info page.
  *
- * @access private
+ * @private
  * @param {LayoutRenderingOptions} options
  *     Options which impact the rendering of the page.
  * @returns {string}
@@ -112,7 +112,7 @@ function renderLayout({ body, request, title }) {
 /**
  * Get an Origami Build Service bundle URL.
  *
- * @access private
+ * @private
  * @param {'css'|'js'} type
  *     The type of bundle to return a URL for.
  * @returns {string}

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -1,8 +1,4 @@
 /**
- * @module @dotcom-reliability-kit/serialize-error
- */
-
-/**
  * @typedef {object} SerializedError
  * @property {string} name
  *     The name of the class that the error is an instance of.

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -23,7 +23,7 @@
 /**
  * Serialize an error object so that it can be consistently logged or output as JSON.
  *
- * @access public
+ * @public
  * @param {(string | Error & Record<string, any>)} error
  *     The error object to serialize.
  * @returns {SerializedError}
@@ -91,7 +91,7 @@ function serializeError(error) {
 /**
  * Create a new serialized error object.
  *
- * @access private
+ * @private
  * @param {Record<string, any>} properties
  *     The properties of the serialized error.
  * @returns {SerializedError}

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -1,8 +1,4 @@
 /**
- * @module @dotcom-reliability-kit/serialize-request
- */
-
-/**
  * @typedef {import('express').Request | import('http').IncomingMessage & {route: object, params: object}} Request
  */
 

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -41,7 +41,7 @@
 /**
  * The default request headers to include in the serialization.
  *
- * @access private
+ * @private
  * @type {Array<string>}
  */
 const DEFAULT_INCLUDED_HEADERS = ['accept', 'content-type'];
@@ -49,7 +49,7 @@ const DEFAULT_INCLUDED_HEADERS = ['accept', 'content-type'];
 /**
  * Serialize a request object so that it can be consistently logged or output as JSON.
  *
- * @access public
+ * @public
  * @param {(string | Request)} request
  *     The request object to serialize. Either an Express Request object or a
  *     built-in Node.js IncomingMessage object.
@@ -128,7 +128,7 @@ function serializeRequest(request, options = {}) {
 /**
  * Serialize request headers.
  *
- * @access private
+ * @private
  * @param {Record<string, any>} headers
  *     The headers object to serialize.
  * @param {Array<string>} includeHeaders
@@ -147,7 +147,7 @@ function serializeHeaders(headers, includeHeaders) {
 /**
  * Create a new serialized request object.
  *
- * @access private
+ * @private
  * @param {Record<string, any>} properties
  *     The properties of the serialized error.
  * @returns {SerializedRequest}

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -64,11 +64,7 @@ This module is part of [FT.com Reliability Kit](https://github.com/Financial-Tim
 	await fs.mkdir(libPath);
 	await fs.writeFile(
 		path.join(libPath, 'index.js'),
-		`/**
- * @module @dotcom-reliability-kit/${name}
- */
-
-module.exports = {};
+		`module.exports = {};
 `
 	);
 


### PR DESCRIPTION
This ensures that when we publish to npm, we generate and include TypeScript type declarations (`.d.ts`) with our modules. These are generated from the JSDoc and map 1:1 with what we've written. It's annoying that we had to do this but I think it makes the most sense when you consider the alternatives.

## Why

@jamesr101 spotted today that with a full TypeScript-based projects, he was getting type errors and no type hinting in VSCode. I tried a basic TypeScript project and it works fine unless you start configuring with a `tsconfig.json` file. Once you add that in, type hinting in VSCode seems to break. This is why we haven't spotted this before – our initial testing was too basic.

I found out that this is a known issue and that JavaScript-based projects which use JSDoc types are not actually usable by TypeScript projects without some extra configuration:

  * https://github.com/microsoft/TypeScript/issues/19145
  * https://github.com/microsoft/TypeScript/issues/29824

I decided that the best solution would be to generate type declarations just before publishing to npm so that our types are picked up in projects that depend on Reliability Kit.

## Alternatives

I considered a few other ways we could address this:

1. **Move this project fully over to TypeScript:** I think this would be an annoying and large job. I also stand by the fact that it's nice that whatever we write is exactly what's running on our servers. If we want to explore this then I think it's a separate piece of work and not something we should take on in a rush to fix the immediate issue

2. **Require that TypeScript-based projects configure themselves to suit Reliability Kit:** it's possible to get around this by adding `"maxNodeModuleJsDepth": 2` to your `.tsconfig.json` file. This tells TypeScript to look two levels deep in `node_modules` for JSDoc-based type declarations. Something feels off about requiring specific configurations just to use Reliability Kit and I don't want to add any barriers to adoption. I have no idea if adding this configuration will cause more pain in projects as third-party JSDoc would be picked up too.

## Review notes

This seems pretty large, but really most of the changes are tweaks to the JSDoc to make sure that it compiles to the correct/expected TypeScript type declarations. Each commit is a distinct piece of work and the more complex commits have a description which explains why the work needed doing.

To test the generated TypeScript files locally, you can run:

```
npm run build
```

Then open a module's `lib` folder and you should see matching `.d.ts` files.

The testing I've done locally is generating these files, symlinking my local Reliability Kit into different Typescript-based CP apps, and running the build to make sure there are no type errors. I also verified that type-hinting in VS Code is working.