### PR TITLE
feat: expand list of default headers included in serialized requests

### DIFF
--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -155,8 +155,21 @@ logRecoverableError({
 
 #### `options.includeHeaders`
 
-An array of request headers to include in the serialized request object (if one is provided with `options.request`). This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
+An array of request headers to include in the serialized request object (if one is provided with `options.request`). This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
 
+This option defaults to:
+```js
+[
+    'accept',
+    'accept-encoding',
+    'accept-language',
+    'content-type',
+    'referer',
+    'user-agent'
+]
+```
+
+Example of usage:
 ```js
 logRecoverableError({
     // ...other required options

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -87,8 +87,21 @@ app.use(createErrorLogger({
 
 #### `options.includeHeaders`
 
-An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
+An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.
 
+This option defaults to:
+```js
+[
+    'accept',
+    'accept-encoding',
+    'accept-language',
+    'content-type',
+    'referer',
+    'user-agent'
+]
+```
+
+Example of usage:
 ```js
 app.use(createErrorLogger({
     includeHeaders: [

--- a/packages/serialize-request/README.md
+++ b/packages/serialize-request/README.md
@@ -77,8 +77,21 @@ serializeRequest(request, {
 
 #### `options.includeHeaders`
 
-An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This defaults to `['accept', 'content-type']`.
+An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information.
 
+This option defaults to:
+```js
+[
+    'accept',
+    'accept-encoding',
+    'accept-language',
+    'content-type',
+    'referer',
+    'user-agent'
+]
+```
+
+Example of usage:
 ```js
 serializeRequest(request, {
     includeHeaders: [

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -62,7 +62,14 @@
  * @private
  * @type {Array<string>}
  */
-const DEFAULT_INCLUDED_HEADERS = ['accept', 'content-type'];
+const DEFAULT_INCLUDED_HEADERS = [
+	'accept',
+	'accept-encoding',
+	'accept-language',
+	'content-type',
+	'referer',
+	'user-agent'
+];
 
 /**
  * Serialize a request object so that it can be consistently logged or output as JSON.

--- a/packages/serialize-request/test/unit/lib/index.spec.js
+++ b/packages/serialize-request/test/unit/lib/index.spec.js
@@ -16,8 +16,12 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				url: '/mock-url',
 				headers: {
 					accept: '*/*',
+					'accept-encoding': 'gzip',
+					'accept-language': 'en-US',
 					'content-type': 'application/json',
 					'mock-header': 'mock-param-value',
+					referer: 'https://foo.com',
+					'user-agent': 'Mozilla/5.0',
 					'x-request-id': 'mock-id'
 				}
 			};
@@ -30,7 +34,11 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				url: '/mock-url',
 				headers: {
 					accept: '*/*',
-					'content-type': 'application/json'
+					'accept-encoding': 'gzip',
+					'accept-language': 'en-US',
+					'content-type': 'application/json',
+					referer: 'https://foo.com',
+					'user-agent': 'Mozilla/5.0'
 				}
 			});
 		});
@@ -45,7 +53,11 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				url: '/mock-url',
 				headers: {
 					accept: '*/*',
+					'accept-encoding': 'gzip',
+					'accept-language': 'en-US',
 					'content-type': 'application/json',
+					referer: 'https://foo.com',
+					'user-agent': 'Mozilla/5.0',
 					'mock-header': 'mock-param-value',
 					'x-request-id': 'mock-id'
 				},
@@ -65,7 +77,11 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				url: '/mock-url',
 				headers: {
 					accept: '*/*',
-					'content-type': 'application/json'
+					'accept-encoding': 'gzip',
+					'accept-language': 'en-US',
+					'content-type': 'application/json',
+					referer: 'https://foo.com',
+					'user-agent': 'Mozilla/5.0'
 				},
 				route: {
 					path: '/mock-route-path',


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/dotcom-reliability-kit/issues/223

I checked the request headers that we see on a locally-running app (next-static) and there were none that seemed like they would be obviously vital to include by default at this stage:

```js
[
	'Host',
	'Connection',
	'sec-ch-ua',
	'sec-ch-ua-mobile',
	'sec-ch-ua-platform',
	'Upgrade-Insecure-Requests',
	'User-Agent',
	'Accept',
	'Purpose',
	'Sec-Fetch-Site',
	'Sec-Fetch-Mode',
	'Sec-Fetch-User',
	'Sec-Fetch-Dest',
	'Accept-Encoding',
	'Accept-Language',
	'Cookie'
]
```

The [HTTP headers list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) provided by MDN is naturally very extensive, suggesting that perhaps the approach we take (as suggested by @rowanmanning) is to wait and see which headers teams using Reliability Kit add in addition to the defaults, and if there are popular choices then those can be added at a later date.