### PR TITLE
feat: add a mask transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,6 +1130,20 @@
         "npm": "7.x || 8.x"
       }
     },
+    "node_modules/@financial-times/n-mask-logger": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
+      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@financial-times/n-logger": "^10.2.0"
+      },
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "node_modules/@financial-times/n-raven": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
@@ -10175,6 +10189,7 @@
       },
       "devDependencies": {
         "@financial-times/n-logger": "^10.3.0",
+        "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.0",
         "@types/ungap__structured-clone": "^0.3.0"
       },
@@ -11022,6 +11037,7 @@
       "requires": {
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@financial-times/n-logger": "^10.3.0",
+        "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.0",
         "@types/ungap__structured-clone": "^0.3.0",
         "@ungap/structured-clone": "^1.0.1",
@@ -11148,6 +11164,15 @@
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.7",
         "winston": "^2.4.6"
+      }
+    },
+    "@financial-times/n-mask-logger": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
+      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
+      "dev": true,
+      "requires": {
+        "@financial-times/n-logger": "^10.2.0"
       }
     },
     "@financial-times/n-raven": {

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -4,5 +4,9 @@ module.exports = new Logger();
 
 module.exports.Logger = Logger;
 
+module.exports.transforms = {
+	legacyMask: require('./transforms/legacy-mask')
+};
+
 // @ts-ignore
 module.exports.default = module.exports;

--- a/packages/logger/lib/transforms/legacy-mask.js
+++ b/packages/logger/lib/transforms/legacy-mask.js
@@ -1,0 +1,188 @@
+/**
+ * @typedef {object} LegacyMaskTransformOptions
+ * @property {Array<string>} [denyList]
+ *     Additional field names to apply masking to.
+ * @property {Array<string>} [allowList]
+ *     Field names to allow from the default deny list.
+ * @property {string} [maskString]
+ *     The mask string to apply to discovered sensitive values.
+ */
+
+/**
+ * @typedef {object} InternalMaskSettings
+ * @property {Set<string>} maskedFields
+ *     Field names to mask.
+ * @property {RegExp} maskRegExp
+ *     A regular expression which applies masking to a string.
+ * @property {string} maskString
+ *     The mask string to apply to discovered sensitive values.
+ */
+
+/**
+ * The default masked fields.
+ *
+ * @private
+ * @type {Array<string>}
+ */
+const DEFAULT_MASKED_FIELDS = [
+	'email',
+	'password',
+	'firstName',
+	'lastName',
+	'phone',
+	'primaryTelephone',
+	'postcode',
+	'session',
+	'sessionId',
+	'ft-session-id',
+	'FTSession_s',
+	'FTSession',
+	'ft-backend-key'
+];
+
+/**
+ * Properties of an error object we need to mask.
+ *
+ * @private
+ * @type {Array<string>}
+ */
+const ERROR_OBJECT_PROPERTIES = [
+	'name',
+	'message',
+	'fileName',
+	'lineNumber',
+	'columnNumber',
+	'stack'
+];
+
+/**
+ * Mask an unknown value.
+ *
+ * @param {any} value
+ *     The value to mask.
+ * @param {InternalMaskSettings} settings
+ *     The settings to use for masking.
+ * @returns {any}
+ *     Returns the masked value.
+ */
+function mask(value, settings) {
+	if (typeof value === 'string') {
+		return maskString(value, settings);
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => mask(item, settings));
+	}
+	if (typeof value === 'object' && value !== null) {
+		return maskObject(value, settings);
+	}
+	return value;
+}
+
+/**
+ * Mask a string.
+ *
+ * @param {string} string
+ *     The string to mask.
+ * @param {InternalMaskSettings} settings
+ *     The settings to use for masking.
+ * @returns {string}
+ *     Returns the masked string.
+ */
+function maskString(string, settings) {
+	// Guess to see if string is stringified JSON and parse as object for better masking
+	if (string.startsWith('{')) {
+		try {
+			const json = JSON.parse(string);
+			return JSON.stringify(mask(json, settings));
+		} catch (_) {}
+	}
+
+	// Capture group of the maskRegex should contain the sensitive value
+	// replace this with the maskString to remove the sensitive information
+	return string.replace(settings.maskRegExp, (match, captureGroup) => {
+		return match.replace(captureGroup, settings.maskString);
+	});
+}
+
+/**
+ * Mask properties and values of an object.
+ *
+ * @param {object} object
+ *     The object to mask.
+ * @param {InternalMaskSettings} settings
+ *     The settings to use for masking.
+ * @returns {object}
+ *     Returns the masked object.
+ */
+function maskObject(object, settings) {
+	// Make a new object rather than modifying the original
+	// which could have some side effects
+	const maskedObject = {};
+
+	// Loop over object properties to mask all keys and values
+	for (let key in object) {
+		// If the key is sensitive mask the value entirely
+		if (settings.maskedFields.has(key)) {
+			maskedObject[key] = settings.maskString;
+		} else {
+			// If the key is not sensitive run the mask on it's value
+			maskedObject[key] = mask(object[key], settings);
+		}
+	}
+
+	// Standard error properties are not iterable so add them separately.
+	// It's unlikely that we come across an error because n-logger explicitly
+	// disallows them as property values. We do this for compatibility with
+	// n-mask-logger just in case.
+	if (object instanceof Error) {
+		for (const errorProperty of ERROR_OBJECT_PROPERTIES) {
+			const value = mask(object[errorProperty], settings);
+			if (value) {
+				maskedObject[errorProperty] = value;
+			}
+		}
+	}
+
+	return maskedObject;
+}
+
+/**
+ * Create a log transform function which masks sensitive fields in log data.
+ *
+ * @param {LegacyMaskTransformOptions} options
+ *     Masking options.
+ * @returns {import('../logger').LogTransform}
+ *     Returns a transform function for use with the logger.
+ */
+function createLegacyMaskTransform({
+	denyList = [],
+	allowList = [],
+	maskString = '*****'
+} = {}) {
+	// Deduplicate the mask list and filter out explicitly allowed values
+	const maskedFields = new Set(
+		[...DEFAULT_MASKED_FIELDS, ...denyList].filter(
+			(item) => !allowList.includes(item)
+		)
+	);
+
+	// Regular expression defined in a string has to have escaped characters escaped
+	// Value regex is space delimited meaning it will stop searching the value if a space is found
+	// A sensitive value that contains a space will only be partially masked
+	const valueRegExp = '[\'"\\s]*[=:][\\s]*([\\S]+)[\\]\\["\'{}]?';
+	const fieldRegExp = `(?:${[...maskedFields].join('|')})`;
+	const maskRegExp = new RegExp(`${fieldRegExp}${valueRegExp}`, 'ig');
+
+	return function maskSensitiveData(logData) {
+		return maskObject(logData, {
+			maskedFields,
+			maskRegExp,
+			maskString
+		});
+	};
+}
+
+module.exports = createLegacyMaskTransform;
+
+// @ts-ignore
+module.exports.default = module.exports;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@financial-times/n-logger": "^10.3.0",
+    "@financial-times/n-mask-logger": "^7.2.0",
     "@types/events": "^3.0.0",
     "@types/ungap__structured-clone": "^0.3.0"
   }

--- a/packages/logger/test/end-to-end/compatibility.spec.js
+++ b/packages/logger/test/end-to-end/compatibility.spec.js
@@ -36,6 +36,19 @@ describe('@dotcom-reliability-kit/logger vs @financial-times/n-logger', () => {
 				});
 			}
 
+			if (expectedOutput.nextMaskLogger) {
+				it('outputs the expected n-mask-logger logs', () => {
+					const log = findLogWithPropertyValue(
+						logs,
+						'_logger',
+						'nextMaskLogger'
+					);
+					expect(log).toBeTruthy();
+					const cleanLog = cleanLogForTesting(log);
+					expect(cleanLog).toEqual(expectedOutput.nextMaskLogger);
+				});
+			}
+
 			if (expectedOutput.reliabilityKit) {
 				it('outputs the expected reliability-kit logs', () => {
 					const log = findLogWithPropertyValue(
@@ -46,6 +59,19 @@ describe('@dotcom-reliability-kit/logger vs @financial-times/n-logger', () => {
 					expect(log).toBeTruthy();
 					const cleanLog = cleanLogForTesting(log);
 					expect(cleanLog).toEqual(expectedOutput.reliabilityKit);
+				});
+			}
+
+			if (expectedOutput.reliabilityKitMaskLogger) {
+				it('outputs the expected reliability-kit masked logs', () => {
+					const log = findLogWithPropertyValue(
+						logs,
+						'_logger',
+						'reliabilityKitMaskLogger'
+					);
+					expect(log).toBeTruthy();
+					const cleanLog = cleanLogForTesting(log);
+					expect(cleanLog).toEqual(expectedOutput.reliabilityKitMaskLogger);
 				});
 			}
 

--- a/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
+++ b/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
@@ -16,6 +16,8 @@ function cleanLogFortesting(log) {
 	// consistent between machines or local vs CI
 	delete log.error?.stack;
 	delete log.error_stack;
+	delete log.nestedError?.stack;
+	delete log.stack;
 
 	// The `time` property cannot be tested because it's always
 	// going to be different

--- a/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
+++ b/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
@@ -4,8 +4,14 @@ process.env.MIGRATE_TO_HEROKU_LOG_DRAINS = 'true';
 process.env.SPLUNK_LOG_LEVEL = 'silly';
 
 const nLogger = require('@financial-times/n-logger').default;
-const reliabilityKitLogger = require('../../../lib').default;
+const MaskLogger = require('@financial-times/n-mask-logger');
+const reliabilityKitLogger = require('../../../lib');
 const testCases = require('../compatibility-test-cases');
+
+const nMaskLogger = new MaskLogger();
+const reliabilityKitMaskLogger = new reliabilityKitLogger.Logger({
+	transforms: [reliabilityKitLogger.transforms.legacyMask()]
+});
 
 // The test case ID is passed as an additional argument on the command.
 // We use this to find the test case in order to perform logging.
@@ -24,4 +30,16 @@ if (nLogger[method]) {
 // Run reliability kit logger
 if (reliabilityKitLogger[method]) {
 	reliabilityKitLogger[method](...args, { _logger: 'reliabilityKit' });
+}
+
+// Run n-mask-logger
+if (nMaskLogger[method]) {
+	nMaskLogger[method](...args, { _logger: 'nextMaskLogger' });
+}
+
+// Run reliability kit masked logger
+if (reliabilityKitMaskLogger[method]) {
+	reliabilityKitMaskLogger[method](...args, {
+		_logger: 'reliabilityKitMaskLogger'
+	});
 }

--- a/packages/logger/test/unit/lib/index.spec.js
+++ b/packages/logger/test/unit/lib/index.spec.js
@@ -3,6 +3,9 @@ const logger = require('../../..');
 jest.mock('../../../lib/logger', () => jest.fn());
 const MockLogger = require('../../../lib/logger');
 
+jest.mock('../../../lib/transforms/legacy-mask', () => jest.fn());
+const createLegacyMaskTransform = require('../../../lib/transforms/legacy-mask');
+
 describe('@dotcom-reliability-kit/logger', () => {
 	it('exports the logger instance', () => {
 		expect(logger).toBeInstanceOf(MockLogger);
@@ -11,6 +14,16 @@ describe('@dotcom-reliability-kit/logger', () => {
 	describe('.Logger', () => {
 		it('aliases lib/logger', () => {
 			expect(logger.Logger).toStrictEqual(MockLogger);
+		});
+	});
+
+	describe('.transforms', () => {
+		describe('.legacyMask', () => {
+			it('aliases lib/transforms/legacy-mask', () => {
+				expect(logger.transforms.legacyMask).toStrictEqual(
+					createLegacyMaskTransform
+				);
+			});
 		});
 	});
 

--- a/packages/logger/test/unit/lib/transforms/legacy-mask.spec.js
+++ b/packages/logger/test/unit/lib/transforms/legacy-mask.spec.js
@@ -1,0 +1,276 @@
+const createLegacyMaskTransform = require('../../../../lib/transforms/legacy-mask');
+
+describe('@dotcom-reliability-kit/logger', () => {
+	it('exports a function', () => {
+		expect(createLegacyMaskTransform).toBeInstanceOf(Function);
+	});
+
+	describe('.default', () => {
+		it('aliases the module exports', () => {
+			expect(createLegacyMaskTransform.default).toStrictEqual(
+				createLegacyMaskTransform
+			);
+		});
+	});
+
+	describe('createLegacyMaskTransform(options)', () => {
+		let transform;
+
+		beforeEach(() => {
+			transform = createLegacyMaskTransform();
+		});
+
+		it('returns a function', () => {
+			expect(transform).toBeInstanceOf(Function);
+		});
+
+		describe('transform(logObject)', () => {
+			it('returns a new object', () => {
+				const logData = {
+					message: 'hello'
+				};
+				const result = transform(logData);
+				expect(result).toEqual({
+					message: 'hello'
+				});
+				expect(result === logData).toBeFalsy();
+			});
+
+			describe('when called with sensitive properties', () => {
+				it('returns an object with masked properties', () => {
+					expect(
+						transform({
+							email: 'mock',
+							firstName: 'mock',
+							'ft-backend-key': 'mock',
+							'ft-session-id': 'mock',
+							FTSession_s: 'mock',
+							FTSession: 'mock',
+							lastName: 'mock',
+							password: 'mock',
+							phone: 'mock',
+							postcode: 'mock',
+							primaryTelephone: 'mock',
+							session: 'mock',
+							sessionId: 'mock'
+						})
+					).toEqual({
+						email: '*****',
+						firstName: '*****',
+						'ft-backend-key': '*****',
+						'ft-session-id': '*****',
+						FTSession_s: '*****',
+						FTSession: '*****',
+						lastName: '*****',
+						password: '*****',
+						phone: '*****',
+						postcode: '*****',
+						primaryTelephone: '*****',
+						session: '*****',
+						sessionId: '*****'
+					});
+				});
+			});
+
+			describe('when called with nested sensitive properties', () => {
+				it('returns an object with masked properties', () => {
+					expect(
+						transform({
+							mock: {
+								email: 'mock',
+								mock: {
+									lastName: 'mock'
+								}
+							}
+						})
+					).toEqual({
+						mock: {
+							email: '*****',
+							mock: {
+								lastName: '*****'
+							}
+						}
+					});
+				});
+			});
+
+			describe('when an object with sensitive properties is in an array', () => {
+				it('returns the array with item properties masked', () => {
+					expect(
+						transform({
+							mock: [
+								{
+									email: 'mock'
+								}
+							]
+						})
+					).toEqual({
+						mock: [
+							{
+								email: '*****'
+							}
+						]
+					});
+				});
+			});
+
+			describe('when an object with sensitive properties is in an Error object', () => {
+				it('returns a basic serialized error object with properties masked', () => {
+					const error = new Error('mock message');
+					error.email = 'mock';
+					expect(
+						transform({
+							mock: error
+						})
+					).toEqual({
+						mock: {
+							message: 'mock message',
+							name: 'Error',
+							stack: expect.stringContaining('mock message'),
+							email: '*****'
+						}
+					});
+				});
+			});
+
+			describe('when an object has sensitive properties listed within a string', () => {
+				it('returns the string with the sensitive data masked', () => {
+					expect(transform({ mock: 'foo=bar email=mock' })).toEqual({
+						mock: 'foo=bar email=*****'
+					});
+				});
+
+				describe('when the sensitive data uses colons to split field and value', () => {
+					it('returns the string with the sensitive data masked', () => {
+						expect(transform({ mock: 'foo:bar email:mock' })).toEqual({
+							mock: 'foo:bar email:*****'
+						});
+					});
+				});
+
+				describe('when the sensitive data has additional whitespace around the field and value split', () => {
+					it('returns the string with the sensitive data masked', () => {
+						expect(
+							transform({
+								mock: 'foo  =  bar email = mock1 email   =   mock2'
+							})
+						).toEqual({
+							mock: 'foo  =  bar email = ***** email   =   *****'
+						});
+					});
+				});
+
+				describe('when the sensitive data wraps the property in double quotes', () => {
+					// TODO something to address when we replace this behaviour
+					it('returns the string with the sensitive data masked, but considers value quotes to be part of the sensitive data', () => {
+						expect(transform({ mock: 'foo="bar" email="mock"' })).toEqual({
+							mock: 'foo="bar" email=*****'
+						});
+					});
+				});
+
+				describe('when the sensitive data wraps the property in single quotes', () => {
+					// TODO something to address when we replace this behaviour
+					it('returns the string with the sensitive data masked, but considers value quotes to be part of the sensitive data', () => {
+						expect(transform({ mock: "foo='bar' email='mock'" })).toEqual({
+							mock: "foo='bar' email=*****"
+						});
+					});
+				});
+			});
+
+			describe('when an object with sensitive properties is in a JSON string', () => {
+				it('returns the string with item properties masked', () => {
+					expect(
+						transform({
+							mock: '{"email":"mock"}'
+						})
+					).toEqual({
+						mock: '{"email":"*****"}'
+					});
+				});
+
+				describe('when the JSON is invalid', () => {
+					// TODO something to address when we replace this behaviour
+					it('returns JSON that is invalid in a different way', () => {
+						expect(transform({ mock: '{email:"mock"}' })).toEqual({
+							mock: '{email:*****'
+						});
+					});
+				});
+
+				describe('when the outer JSON is not an object', () => {
+					// TODO something to address when we replace this behaviour
+					it('breaks the JSON during the masking', () => {
+						expect(transform({ mock: '[{"email":"mock"}]' })).toEqual({
+							mock: '[{"email":*****'
+						});
+						expect(transform({ mock: '[{"email":"mock"}]' })).toEqual({
+							mock: '[{"email":*****'
+						});
+					});
+				});
+			});
+
+			describe('when an object has non-string properties', () => {
+				it('returns the properties unmasked', () => {
+					expect(transform({ mock: 123 })).toEqual({ mock: 123 });
+				});
+			});
+		});
+
+		describe('when `options.denyList` is set', () => {
+			beforeEach(() => {
+				transform = createLegacyMaskTransform({
+					denyList: ['extraProperty']
+				});
+			});
+
+			describe('transform(logObject)', () => {
+				describe('when called with one of the configured properties', () => {
+					it('returns an object with that property masked', () => {
+						expect(transform({ extraProperty: 'mock' })).toEqual({
+							extraProperty: '*****'
+						});
+					});
+				});
+			});
+		});
+
+		describe('when `options.allowList` is set', () => {
+			beforeEach(() => {
+				transform = createLegacyMaskTransform({
+					allowList: ['email']
+				});
+			});
+
+			describe('transform(logObject)', () => {
+				describe('when called with one of the configured properties', () => {
+					it('returns an object with that property unmasked', () => {
+						expect(transform({ email: 'mock' })).toEqual({
+							email: 'mock'
+						});
+					});
+				});
+			});
+		});
+
+		describe('when `options.maskString` is set', () => {
+			beforeEach(() => {
+				transform = createLegacyMaskTransform({
+					maskString: '🙈🙉🙊'
+				});
+			});
+
+			describe('transform(logObject)', () => {
+				describe('when called with sensitive properties', () => {
+					it('returns an object with that property masked with the configured string', () => {
+						expect(transform({ email: 'mock' })).toEqual({
+							email: '🙈🙉🙊'
+						});
+					});
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
This should be the final piece of work needed to allow users of n-mask-logger to migrate to this library in future. It brings us to the point where we have a functional replacement for all three of our current logging libraries.

There's more information in the README and migration guide for this commit, but essentially you can now introduce the same masking-behaviour as n-mask-logger to the Reliability Kit logger:

```js
const { Logger, transforms } = require('@dotcom-reliability-kit/logger');

const logger = new Logger({
    transforms: [
        transforms.legacyMask()
    ]
});

logger.info({
    email: 'oops@ft.com'
});
// Outputs:
// {
//     "level": "info",
//     "email": "*****"
// }
```

I went with the name `legacyMask` so that we can continue to support this masking behaviour alongside a new one if we ever decide to improve it - I noticed quite a few issues while digging into the n-mask-logger source code and it's not as thorough as we might like it to be.