### PR TITLE
feat: add an uncaught exception handler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,13 @@ updates:
       timezone: "Europe/London"
 
   - package-ecosystem: "npm"
+    directory: "/packages/crash-handler"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+
+  - package-ecosystem: "npm"
     directory: "/packages/log-error"
     schedule:
       interval: "daily"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/app-info": "1.0.3",
+  "packages/crash-handler": "0.0.0",
   "packages/errors": "1.2.6",
   "packages/log-error": "1.3.8",
   "packages/middleware-log-errors": "1.2.9",

--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -176,7 +176,7 @@ There are times where an unexpected error can occur in your app and your code is
 Uncaught exception handling should never attempt to keep the app alive. If an error is thrown in a place where no handling is present then it's correct for the application to crash, _however_ if the app is crashing then we need to be sure that the fatal error is logged somewhere:
 
 > **Note**
-> This code examples is illustrative, you should not use this in your application but it helps us explain how logging fatal errors works. For a production solution, see the later examples under this heading.
+> This code example is illustrative, you should not use this in your application but it helps us explain how logging fatal errors works. For a production solution, see the later example under this heading.
 
 ```js
 process.on('uncaughtException', (error) => {

--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -171,8 +171,27 @@ app.get('/fruit/:name', async (request, response, next) => {
 
 ## Unhandled errors
 
-**:construction: Under construction:** this part of the documentation relates to a planned feature.<br/>
-[See the discussion here for more information on unhandled errors](https://github.com/Financial-Times/dotcom-reliability-kit/discussions/32).
+There are times where an unexpected error can occur in your app and your code is not designed to handle that error. This is OK, and it's where the [Node.js `uncaughtException` event](https://nodejs.org/api/process.html#event-uncaughtexception) comes in.
+
+Uncaught exception handling should never attempt to keep the app alive. If an error is thrown in a place where no handling is present then it's correct for the application to crash, _however_ if the app is crashing then we need to be sure that the fatal error is logged somewhere:
+
+> **Note**
+> This code examples is illustrative, you should not use this in your application but it helps us explain how logging fatal errors works. For a production solution, see the later examples under this heading.
+
+```js
+process.on('uncaughtException', (error) => {
+    console.log(`The app is crashing because ${error.message}`);
+    process.exit(1);
+});
+```
+
+[`@dotcom-reliability-kit/crash-handler`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/crash-handler#readme) offers a way to register a consistent error handler in your apps, which [provides as much error information as possible](#extracting-logging-information). Using this will make fatal errors in your app a lot easier to debug.
+
+It abstracts the actual uncaught exception handling code away into a neat function call:
+
+```js
+registerCrashHandler({ process });
+```
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -979,6 +979,10 @@
       "resolved": "packages/app-info",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/crash-handler": {
+      "resolved": "packages/crash-handler",
+      "link": true
+    },
     "node_modules/@dotcom-reliability-kit/errors": {
       "resolved": "packages/errors",
       "link": true
@@ -9971,6 +9975,18 @@
         "npm": "7.x || 8.x"
       }
     },
+    "packages/crash-handler": {
+      "name": "@dotcom-reliability-kit/crash-handler",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^1.3.4"
+      },
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
       "version": "1.2.6",
@@ -10801,6 +10817,12 @@
     },
     "@dotcom-reliability-kit/app-info": {
       "version": "file:packages/app-info"
+    },
+    "@dotcom-reliability-kit/crash-handler": {
+      "version": "file:packages/crash-handler",
+      "requires": {
+        "@dotcom-reliability-kit/log-error": "^1.3.4"
+      }
     },
     "@dotcom-reliability-kit/errors": {
       "version": "file:packages/errors"

--- a/packages/crash-handler/.npmignore
+++ b/packages/crash-handler/.npmignore
@@ -1,0 +1,5 @@
+!*.d.ts
+!*.d.ts.map
+CHANGELOG.md
+docs
+test

--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -34,7 +34,12 @@ const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
 
 ### `registerCrashHandler`
 
-The `registerCrashHandler` function can be used to bind an event handler to the [Node.js `process.uncaughtException` event](https://nodejs.org/api/process.html#event-uncaughtexception). This ensures that your application logs a final message before crashing in the event on an unexpected error or promise rejection. This function should only ever be called once in your app, normally alongside all your setup code (e.g. alongside creating an Express app).
+The `registerCrashHandler` function can be used to bind an event handler to the [Node.js `process.uncaughtException` event](https://nodejs.org/api/process.html#event-uncaughtexception). This ensures that your application logs a final message before crashing in the event on an unexpected error or promise rejection.
+
+This function should only ever be called once in your app, normally alongside all your setup code (e.g. alongside creating an Express app).
+
+> **Note**
+> It's not a requirement, but generally the earlier the better with registering an uncaught exception handler – the sooner you register it the more likely you are to catch uncaught exceptions.
 
 ```js
 registerCrashHandler();

--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -1,0 +1,98 @@
+
+# @dotcom-reliability-kit/crash-handler
+
+> **Warning**
+> This Reliability Kit package is **experimental** and should be used with caution in production applications. Please also let the Customer Products Reliability team know if you intend on using this.
+
+A method to bind an uncaught exception handler to ensure that fatal application errors are logged. It is a replacement for Sentry fatal error logging. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+  * [Usage](#usage)
+    * [`registerCrashHandler`](#registercrashhandler)
+    * [configuration options](#configuration-options)
+      * [`process`](#optionsprocess)
+  * [Compatibility](#compatibility)
+    * [Migrating from Sentry](#migrating-from-sentry)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/crash-handler` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/crash-handler
+```
+
+Include in your code:
+
+```js
+import registerCrashHandler from '@dotcom-reliability-kit/crash-handler';
+// or
+const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
+```
+
+### `registerCrashHandler`
+
+The `registerCrashHandler` function can be used to bind an event handler to the [Node.js `process.uncaughtException` event](https://nodejs.org/api/process.html#event-uncaughtexception). This ensures that your application logs a final message before crashing in the event on an unexpected error or promise rejection. This function should only ever be called once in your app, normally alongside all your setup code (e.g. alongside creating an Express app).
+
+```js
+registerCrashHandler();
+```
+
+If an error is thrown which will crash your application, error information will be logged and then the process will exit with the value of `process.exitCode` or `1`.
+
+> **Warning**
+> This function will not work as expected if your app is using [n-raven](https://github.com/Financial-Times/n-raven) or n-express without [the `withSentry` option](https://github.com/Financial-Times/n-express#optional) set to `false`. This is because the way we set up Sentry prevents registering any other uncaught exception handlers. You'll need to [migrate away from Sentry](#migrating-from-sentry) to use this module.
+
+### Configuration options
+
+Config options can be passed into the `registerCrashHandler` function as an object with any of the keys below.
+
+```js
+registerCrashHandler({
+    // Config options go here
+});
+```
+
+#### `options.process`
+
+The [Node.js Process](https://nodejs.org/api/process.html#process) object to bind the error handling event to. You may use this if you are using a child process or want to mock the process object in your tests.
+
+```js
+registerCrashHandler({
+    process: myProcessObject
+});
+```
+
+
+## Compatibility
+
+### Migrating from Sentry
+
+The Reliability Kit crash handler is a replacement for Sentry's uncaught exception handling, which your app is likely using. You'll need to migrate away from Sentry in order to use this module. You can do so by:
+
+  1. Remove any references to [n-raven](https://github.com/Financial-Times/n-raven) in your codebase. You may be importing this module yourself, and if you do then `registerCrashHandler` will not work as expected.
+
+  2. If you're using n-express, it must be on [v26.3.0](https://github.com/Financial-Times/n-express/releases/tag/v26.3.0) or higher. This version of n-express introduces the ability to turn off Sentry.
+
+  3. Configure n-express to disable Sentry by setting the [`withSentry` option](https://github.com/Financial-Times/n-express#optional) to `false`. Find your n-express setup and add the option:
+
+      ```js
+      express({
+          withSentry: false
+      });
+      ```
+
+  4. Follow the instructions in the [usage guide](#usage) to set up Reliability Kit's crash handler.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2022, The Financial Times Ltd.

--- a/packages/crash-handler/lib/index.js
+++ b/packages/crash-handler/lib/index.js
@@ -1,0 +1,26 @@
+const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
+
+/**
+ * @typedef {object} CrashHandlerOptions
+ * @property {import('process')} [process]
+ *     The Node.js process to add crash handlers for.
+ */
+
+/**
+ * Register a crash handler on a process.
+ *
+ * @public
+ * @param {CrashHandlerOptions} [options = {}]
+ *     Options to configure the crash handler.
+ */
+function registerCrashHandler(options = {}) {
+	const process = options.process || global.process;
+	process.on('uncaughtException', (error) => {
+		logUnhandledError({ error });
+		process.exit(process.exitCode || 1);
+	});
+}
+
+module.exports = registerCrashHandler;
+
+module.exports.default = module.exports;

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dotcom-reliability-kit/crash-handler",
+  "version": "0.0.0",
+  "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/crash-handler"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/crash-handler#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: crash-handler\"",
+  "license": "MIT",
+  "engines": {
+    "node": "14.x || 16.x || 18.x",
+    "npm": "7.x || 8.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/log-error": "^1.3.8"
+  }
+}

--- a/packages/crash-handler/test/unit/lib/index.spec.js
+++ b/packages/crash-handler/test/unit/lib/index.spec.js
@@ -1,0 +1,123 @@
+const registerCrashHandler = require('../../../lib');
+
+jest.mock('@dotcom-reliability-kit/log-error', () => ({
+	logUnhandledError: jest.fn()
+}));
+const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
+
+describe('@dotcom-reliability-kit/crash-handler', () => {
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(registerCrashHandler.default).toStrictEqual(registerCrashHandler);
+		});
+	});
+
+	describe('registerCrashHandler(options)', () => {
+		let mockProcess;
+
+		beforeEach(() => {
+			mockProcess = {
+				exit: jest.fn(),
+				on: jest.fn()
+			};
+
+			registerCrashHandler({
+				process: mockProcess
+			});
+		});
+
+		it('binds a handler to the process `uncaughtException` event', () => {
+			expect(mockProcess.on).toBeCalledTimes(1);
+			expect(mockProcess.on).toBeCalledWith(
+				'uncaughtException',
+				expect.any(Function)
+			);
+		});
+
+		describe('uncaughtExceptionHandler(error)', () => {
+			let error;
+			let uncaughtExceptionHandler;
+
+			beforeEach(() => {
+				error = new Error('mock error');
+				uncaughtExceptionHandler = mockProcess.on.mock.calls[0][1];
+				uncaughtExceptionHandler(error);
+			});
+
+			it('logs the error as being unhandled', () => {
+				expect(logUnhandledError).toBeCalledTimes(1);
+				expect(logUnhandledError).toBeCalledWith({ error });
+			});
+
+			it('exits the process with a code of `1`', () => {
+				expect(mockProcess.exit).toBeCalledTimes(1);
+				expect(mockProcess.exit).toBeCalledWith(1);
+			});
+
+			describe('when the process has a defined exit code already', () => {
+				beforeEach(() => {
+					mockProcess.exit.mockReset();
+					mockProcess.exitCode = 137;
+					uncaughtExceptionHandler(error);
+				});
+
+				it('exits the process with the given code', () => {
+					expect(mockProcess.exit).toBeCalledTimes(1);
+					expect(mockProcess.exit).toBeCalledWith(137);
+				});
+			});
+		});
+
+		describe('when `options.process` is undefined', () => {
+			let mockGlobalProcess;
+			let originalProcess;
+
+			beforeEach(() => {
+				originalProcess = global.process;
+				global.process = mockGlobalProcess = {
+					on: jest.fn()
+				};
+
+				registerCrashHandler({});
+			});
+
+			afterEach(() => {
+				global.process = originalProcess;
+			});
+
+			it('binds a handler to the global process `uncaughtException` event', () => {
+				expect(mockGlobalProcess.on).toBeCalledTimes(1);
+				expect(mockGlobalProcess.on).toBeCalledWith(
+					'uncaughtException',
+					expect.any(Function)
+				);
+			});
+		});
+
+		describe('when no options are set', () => {
+			let mockGlobalProcess;
+			let originalProcess;
+
+			beforeEach(() => {
+				originalProcess = global.process;
+				global.process = mockGlobalProcess = {
+					on: jest.fn()
+				};
+
+				registerCrashHandler();
+			});
+
+			afterEach(() => {
+				global.process = originalProcess;
+			});
+
+			it('binds a handler to the global process `uncaughtException` event', () => {
+				expect(mockGlobalProcess.on).toBeCalledTimes(1);
+				expect(mockGlobalProcess.on).toBeCalledWith(
+					'uncaughtException',
+					expect.any(Function)
+				);
+			});
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,7 @@
 	],
 	"packages": {
 		"packages/app-info": {},
+		"packages/crash-handler": {},
 		"packages/errors": {},
 		"packages/log-error": {},
 		"packages/middleware-log-errors": {},


### PR DESCRIPTION
This is the basic functionality for an uncaught exception handler. We're going with a single option for now so that you can pass the process in (e.g. for binding to a child process).

I decided against adding an `exitCode` or `onError` option as outlined in the issue, because I think we shouldn't add things unless our teams have demostrated a need for them.

Resolves #225.