### PR TITLE
fix: add proper types for the default logger

### DIFF
--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -1,12 +1,28 @@
 const Logger = require('./logger');
+const legacyMask = require('./transforms/legacy-mask');
 
+/**
+ * @typedef {object} Transforms
+ * @property {legacyMask} legacyMask
+ *     The legacy mask logger.
+ */
+
+/**
+ * @typedef {object} DefaultLogger
+ * @property {typeof Logger} Logger
+ *     The Logger class.
+ * @property {Transforms} transforms
+ *     Built-in log transforms.
+ */
+
+/**
+ * @type {Logger & DefaultLogger}
+ */
 module.exports = new Logger();
 
 module.exports.Logger = Logger;
 
-module.exports.transforms = {
-	legacyMask: require('./transforms/legacy-mask')
-};
+module.exports.transforms = { legacyMask };
 
 // @ts-ignore
 module.exports.default = module.exports;


### PR DESCRIPTION
This should address another issue that Kara spotted, where we're not properly defining types in this logger entrypoint.