### PR TITLE
feat: add prettification to logs in local dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10127,10 +10127,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^1.3.9"
+        "@dotcom-reliability-kit/log-error": "^1.3.10"
       },
       "engines": {
         "node": "14.x || 16.x || 18.x",
@@ -10148,12 +10148,12 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^1.0.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.0.3",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.4",
         "@financial-times/n-logger": "^10.3.1"
       },
       "devDependencies": {
@@ -10166,9 +10166,10 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^1.0.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@ungap/structured-clone": "^1.0.1",
         "pino": "^8.7.0"
@@ -10185,10 +10186,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^1.3.9"
+        "@dotcom-reliability-kit/log-error": "^1.3.10"
       },
       "devDependencies": {
         "@financial-times/n-express": "^26.3.3",
@@ -10202,11 +10203,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^1.0.3",
-        "@dotcom-reliability-kit/log-error": "^1.3.9",
+        "@dotcom-reliability-kit/log-error": "^1.3.10",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "entities": "^4.4.0"
       },
@@ -10240,7 +10241,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.14"
@@ -10990,7 +10991,7 @@
     "@dotcom-reliability-kit/crash-handler": {
       "version": "file:packages/crash-handler",
       "requires": {
-        "@dotcom-reliability-kit/log-error": "^1.3.9"
+        "@dotcom-reliability-kit/log-error": "^1.3.10"
       }
     },
     "@dotcom-reliability-kit/errors": {
@@ -11012,7 +11013,7 @@
       "requires": {
         "@dotcom-reliability-kit/app-info": "^1.0.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.0.3",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.4",
         "@financial-times/n-logger": "^10.3.1",
         "@types/express": "^4.17.14"
       }
@@ -11020,6 +11021,7 @@
     "@dotcom-reliability-kit/logger": {
       "version": "file:packages/logger",
       "requires": {
+        "@dotcom-reliability-kit/app-info": "^1.0.3",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@financial-times/n-logger": "^10.3.0",
         "@types/events": "^3.0.0",
@@ -11040,7 +11042,7 @@
     "@dotcom-reliability-kit/middleware-log-errors": {
       "version": "file:packages/middleware-log-errors",
       "requires": {
-        "@dotcom-reliability-kit/log-error": "^1.3.9",
+        "@dotcom-reliability-kit/log-error": "^1.3.10",
         "@financial-times/n-express": "^26.3.3",
         "@types/express": "^4.17.14",
         "node-fetch": "^2.6.7"
@@ -11050,7 +11052,7 @@
       "version": "file:packages/middleware-render-error-info",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^1.0.3",
-        "@dotcom-reliability-kit/log-error": "^1.3.9",
+        "@dotcom-reliability-kit/log-error": "^1.3.10",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@types/express": "^4.17.14",
         "entities": "^4.4.0"

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -440,19 +440,17 @@ logger.info({ example: 1 }, { example: 2 }, { example: 3 });
 
 ### Local development usage
 
-`@dotcom-reliability-kit/logger` does not format or colourize logs, which can make reading them in local development more difficult. If reading raw JSON isn't your thing then we suggest using [pino-pretty](https://github.com/pinojs/pino-pretty#readme) in local development to colourize and format log lines.
+In local development `@dotcom-reliability-kit/logger` does not format or colourize logs by default. You may want to enable this to make reading logs in local development more easy.
 
-You can do this by installing pino-pretty as a development dependency:
+To get formatted and colourised logs locally, you need to meet two conditions:
 
-```sh
-npm install -D pino-pretty
-```
+  1. Have the `NODE_ENV` environment variable set to either `development` or don't have it set at all.
 
-and then piping your application start into the `pino-pretty` binary. The following ensures that the log message appears as the top highlighted line:
+  2. Install [pino-pretty](https://github.com/pinojs/pino-pretty#readme) as a **development dependency** in your project. It's very important that this is a development dependency rather than a production one, otherwise you risk prettifying logs in production which makes them appear incorrectly in Splunk:
 
-```sh
-npm start | pino-pretty --messageKey message
-```
+      ```sh
+      npm install -D pino-pretty
+      ```
 
 ### Production usage
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,6 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
+    "@dotcom-reliability-kit/app-info": "^1.0.3",
     "@dotcom-reliability-kit/serialize-error": "^1.1.4",
     "@ungap/structured-clone": "^1.0.1",
     "pino": "^8.7.0"


### PR DESCRIPTION
This adds the ability for an app using the new logger to see prettified logs locally, which makes issues easier to debug. We configure pino-pretty if it's present to work with our logs.

This resolves #281. I decided against adding extra options to disable prettification, as teams can manually set their `NODE_ENV` to `production` if they want to inspect the raw JSON output.

The issue linked above contains more information on why I decided to solve this within the logger rather than externally or with Tool Kit.