### PR TITLE
feat: add filter option to the logging middleware

### DIFF
--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -86,6 +86,34 @@ app.use(createErrorLogger({
 }));
 ```
 
+#### `options.filter`
+
+A function used to determine whether a particular error or request should be logged. This must be a `Function` which returns a `Boolean` and accepts both an error object and an Express Request object:
+
+```ts
+type ErrorLoggingFilter = (error: any, request: express.Request) => boolean;
+```
+
+If the function returns `true` then the error and request details will be logged. Otherwise no logs will be output.
+
+> **Warning**
+> This option can be dangerous, misconfiguring it can result in a loss of log information. Consider whether you _definitely_ need to filter logs before using, sometimes it's better to have a few too many logs than miss an important one.
+
+Example of usage:
+```js
+app.use(createErrorLogger({
+    filter: (error, request) => {
+        if (request.url === '/deliberate-erroring-endpoint') {
+            return false;
+        }
+        if (error?.code === 'ERROR_WE_DO_NOT_CARE_ABOUT') {
+            return false;
+        }
+        return true;
+    }
+}));
+```
+
 #### `options.includeHeaders`
 
 An array of request headers to include in the serialized request object. This must be an `Array` of `String`s, with each string being a header name. It's important that you do not include headers which include personally-identifiable-information, API keys, or other privileged information. This option gets passed directly into [`dotcom-reliability-kit/serialize-request`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-request#readme) which has further documentation.

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -65,7 +65,7 @@ function createErrorLoggingMiddleware(options = {}) {
 						return next(error);
 					}
 				} catch (/** @type {any} */ filterError) {
-					// If the filtering fails we just log the reguler error as-is but
+					// If the filtering fails we just log the regular error as-is but
 					// also log that the filtering failed
 					logRecoverableError({
 						// This is not an operational error because the filtering

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -1,9 +1,24 @@
-const { logHandledError } = require('@dotcom-reliability-kit/log-error');
+const {
+	logHandledError,
+	logRecoverableError
+} = require('@dotcom-reliability-kit/log-error');
+
+/**
+ * @callback ErrorLoggingFilter
+ * @param {any} error
+ *     The error that will be logged.
+ * @param {import('express').Request} request
+ *     The Express request that resulted in the error.
+ * @returns {boolean | void}
+ *     Returns `true` if the error should be logged.
+ */
 
 /**
  * @typedef {object} ErrorLoggingOptions
  * @property {Array<string>} [includeHeaders]
  *     An array of request headers to include in the log.
+ * @property {ErrorLoggingFilter} [filter]
+ *     A filter function to determine whether an error should be logged.
  * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
  *     The logger to use to output errors. Defaults to n-logger.
  */
@@ -32,10 +47,40 @@ function createErrorLoggingMiddleware(options = {}) {
 		}
 	}
 
+	// Validate the error filter.
+	const filter = options?.filter;
+	if (filter && typeof filter !== 'function') {
+		throw new TypeError('The `filter` option must be a function');
+	}
+
 	return function errorLoggingMiddleware(error, request, response, next) {
 		// We add a paranoid try/catch here because it'd be really embarassing
 		// if the error logging middleware threw an unhandled error, wouldn't it
 		try {
+			// If we have a filter then check whether the error should be logged
+			if (filter) {
+				try {
+					const shouldLog = filter(error, request);
+					if (!shouldLog) {
+						return next(error);
+					}
+				} catch (/** @type {any} */ filterError) {
+					// If the filtering fails we just log the reguler error as-is but
+					// also log that the filtering failed
+					logRecoverableError({
+						// This is not an operational error because the filtering
+						// error is highly likely to be a programmer error
+						error: Object.assign(new Error('Log filtering failed'), {
+							code: 'LOG_FILTER_FAILURE',
+							cause: filterError
+						}),
+						includeHeaders,
+						logger: options.logger,
+						request
+					});
+				}
+			}
+
 			logHandledError({
 				error,
 				includeHeaders,

--- a/packages/middleware-log-errors/test/end-to-end/fixtures/app.js
+++ b/packages/middleware-log-errors/test/end-to-end/fixtures/app.js
@@ -21,7 +21,23 @@ app.get('/error', () => {
 	throw error;
 });
 
-app.use(createErrorLogger());
+app.get('/error-filtered', () => {
+	const error = new Error('example filtered error');
+	error.stack = 'mock stack';
+	error.code = 'FILTERED_ERROR';
+	throw error;
+});
+
+app.use(
+	createErrorLogger({
+		filter: (error) => {
+			if (error?.code === 'FILTERED_ERROR') {
+				return false;
+			}
+			return true;
+		}
+	})
+);
 
 app.listen(undefined).then((server) => {
 	if (process.send) {

--- a/packages/middleware-log-errors/test/end-to-end/index.spec.js
+++ b/packages/middleware-log-errors/test/end-to-end/index.spec.js
@@ -71,4 +71,14 @@ describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {
 			});
 		});
 	});
+
+	describe('GET /error-filtered', () => {
+		beforeAll(async () => {
+			await fetch(`${baseUrl}/error-filtered`);
+		});
+
+		it('does not log error information to stdout', () => {
+			expect(stderr).not.toContain('FILTERED_ERROR');
+		});
+	});
 });


### PR DESCRIPTION
This allows an app to tell the error logging middleware not to log for specific errors or requests. I think this is required for us to use the error logging middleware in next-api because [it filters out certain logs based on which app has made the request](https://github.com/Financial-Times/next-api/blob/0a700435124f5c30b6b52d333acb2f1e28e0c6a8/server/utils/log-app-error.js#L8).

Without a filter for these errors we'll see a dramatic noisy increase in next-api logs

I don't want this option to start being used frequently across our apps so there's a warning in the README. I'm also sending further logs if someone misconfigures the option so that we have visibility if an app has broken logging due to use of this feature.