### PR TITLE
feat: mark the logger package as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ We maintain documentation in this repo:
     * **[@dotcom-reliability-kit/log-error](./packages/log-error/#readme):**<br/>
       A method to consistently log error object with optional request information
 
+    * **[@dotcom-reliability-kit/logger](./packages/logger/#readme):**<br/>
+      A simple and fast logger based on [Pino](https://getpino.io/), with FT preferences baked in
+
     * **[@dotcom-reliability-kit/middleware-log-errors](./packages/middleware-log-errors/#readme):**<br/>
       Express middleware to consistently log errors
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,9 +1,6 @@
 
 ## @dotcom-reliability-kit/logger
 
-> **Warning**
-> This Reliability Kit package is **experimental** and should not be used in critical production applications until we've reached a stable version (the latest major version is greater than `0`).
-
 A simple and fast logger based on [Pino](https://getpino.io/), with FT preferences baked in. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
   * [Usage](#usage)


### PR DESCRIPTION
The logger package is now considered stable and ready for use in production. This PR removes the warnings in the package README and adds the logger to the main README.