### PR TITLE
feat: expose the default serialized headers

### DIFF
--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -182,6 +182,20 @@ logRecoverableError({
 });
 ```
 
+The default set of headers is also available to use, so that you don't need to repeat them if you want to add new included headers. You'll need to import `@dotcom-reliability-kit/serialize-request`, then these headers are available:
+
+```js
+const { DEFAULT_INCLUDED_HEADERS } = require('@dotcom-reliability-kit/serialize-request');
+
+logRecoverableError({
+    // ...other required options
+    includeHeaders: [
+        ...DEFAULT_INCLUDED_HEADERS,
+        'my-custom-header'
+    ]
+});
+```
+
 > **Note**
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -113,6 +113,19 @@ app.use(createErrorLogger({
 }));
 ```
 
+The default set of headers is also available to use, so that you don't need to repeat them if you want to add new included headers. You'll need to import `@dotcom-reliability-kit/serialize-request`, then these headers are available:
+
+```js
+const { DEFAULT_INCLUDED_HEADERS } = require('@dotcom-reliability-kit/serialize-request');
+
+app.use(createErrorLogger({
+    includeHeaders: [
+        ...DEFAULT_INCLUDED_HEADERS,
+        'my-custom-header'
+    ]
+}));
+```
+
 > **Note**
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 

--- a/packages/serialize-request/README.md
+++ b/packages/serialize-request/README.md
@@ -103,6 +103,18 @@ serializeRequest(request, {
 });
 ```
 
+The default set of headers is also available to use, so that you don't need to repeat them if you want to add new included headers. It can be accessed as `serializeRequest.DEFAULT_INCLUDED_HEADERS`:
+
+```js
+serializeRequest(request, {
+    includeHeaders: [
+        ...serializeRequest.DEFAULT_INCLUDED_HEADERS,
+        'my-custom-header'
+    ]
+});
+```
+
+
 ### `SerializedRequest` type
 
 The `SerializedRequest` type documents the return value of the [`serializeRequest` function](#serializerequest). It will have the following properties, extracting them from a given request object.

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -59,7 +59,7 @@
 /**
  * The default request headers to include in the serialization.
  *
- * @private
+ * @public
  * @type {Array<string>}
  */
 const DEFAULT_INCLUDED_HEADERS = [
@@ -191,7 +191,14 @@ function createSerializedRequest(properties) {
 	);
 }
 
-module.exports = serializeRequest;
+exports = module.exports = serializeRequest;
+
+// We freeze this object so that we avoid any side-effects
+// introduced by the way Node.js caches modules. If this
+// array is edited within a dependent app, then any changes
+// will apply to _all_ uses of `serializeRequest`. This
+// could cause some weird issues so we lock it down.
+exports.DEFAULT_INCLUDED_HEADERS = Object.freeze([...DEFAULT_INCLUDED_HEADERS]);
 
 // @ts-ignore
 module.exports.default = module.exports;

--- a/packages/serialize-request/test/unit/lib/index.spec.js
+++ b/packages/serialize-request/test/unit/lib/index.spec.js
@@ -7,6 +7,28 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 		});
 	});
 
+	describe('.DEFAULT_INCLUDED_HEADERS', () => {
+		it('is an array of included headers', () => {
+			expect(serializeRequest.DEFAULT_INCLUDED_HEADERS).toEqual([
+				'accept',
+				'accept-encoding',
+				'accept-language',
+				'content-type',
+				'referer',
+				'user-agent'
+			]);
+		});
+
+		it('is readonly', () => {
+			expect(() => {
+				serializeRequest.DEFAULT_INCLUDED_HEADERS.push('nope');
+			}).toThrowError(TypeError);
+
+			serializeRequest.DEFAULT_INCLUDED_HEADERS[0] = 'nope';
+			expect(serializeRequest.DEFAULT_INCLUDED_HEADERS[0]).not.toEqual('nope');
+		});
+	});
+
 	describe('when called with an `http.IncomingMessage` object', () => {
 		let request;
 


### PR DESCRIPTION
This resolves #222, exposing the default headers that we use in `serializeRequest`. This should reduce the need for repetition across our apps as they can destructure this into their own `includeHeaders` config.

I decided to go for the uppercase "constant-style" naming with `DEFAULT_INCLUDED_HEADERS`. I also froze the exported object to avoid potential side-effects.