### PR TITLE
docs: make the user guide less Express-centric

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -3,7 +3,7 @@
 
 To use Reliability Kit you'll need a few things set up in advance.
 
-  1. A Node.js application (ideally built with [Express](https://expressjs.com/), but you should get some benefits even if you're not using it)
+  1. A Node.js application (ideally built with either [Express](https://expressjs.com/) or AWS Lambda with [Serverless](https://www.serverless.com/), but you should get some benefits even if you're not using these)
 
   2. For your application to be running on [Node.js](https://nodejs.org/) 14 or above
 

--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -3,19 +3,21 @@
 
 Throwing good errors is key to producing a reliable application. Most of Reliability Kit's packages rely on sensible errors being thrown if a fault is encountered in your app, and without reviewing your existing errors you won't get as much value from using it.
 
-  * [Types of error](#types-of-error)
-    * [Operational errors](#operational-errors)
-    * [Programmer errors](#programmer-errors)
-  * [Types of error in code](#types-of-error-in-code)
-    * [Operational errors in library code](#operational-errors-in-library-code)
-  * [What does a good error look like?](#what-does-a-good-error-look-like)
-    * [Using error objects](#using-error-objects)
-    * [Making errors human readable](#making-errors-human-readable)
-    * [Making errors machine readable](#making-errors-machine-readable)
-      * [Error codes](#error-codes)
-      * [Error classes](#error-classes)
-    * [Adding more data](#adding-more-data)
-    * [Being specific](#being-specific)
+The examples in this file assume Express, but the same principles of throwing well-structured errors apply to AWS Lambda or any other framework you're using.
+
+* [Types of error](#types-of-error)
+  * [Operational errors](#operational-errors)
+  * [Programmer errors](#programmer-errors)
+* [Types of error in code](#types-of-error-in-code)
+  * [Operational errors in library code](#operational-errors-in-library-code)
+* [What does a good error look like?](#what-does-a-good-error-look-like)
+  * [Using error objects](#using-error-objects)
+  * [Making errors human readable](#making-errors-human-readable)
+  * [Making errors machine readable](#making-errors-machine-readable)
+    * [Error codes](#error-codes)
+    * [Error classes](#error-classes)
+  * [Adding more data](#adding-more-data)
+  * [Being specific](#being-specific)
 
 
 ## Types of error


### PR DESCRIPTION
The getting started guide was quite Express-centric. I've added in examples using AWS Lambda/Serverless and made the language a lot more friendly to non-Express apps.

Resolves [CPREL-478](https://financialtimes.atlassian.net/browse/CPREL-478)

[CPREL-478]: https://financialtimes.atlassian.net/browse/CPREL-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ