### PR TITLE
docs: use the new logger in serverless example

### DIFF
--- a/examples/serverless/handler.js
+++ b/examples/serverless/handler.js
@@ -2,7 +2,7 @@
 
 const { OperationalError } = require('@dotcom-reliability-kit/errors');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
-const logger = require('@financial-times/n-serverless-logger').default;
+const logger = require('@dotcom-reliability-kit/logger');
 
 module.exports.example = async (event) => {
 	if (event.status === 'bad') {

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@dotcom-reliability-kit/errors": "*",
     "@dotcom-reliability-kit/log-error": "*",
-    "@financial-times/n-serverless-logger": "0.5.1"
+    "@dotcom-reliability-kit/logger": "*"
   },
   "devDependencies": {
     "serverless": "3.26.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
       "dependencies": {
         "@dotcom-reliability-kit/errors": "*",
         "@dotcom-reliability-kit/log-error": "*",
-        "@financial-times/n-serverless-logger": "0.5.1"
+        "@dotcom-reliability-kit/logger": "*"
       },
       "devDependencies": {
         "serverless": "3.26.0"
@@ -1210,75 +1210,6 @@
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-serverless-logger/-/n-serverless-logger-0.5.1.tgz",
-      "integrity": "sha512-FWMkAKYF9n6UtWGPc39DEAUyXkzmEwzP1wPprF6mmt+5bKWSspyXGwP9PjBkfjHAisuVJ/JPwq8yMKDu6iGvig==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "chalk": "^2.3.2"
-      },
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@financial-times/n-serverless-logger/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@google-automations/git-file-utils": {
@@ -5588,6 +5519,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -13615,7 +13547,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "0.1.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^1.1.0",
@@ -13653,7 +13585,7 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^1.1.0",
@@ -14490,7 +14422,7 @@
       "requires": {
         "@dotcom-reliability-kit/errors": "*",
         "@dotcom-reliability-kit/log-error": "*",
-        "@financial-times/n-serverless-logger": "0.5.1",
+        "@dotcom-reliability-kit/logger": "*",
         "serverless": "3.26.0"
       }
     },
@@ -14658,60 +14590,6 @@
         "@dotcom-reliability-kit/log-error": "^1.3.0",
         "@financial-times/n-logger": "^10.2.0",
         "raven": "^2.3.0"
-      }
-    },
-    "@financial-times/n-serverless-logger": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-serverless-logger/-/n-serverless-logger-0.5.1.tgz",
-      "integrity": "sha512-FWMkAKYF9n6UtWGPc39DEAUyXkzmEwzP1wPprF6mmt+5bKWSspyXGwP9PjBkfjHAisuVJ/JPwq8yMKDu6iGvig==",
-      "requires": {
-        "chalk": "^2.3.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "@google-automations/git-file-utils": {
@@ -18166,7 +18044,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",


### PR DESCRIPTION
This switches the Serverless example to use the Reliability Kit logger rather than n-serverless-logger, now that it's stable.