### PR TITLE
Add stricter type checking

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,11 @@
 {
 	"compilerOptions": {
+		"alwaysStrict": true,
 		"checkJs": true,
+		"exactOptionalPropertyTypes": true,
 		"module": "commonjs",
 		"noEmit": true,
+		"noImplicitThis": true,
 		"resolveJsonModule": true,
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,6 +5,7 @@
 		"exactOptionalPropertyTypes": true,
 		"module": "commonjs",
 		"noEmit": true,
+		"noImplicitOverride": true,
 		"noImplicitThis": true,
 		"resolveJsonModule": true,
 		"strictBindCallApply": true,

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -5,6 +5,7 @@ const OperationalError = require('./operational-error');
  */
 class DataStoreError extends OperationalError {
 	/**
+	 * @override
 	 * @readonly
 	 * @public
 	 * @type {string}

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -21,6 +21,7 @@ const STATUS_CODES = require('http').STATUS_CODES;
  */
 class HttpError extends OperationalError {
 	/**
+	 * @override
 	 * @readonly
 	 * @public
 	 * @type {string}
@@ -94,6 +95,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Reserved keys that should not appear in `HttpError.prototype.data`.
 	 *
+	 * @override
 	 * @protected
 	 * @type {Array<string>}
 	 */

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -15,6 +15,7 @@
  */
 class OperationalError extends Error {
 	/**
+	 * @override
 	 * @readonly
 	 * @public
 	 * @type {string}

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -5,6 +5,7 @@ const HttpError = require('./http-error');
  */
 class UpstreamServiceError extends HttpError {
 	/**
+	 * @override
 	 * @readonly
 	 * @public
 	 * @type {string}

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -5,6 +5,7 @@ const HttpError = require('./http-error');
  */
 class UserInputError extends HttpError {
 	/**
+	 * @override
 	 * @readonly
 	 * @public
 	 * @type {string}


### PR DESCRIPTION
This adds in some stricter type checking which is easy to add now but more difficult to add later. Most of these are properties which can be added without having to change any Reliability Kit code, the exception being `noImplicitOverride` (see below). I think it's worth adding these in so that we catch these kinds of issues if they're ever introduced.

**`noImplicitOverride`:** This option requires you to acknowledge when you're overriding a property or method on a parent class. This ensures that TypeScript will error if we ever change methods or properties on a base class but miss any extending classes. It requires that we add an `@override` tag to extended class members and I've added these.

[Documentation for all of these options is here](https://www.typescriptlang.org/tsconfig).