### PR TITLE
chore: add a commitlint action to validate PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,21 @@
+name: Enforce commit formatting
+on: [pull_request]
+jobs:
+  run-commitlint-on-pr:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Validate all commits from the PR
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
This ensures that PRs contain only valid commit messages. We all run this locally via Husky but if a PR is opened via edits in the GitHub interface then we rely on one of us spotting an incorrect commit message. This addresses that by failing the build.

I decided to use GitHub Actions instead of CircleCI for this for a couple of reasons:

  1. GitHub Actions has access to the range of commits that have appeared in the pull request without having to make any API calls. In CircleCI this turned out to be a lot more complex

  2. GitHub Actions are free for open source projects, which this is. So we're not consuming any FT resources to do this.

You can see an example of this build failing here: https://github.com/Financial-Times/dotcom-reliability-kit/pull/410

This resolves #405