### PR TITLE
chore: configure Dependabot to use fix commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/examples/express"
@@ -14,6 +17,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/resources/logos"
@@ -21,6 +27,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/errors"
@@ -28,6 +37,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/crash-handler"
@@ -35,6 +47,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/log-error"
@@ -42,6 +57,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/middleware-log-errors"
@@ -49,6 +67,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/middleware-render-error-info"
@@ -56,6 +77,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/serialize-error"
@@ -63,6 +87,9 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"
 
   - package-ecosystem: "npm"
     directory: "/packages/serialize-request"
@@ -70,3 +97,6 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    commit-message:
+      prefix: "fix:"
+      prefix-development: "chore:"


### PR DESCRIPTION
This configures Dependabot to use the `fix:` commit prefix for production dependencies by default and `chore:` for development dependencies. Right now it's defaulting to `chore:` for everything which is incorrect as chores do not trigger releases.

This stops us from having to manually override the commit message so often, though we'll still need to do this if we decide that the dependency bump is either a feature or breaking change.