### PR TITLE
fix: stop pinning dependencies in express example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
-      prefix: "fix:"
+      prefix: "chore:"
       prefix-development: "chore:"
 
   - package-ecosystem: "npm"

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -19,11 +19,11 @@
     "start": "SYSTEM_CODE='$$$-no-bizops-system-code-$$$' node ."
   },
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^1.0.0",
-    "@dotcom-reliability-kit/errors": "^1.2.1",
-    "@dotcom-reliability-kit/log-error": "^1.3.4",
-    "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
-    "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.3",
+    "@dotcom-reliability-kit/app-info": "*",
+    "@dotcom-reliability-kit/errors": "*",
+    "@dotcom-reliability-kit/log-error": "*",
+    "@dotcom-reliability-kit/middleware-log-errors": "*",
+    "@dotcom-reliability-kit/middleware-render-error-info": "*",
     "@financial-times/n-express": "^26.3.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,11 +41,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^1.0.0",
-        "@dotcom-reliability-kit/errors": "^1.2.1",
-        "@dotcom-reliability-kit/log-error": "^1.3.4",
-        "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
-        "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.3",
+        "@dotcom-reliability-kit/app-info": "*",
+        "@dotcom-reliability-kit/errors": "*",
+        "@dotcom-reliability-kit/log-error": "*",
+        "@dotcom-reliability-kit/middleware-log-errors": "*",
+        "@dotcom-reliability-kit/middleware-render-error-info": "*",
         "@financial-times/n-express": "^26.3.3"
       },
       "engines": {
@@ -11015,11 +11015,11 @@
     "@dotcom-reliability-kit/example-express": {
       "version": "file:examples/express",
       "requires": {
-        "@dotcom-reliability-kit/app-info": "^1.0.0",
-        "@dotcom-reliability-kit/errors": "^1.2.1",
-        "@dotcom-reliability-kit/log-error": "^1.3.4",
-        "@dotcom-reliability-kit/middleware-log-errors": "^1.2.5",
-        "@dotcom-reliability-kit/middleware-render-error-info": "^1.1.3",
+        "@dotcom-reliability-kit/app-info": "*",
+        "@dotcom-reliability-kit/errors": "*",
+        "@dotcom-reliability-kit/log-error": "*",
+        "@dotcom-reliability-kit/middleware-log-errors": "*",
+        "@dotcom-reliability-kit/middleware-render-error-info": "*",
         "@financial-times/n-express": "^26.3.3"
       }
     },


### PR DESCRIPTION
This is causing issues because it results in multiple versions of Reliability Kit packages being installed in the repo. This means that, when we're testing changes to the types, TypeScript gets confused about which version of a package we're actually looking at. Setting these to `*` means that we always use the local dependency.

We also set bumping dependencies in the examples to always be marked as a chore, as this should never result in an actual release.