### PR TITLE
fix: include TypeScript types in the build

### DIFF
--- a/packages/app-info/.npmignore
+++ b/packages/app-info/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/errors/.npmignore
+++ b/packages/errors/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/log-error/.npmignore
+++ b/packages/log-error/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/middleware-log-errors/.npmignore
+++ b/packages/middleware-log-errors/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/middleware-render-error-info/.npmignore
+++ b/packages/middleware-render-error-info/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/serialize-error/.npmignore
+++ b/packages/serialize-error/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/serialize-request/.npmignore
+++ b/packages/serialize-request/.npmignore
@@ -1,3 +1,5 @@
+!*.d.ts
+!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -55,7 +55,7 @@ This module is part of [FT.com Reliability Kit](https://github.com/Financial-Tim
 	console.log('📄 adding ".npmignore"');
 	await fs.writeFile(
 		path.join(packagePath, '.npmignore'),
-		['CHANGELOG.md', 'docs', 'test'].join('\n')
+		['!*.d.ts', '!*.d.ts.map', 'CHANGELOG.md', 'docs', 'test'].join('\n')
 	);
 
 	// Bootstrap base JavaScript files


### PR DESCRIPTION
This is annoying. I forgot that `.npmignore` also uses `.gitignore` rules and so our TypeScript files were being ignored.