### PR TITLE
feat: add the ability to set a custom logger

### DIFF
--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -3,14 +3,15 @@
 
 A method to bind an uncaught exception handler to ensure that fatal application errors are logged. It is a replacement for Sentry fatal error logging. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
-  * [Usage](#usage)
-    * [`registerCrashHandler`](#registercrashhandler)
-    * [configuration options](#configuration-options)
-      * [`process`](#optionsprocess)
-  * [Compatibility](#compatibility)
-    * [Migrating from Sentry](#migrating-from-sentry)
-  * [Contributing](#contributing)
-  * [License](#license)
+* [Usage](#usage)
+  * [`registerCrashHandler`](#registercrashhandler)
+  * [Configuration options](#configuration-options)
+    * [`options.logger`](#optionslogger)
+    * [`options.process`](#optionsprocess)
+* [Compatibility](#compatibility)
+  * [Migrating from Sentry](#migrating-from-sentry)
+* [Contributing](#contributing)
+* [License](#license)
 
 
 ## Usage
@@ -56,6 +57,16 @@ registerCrashHandler({
     // Config options go here
 });
 ```
+
+#### `options.logger`
+
+A logger object which implements two methods, `error` and `warn`, which have the following permissive signature:
+
+```ts
+type LogMethod = (...logData: any) => any;
+```
+
+This is passed directly onto the relevant log-error method, [see the documentation for that package for more details](../log-error/README.md#optionslogger).
 
 #### `options.process`
 

--- a/packages/crash-handler/lib/index.js
+++ b/packages/crash-handler/lib/index.js
@@ -2,6 +2,8 @@ const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
 
 /**
  * @typedef {object} CrashHandlerOptions
+ * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
+ *     The logger to use to output errors. Defaults to n-logger.
  * @property {import('process')} [process]
  *     The Node.js process to add crash handlers for.
  */
@@ -16,7 +18,7 @@ const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
 function registerCrashHandler(options = {}) {
 	const process = options.process || global.process;
 	process.on('uncaughtException', (error) => {
-		logUnhandledError({ error });
+		logUnhandledError({ error, logger: options.logger });
 		process.exit(process.exitCode || 1);
 	});
 }

--- a/packages/crash-handler/test/unit/lib/index.spec.js
+++ b/packages/crash-handler/test/unit/lib/index.spec.js
@@ -68,6 +68,36 @@ describe('@dotcom-reliability-kit/crash-handler', () => {
 			});
 		});
 
+		describe('when `options.logger` is set', () => {
+			beforeEach(() => {
+				mockProcess.on.mockReset();
+				logUnhandledError.mockReset();
+				registerCrashHandler({
+					logger: 'mock-logger',
+					process: mockProcess
+				});
+			});
+
+			describe('uncaughtExceptionHandler(error)', () => {
+				let error;
+				let uncaughtExceptionHandler;
+
+				beforeEach(() => {
+					error = new Error('mock error');
+					uncaughtExceptionHandler = mockProcess.on.mock.calls[0][1];
+					uncaughtExceptionHandler(error);
+				});
+
+				it('logs the error as being unhandled with the custom logger', () => {
+					expect(logUnhandledError).toBeCalledTimes(1);
+					expect(logUnhandledError).toBeCalledWith({
+						error,
+						logger: 'mock-logger'
+					});
+				});
+			});
+		});
+
 		describe('when `options.process` is undefined', () => {
 			let mockGlobalProcess;
 			let originalProcess;

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -1,18 +1,19 @@
 
-## @dotcom-reliability-kit/log-error
+# @dotcom-reliability-kit/log-error
 
 A method to consistently log error object with optional request information. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
-  * [Usage](#usage)
-    * [`logHandledError`](#loghandlederror)
-    * [`logRecoverableError`](#logrecoverableerror)
-    * [`logUnhandledError`](#logunhandlederror)
-    * [configuration options](#configuration-options)
-      * [`error`](#optionserror)
-      * [`includeHeaders`](#optionsincludeheaders)
-      * [`request`](#optionsrequest)
-  * [Contributing](#contributing)
-  * [License](#license)
+* [Usage](#usage)
+  * [`logHandledError`](#loghandlederror)
+  * [`logRecoverableError`](#logrecoverableerror)
+  * [`logUnhandledError`](#logunhandlederror)
+  * [Configuration options](#configuration-options)
+    * [`options.error`](#optionserror)
+    * [`options.includeHeaders`](#optionsincludeheaders)
+    * [`options.logger`](#optionslogger)
+    * [`options.request`](#optionsrequest)
+* [Contributing](#contributing)
+* [License](#license)
 
 
 ## Usage
@@ -198,6 +199,28 @@ logRecoverableError({
 
 > **Note**
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
+
+#### `options.logger`
+
+A logger object which implements two methods: `error` and `warn`. It may implement other methods but they're not used. The methods have a very permissive signature:
+
+```ts
+type LogMethod = (...logData: any) => any;
+```
+
+Though it's best if they can accept a single object and output results as JSON.
+
+This option defaults to [n-logger](https://github.com/Financial-Times/n-logger) and is compatible with [n-mask-logger](https://github.com/Financial-Times/n-mask-logger):
+
+```js
+const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
+const MaskLogger = require('@financial-times/n-mask-logger');
+
+logRecoverableError({
+    error: new Error('Oops'),
+    logger: new MaskLogger()
+});
+```
 
 #### `options.request`
 

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -1,14 +1,15 @@
 
-## @dotcom-reliability-kit/middleware-log-errors
+# @dotcom-reliability-kit/middleware-log-errors
 
 Express middleware to consistently log errors. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
-  * [Usage](#usage)
-    * [`createErrorLogger`](#createerrorlogger)
-    * [configuration options](#configuration-options)
-      * [`includeHeaders`](#optionsincludeheaders)
-  * [Contributing](#contributing)
-  * [License](#license)
+* [Usage](#usage)
+  * [`createErrorLogger`](#createerrorlogger)
+  * [Configuration options](#configuration-options)
+    * [`options.includeHeaders`](#optionsincludeheaders)
+    * [`options.logger`](#optionslogger)
+* [Contributing](#contributing)
+* [License](#license)
 
 
 ## Usage
@@ -128,6 +129,16 @@ app.use(createErrorLogger({
 
 > **Note**
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
+
+#### `options.logger`
+
+A logger object which implements two methods, `error` and `warn`, which have the following permissive signature:
+
+```ts
+type LogMethod = (...logData: any) => any;
+```
+
+This is passed directly onto the relevant log-error method, [see the documentation for that package for more details](../log-error/README.md#optionslogger).
 
 
 ## Contributing

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -4,6 +4,8 @@ const { logHandledError } = require('@dotcom-reliability-kit/log-error');
  * @typedef {object} ErrorLoggingOptions
  * @property {Array<string>} [includeHeaders]
  *     An array of request headers to include in the log.
+ * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
+ *     The logger to use to output errors. Defaults to n-logger.
  */
 
 /**
@@ -37,6 +39,7 @@ function createErrorLoggingMiddleware(options = {}) {
 			logHandledError({
 				error,
 				includeHeaders,
+				logger: options.logger,
 				request
 			});
 

--- a/packages/middleware-log-errors/test/unit/lib/index.spec.js
+++ b/packages/middleware-log-errors/test/unit/lib/index.spec.js
@@ -90,6 +90,23 @@ describe('@dotcom-reliability-kit/middleware-log-errors', () => {
 			});
 		});
 
+		describe('when the logger option is set', () => {
+			beforeEach(() => {
+				middleware = createErrorLoggingMiddleware({
+					logger: 'mock-logger'
+				});
+				middleware(error, request, response, next);
+			});
+
+			it('passes on the custom logger to the log method', () => {
+				expect(logHandledError).toBeCalledWith({
+					error,
+					request,
+					logger: 'mock-logger'
+				});
+			});
+		});
+
 		describe('when logging fails', () => {
 			beforeEach(() => {
 				logHandledError.mockImplementation(() => {


### PR DESCRIPTION
Setting a custom logger is essential for teams who use log masking or their app relies on other custom logging (e.g. their logger must include certain base data).

This is more complex than I originally thought, as we can no longer trust the logging methods that we're using. Because of this I'm now wrapping all our error logging in a try/catch so that we can fall back to logging via `console.log` which is guaranteed to work. This is a similar approach to @reliability-kit/logger.

This resolves #221.

## Examples of how/why you'd use this

Log masking:

```js
const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
const MaskLogger = require('@financial-times/n-mask-logger');

logRecoverableError({
    error: new Error('Oops'),
    logger: new MaskLogger()
});
```

Adding base data:

```js
const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
const {Logger} = require('@dotcom-reliability-kit/logger');

logRecoverableError({
    error: new Error('Oops'),
    logger: new Logger({
        baseLogData: {
            example:  true
        }
    })
});
```