### PR TITLE
fix: loosen serialize-request type requirements

### DIFF
--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -1,5 +1,23 @@
 /**
- * @typedef {import('express').Request | import('http').IncomingMessage & {route: object, params: object}} Request
+ * @typedef {import('express').Request} ExpressRequest
+ */
+
+/**
+ * @typedef {import('http').IncomingMessage} HttpIncomingMessage
+ */
+
+/**
+ * @typedef {object} BasicRequest
+ * @property {Object<string, string>} [headers]
+ *     The request HTTP headers.
+ * @property {string} [method]
+ *     The request HTTP method.
+ * @property {string} [url]
+ *     The request URL.
+ */
+
+/**
+ * @typedef {BasicRequest & Record<string, any> | ExpressRequest | HttpIncomingMessage & Record<string, any>} Request
  */
 
 /**
@@ -35,7 +53,7 @@
  * @property {SerializedRequestHeaders} headers
  *     A subset of HTTP headers which came with the request.
  * @property {SerializedRequestRoute} [route]
- *     A subset of HTTP headers which came with the request.
+ *     The express route details.
  */
 
 /**
@@ -50,9 +68,10 @@ const DEFAULT_INCLUDED_HEADERS = ['accept', 'content-type'];
  * Serialize a request object so that it can be consistently logged or output as JSON.
  *
  * @public
- * @param {(string | Request)} request
- *     The request object to serialize. Either an Express Request object or a
- *     built-in Node.js IncomingMessage object.
+ * @param {string | Request} request
+ *     The request object to serialize. Either an Express Request object, a
+ *     built-in Node.js IncomingMessage object, or an object with the expected
+ *     `headers`, `method`, and `url` properties.
  * @param {SerializeRequestOptions} [options = {}]
  *     Options to configure the serialization.
  * @returns {SerializedRequest}
@@ -114,8 +133,7 @@ function serializeRequest(request, options = {}) {
 	}
 
 	// If the request route is present and valid, add it
-	const routePath = request.route?.path;
-	if (routePath && typeof routePath === 'string') {
+	if (request.route && typeof request.route.path === 'string') {
 		requestProperties.route = {
 			path: request.route.path,
 			params: request.params || {}


### PR DESCRIPTION
I think this fixes #269. Our types are quite restrictive, but actually it's fine to pass in an object which looks vaguely like a request (has `headers`, `method`, and `url` properties). @apaleslimghost does this look like it'll fix your issue?

The easiest way to test might be for you to drop the generated types file into your project's `node_modules/@dotcom-reliability-kit/serialize-request/lib` folder and verify that you no longer have issues:

```ts
export = serializeRequest;
declare function serializeRequest(request: string | Request, options?: SerializeRequestOptions | undefined): SerializedRequest;
declare namespace serializeRequest {
    export { exports as default, ExpressRequest, HttpIncomingMessage, BasicRequest, Request, SerializeRequestOptions, SerializedRequestHeaders, SerializedRequestRouteParams, SerializedRequestRoute, SerializedRequest };
}
type Request = (BasicRequest & Record<string, any>) | ExpressRequest | (HttpIncomingMessage & Record<string, any>);
type SerializeRequestOptions = {
    includeHeaders?: string[] | undefined;
};
type SerializedRequest = {
    id: (string | null);
    method: string;
    url: string;
    headers: SerializedRequestHeaders;
    route?: SerializedRequestRoute | undefined;
};
declare namespace exports {
    export { exports as default, ExpressRequest, HttpIncomingMessage, BasicRequest, Request, SerializeRequestOptions, SerializedRequestHeaders, SerializedRequestRouteParams, SerializedRequestRoute, SerializedRequest };
}
type ExpressRequest = import('express').Request;
type HttpIncomingMessage = import('http').IncomingMessage;
type BasicRequest = {
    headers?: {
        [x: string]: string;
    } | undefined;
    method?: string | undefined;
    url?: string | undefined;
};
type SerializedRequestHeaders = {
    [x: string]: string;
};
type SerializedRequestRouteParams = {
    [x: string]: string;
};
type SerializedRequestRoute = {
    path: string;
    params: SerializedRequestRouteParams;
};
```

**Some testing notes for CP Reliability:** the fact that the linter passes with no issues and without changes to our own dependent modules indicates this isn't a breaking change. I also manually checked that type hinting in VS Code still works.