### PR TITLE
fix: correct ESM exports

### DIFF
--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -1,9 +1,7 @@
-module.exports = {
-	DataStoreError: require('./data-store-error'),
-	HttpError: require('./http-error'),
-	OperationalError: require('./operational-error'),
-	UpstreamServiceError: require('./upstream-service-error'),
-	UserInputError: require('./user-input-error')
-};
+exports.DataStoreError = require('./data-store-error');
+exports.HttpError = require('./http-error');
+exports.OperationalError = require('./operational-error');
+exports.UpstreamServiceError = require('./upstream-service-error');
+exports.UserInputError = require('./user-input-error');
 
-module.exports.default = module.exports;
+exports.default = exports;

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -117,10 +117,8 @@ function logUnhandledError({ error, includeHeaders, request }) {
 	});
 }
 
-module.exports = {
-	logHandledError,
-	logRecoverableError,
-	logUnhandledError
-};
+exports.logHandledError = logHandledError;
+exports.logRecoverableError = logRecoverableError;
+exports.logUnhandledError = logUnhandledError;
 
-module.exports.default = module.exports;
+exports.default = exports;


### PR DESCRIPTION
This commit 8cdd4d74afe44c51504ddf0f9a3219db3ad2654a broke the exports when used in a native ESM context. I'd rather have a little more clutter in our type definitions than not be able to import modules as our users expect. Thanks @apaleslimghost for the heads up.

I'm going to investigate whether we need automated tests to ensure that our modules behave as expected in:

  * CommonJS (native)
  * ESM (native)
  * ESM via [Sucrase](https://sucrase.io/)
  * ESM via TypeScript
  * ESM via Babel???

I _really_ hate that this is the Node.js ecosystem.