### PR TITLE
fix(errors): removes readonly JDoc property from getter

### DIFF
--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -42,7 +42,6 @@ class HttpError extends OperationalError {
 	statusMessage = STATUS_CODES[500];
 
 	/**
-	 * @readonly
 	 * @public
 	 * @type {number}
 	 */


### PR DESCRIPTION
## Correcting the JDocs to fix TS error

### Issue
When trying to use the dotcom-reliability-kit/errors in a TS project, I was getting a build error saying "'readonly' modifier can only appear on a property declaration".  


See below for the full error I was getting in my TS project. I was also getting the same error from VSCode in the `http-error.d.ts` file.
```
➜  n-membership-sdk git:(ACC-1965-using-upstreamError) ✗ make build            
./node_modules/.bin/tsc --declaration
node_modules/@dotcom-reliability-kit/errors/lib/http-error.d.ts:8:12 - error TS1024: 'readonly' modifier can only appear on a property declaration or index signature.

8     public readonly get status(): number;
             ~~~~~~~~


Found 1 error.

make: *** [build] Error 2
```

### Solution
`get status()` is not a property, so it doesn't make sense for it to be readonly, and should be readonly by default. I have removed this.

### Testing
My TS project no longer throws a TS error in build when importing dotcom toolkit. Although not sure why this wasn't throwing an error you when building the .d.ts files in the toolkit project 🤔 