### PR TITLE
fix: use fake timers in middleware rendering snapshot test

### DIFF
--- a/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
@@ -344,7 +344,7 @@ See the <a href="https://github.com/Financial-Times/dotcom-reliability-kit/blob/
 <a href="http://help.ft.com/help/legal-privacy/terms-conditions">Terms &amp; Conditions</a>
 </div>
 <p>
-<span>&#xA9; THE FINANCIAL TIMES LTD 2022.</span> FT and
+<span>&#xA9; THE FINANCIAL TIMES LTD 1888.</span> FT and
 &apos;Financial Times&apos; are trademarks of The Financial Times Ltd.
 </p>
 </div>

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -64,6 +64,9 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 		let response;
 
 		beforeEach(() => {
+			// The error page template contains the current year
+			jest.useFakeTimers().setSystemTime(new Date('1888-01-09'));
+
 			error = new Error('mock error');
 			request = {
 				method: 'mock request method',


### PR DESCRIPTION
This test contains the current year for the copyright in the footer. The year changes every year so we should stub it.