### PR TITLE
feat: use AWS environment variables in app-info

### DIFF
--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -34,11 +34,11 @@ The `appInfo` object has several properties which can be used to access applicat
 
 ### `appInfo.commitHash`
 
-Get the commit hash that the application last deployed. This will be a string (if `process.env.HEROKU_SLUG_COMMIT` or `process.env.GIT_COMMIT` is defined) or `null` otherwise.
+Get the commit hash that the application last deployed. This will be a string (if `process.env.HEROKU_SLUG_COMMIT`, `process.env.GIT_COMMIT_LONG`, or `process.env.GIT_COMMIT` is defined) or `null` otherwise.
 
 For Heroku, this relies on the [Dyno Metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
 
-For AWS Lambda, you can set the `GIT_COMMIT` environment variable using a plugin, e.g. [serverless-plugin-git-variables](https://www.npmjs.com/package/serverless-plugin-git-variables).
+For AWS Lambda, you can use a plugin like [serverless-plugin-git-variables](https://www.npmjs.com/package/serverless-plugin-git-variables) to provide this data or set the `GIT_COMMIT` environment variable during deployment.
 
 ### `appInfo.environment`
 

--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -34,7 +34,11 @@ The `appInfo` object has several properties which can be used to access applicat
 
 ### `appInfo.commitHash`
 
-Get the commit hash that the application last deployed. This will be a string (if `process.env.HEROKU_SLUG_COMMIT` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+Get the commit hash that the application last deployed. This will be a string (if `process.env.HEROKU_SLUG_COMMIT` or `process.env.GIT_COMMIT` is defined) or `null` otherwise.
+
+For Heroku, this relies on the [Dyno Metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+
+For AWS Lambda, you can set the `GIT_COMMIT` environment variable using a plugin, e.g. [serverless-plugin-git-variables](https://www.npmjs.com/package/serverless-plugin-git-variables).
 
 ### `appInfo.environment`
 
@@ -42,15 +46,19 @@ Get the application environment, normally either `development` or `production`. 
 
 ### `appInfo.region`
 
-Get the application Heroku region. This will be a string (if `process.env.REGION` is defined) or `null` otherwise.
+Get the region that the application is running in. This will be a string (if `process.env.REGION` or `process.env.AWS_REGION` is defined) or `null` otherwise.
 
 ### `appInfo.releaseDate`
 
-Get the application Heroku release date. This will be a string (if `process.env.HEROKU_RELEASE_CREATED_AT` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+Get the application Heroku release date. This will be a string (if `process.env.HEROKU_RELEASE_CREATED_AT` is defined) or `null` otherwise.
+
+For Heroku, this relies on the [Dyno Metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
 
 ### `appInfo.releaseVersion`
 
-Get the application Heroku release version. This will be a string (if `process.env.HEROKU_RELEASE_VERSION` is defined) or `null` otherwise. This relies on the [Heroku Dyno metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
+Get the application Heroku release version. This will be a string (if `process.env.HEROKU_RELEASE_VERSION` or `process.env.AWS_LAMBDA_FUNCTION_VERSION` is defined) or `null` otherwise.
+
+For Heroku, this relies on the [Dyno Metadata labs feature](https://devcenter.heroku.com/articles/dyno-metadata) and will not be present in local development.
 
 ### `appInfo.systemCode`
 

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -1,5 +1,11 @@
 const path = require('path');
 
+// This package relies on Heroku and AWS Lambda environment variables.
+// Documentation for these variables is available here:
+//
+//   - Heroku: https://devcenter.heroku.com/articles/dyno-metadata
+//   - Lambda: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
+
 /**
  * Get the application system code from a package.json file.
  *
@@ -47,7 +53,7 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	commitHash: process.env.HEROKU_SLUG_COMMIT || null,
+	commitHash: process.env.HEROKU_SLUG_COMMIT || process.env.GIT_COMMIT || null,
 
 	/**
 	 * The application environment.
@@ -63,7 +69,7 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	region: process.env.REGION || null,
+	region: process.env.REGION || process.env.AWS_REGION || null,
 
 	/**
 	 * The date and time that the application was last released at.
@@ -79,7 +85,10 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	releaseVersion: process.env.HEROKU_RELEASE_VERSION || null,
+	releaseVersion:
+		process.env.HEROKU_RELEASE_VERSION ||
+		process.env.AWS_LAMBDA_FUNCTION_VERSION ||
+		null,
 
 	/**
 	 * The application system code.

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -53,7 +53,11 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	commitHash: process.env.HEROKU_SLUG_COMMIT || process.env.GIT_COMMIT || null,
+	commitHash:
+		process.env.HEROKU_SLUG_COMMIT ||
+		process.env.GIT_COMMIT_LONG ||
+		process.env.GIT_COMMIT ||
+		null,
 
 	/**
 	 * The application environment.

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -6,6 +6,7 @@ describe('@dotcom-reliability-kit/app-info', () => {
 		process.env.AWS_LAMBDA_FUNCTION_VERSION = 'mock-aws-release-version';
 		process.env.AWS_REGION = 'mock-aws-region';
 		process.env.GIT_COMMIT = 'mock-git-commit';
+		process.env.GIT_COMMIT_LONG = 'mock-git-commit-long';
 		process.env.HEROKU_RELEASE_CREATED_AT = 'mock-heroku-release-date';
 		process.env.HEROKU_RELEASE_VERSION = 'mock-heroku-release-version';
 		process.env.HEROKU_SLUG_COMMIT = 'mock-heroku-commit-hash';
@@ -33,15 +34,29 @@ describe('@dotcom-reliability-kit/app-info', () => {
 				appInfo = require('../../../lib');
 			});
 
+			it('is set to `process.env.GIT_COMMIT_LONG`', () => {
+				expect(appInfo.commitHash).toBe('mock-git-commit-long');
+			});
+		});
+
+		describe('when both `process.env.HEROKU_SLUG_COMMIT` and `process.env.GIT_COMMIT_LONG` are not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.GIT_COMMIT_LONG;
+				delete process.env.HEROKU_SLUG_COMMIT;
+				appInfo = require('../../../lib');
+			});
+
 			it('is set to `process.env.GIT_COMMIT`', () => {
 				expect(appInfo.commitHash).toBe('mock-git-commit');
 			});
 		});
 
-		describe('when neither environment variable is defined', () => {
+		describe('when no commit-related environment variable is defined', () => {
 			beforeEach(() => {
 				jest.resetModules();
 				delete process.env.GIT_COMMIT;
+				delete process.env.GIT_COMMIT_LONG;
 				delete process.env.HEROKU_SLUG_COMMIT;
 				appInfo = require('../../../lib');
 			});

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -3,9 +3,12 @@ describe('@dotcom-reliability-kit/app-info', () => {
 
 	beforeEach(() => {
 		jest.spyOn(process, 'cwd').mockReturnValue('/mock-cwd');
-		process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
-		process.env.HEROKU_RELEASE_VERSION = 'mock-release-version';
-		process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
+		process.env.AWS_LAMBDA_FUNCTION_VERSION = 'mock-aws-release-version';
+		process.env.AWS_REGION = 'mock-aws-region';
+		process.env.GIT_COMMIT = 'mock-git-commit';
+		process.env.HEROKU_RELEASE_CREATED_AT = 'mock-heroku-release-date';
+		process.env.HEROKU_RELEASE_VERSION = 'mock-heroku-release-version';
+		process.env.HEROKU_SLUG_COMMIT = 'mock-heroku-commit-hash';
 		process.env.NODE_ENV = 'mock-environment';
 		process.env.REGION = 'mock-region';
 		process.env.SYSTEM_CODE = 'mock-system-code';
@@ -20,12 +23,25 @@ describe('@dotcom-reliability-kit/app-info', () => {
 
 	describe('.commitHash', () => {
 		it('is set to `process.env.HEROKU_SLUG_COMMIT`', () => {
-			expect(appInfo.commitHash).toBe('mock-commit-hash');
+			expect(appInfo.commitHash).toBe('mock-heroku-commit-hash');
 		});
 
 		describe('when `process.env.HEROKU_SLUG_COMMIT` is not defined', () => {
 			beforeEach(() => {
 				jest.resetModules();
+				delete process.env.HEROKU_SLUG_COMMIT;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to `process.env.GIT_COMMIT`', () => {
+				expect(appInfo.commitHash).toBe('mock-git-commit');
+			});
+		});
+
+		describe('when neither environment variable is defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.GIT_COMMIT;
 				delete process.env.HEROKU_SLUG_COMMIT;
 				appInfo = require('../../../lib');
 			});
@@ -66,6 +82,19 @@ describe('@dotcom-reliability-kit/app-info', () => {
 				appInfo = require('../../../lib');
 			});
 
+			it('is set to `process.env.AWS_REGION`', () => {
+				expect(appInfo.region).toBe('mock-aws-region');
+			});
+		});
+
+		describe('when neither environment variable is defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.AWS_REGION;
+				delete process.env.REGION;
+				appInfo = require('../../../lib');
+			});
+
 			it('is set to null', () => {
 				expect(appInfo.region).toBe(null);
 			});
@@ -74,7 +103,7 @@ describe('@dotcom-reliability-kit/app-info', () => {
 
 	describe('.releaseDate', () => {
 		it('is set to `process.env.HEROKU_RELEASE_CREATED_AT`', () => {
-			expect(appInfo.releaseDate).toBe('mock-release-date');
+			expect(appInfo.releaseDate).toBe('mock-heroku-release-date');
 		});
 
 		describe('when `process.env.HEROKU_RELEASE_CREATED_AT` is not defined', () => {
@@ -92,12 +121,25 @@ describe('@dotcom-reliability-kit/app-info', () => {
 
 	describe('.releaseVersion', () => {
 		it('is set to `process.env.HEROKU_RELEASE_VERSION`', () => {
-			expect(appInfo.releaseVersion).toBe('mock-release-version');
+			expect(appInfo.releaseVersion).toBe('mock-heroku-release-version');
 		});
 
 		describe('when `process.env.HEROKU_RELEASE_VERSION` is not defined', () => {
 			beforeEach(() => {
 				jest.resetModules();
+				delete process.env.HEROKU_RELEASE_VERSION;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to `process.env.AWS_LAMBDA_FUNCTION_VERSION`', () => {
+				expect(appInfo.releaseVersion).toBe('mock-aws-release-version');
+			});
+		});
+
+		describe('when neither environment variable is defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.AWS_LAMBDA_FUNCTION_VERSION;
 				delete process.env.HEROKU_RELEASE_VERSION;
 				appInfo = require('../../../lib');
 			});


### PR DESCRIPTION
This increases Reliability Kit's usefulness in an AWS environment, falling back to AWS and more generic variable names if the Heroku environment variables are not present. We can do this relatively easily for region, release version, and commit hash.

[Documentation on these environment variables is here](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime).