### PR TITLE
fix: simplify and tidy up the error types

### DIFF
--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -15,7 +15,7 @@ class DataStoreError extends OperationalError {
 	/**
 	 * Create a data store error.
 	 *
-	 * @param {(string | OperationalError.OperationalErrorData & Record<string, any>)} [data = {}]
+	 * @param {string | OperationalError.OperationalErrorData} [data = {}]
 	 *     The error message if it's a string, or full error information if an object.
 	 */
 	constructor(data = {}) {

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -11,9 +11,13 @@ const OperationalError = require('./operational-error');
 const STATUS_CODES = require('http').STATUS_CODES;
 
 /**
- * @typedef {object} HttpErrorData
+ * @typedef {object} HttpErrorStrictData
  * @property {number} [statusCode]
  *     An HTTP status code.
+ */
+
+/**
+ * @typedef {HttpErrorStrictData & OperationalError.OperationalErrorData} HttpErrorData
  */
 
 /**
@@ -53,7 +57,7 @@ class HttpError extends OperationalError {
 	/**
 	 * Create an HTTP error.
 	 *
-	 * @param {(string | number | HttpErrorData & OperationalError.OperationalErrorData & Record<string, any>)} [data = {}]
+	 * @param {string | number | HttpErrorData} [data = {}]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
 	 */

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {object} OperationalErrorData
+ * @typedef {object} OperationalErrorStrictData
  * @property {string} [code]
  *     A machine-readable error code which identifies the specific type of error.
  * @property {string} [message]
@@ -8,6 +8,10 @@
  *     An array of FT system codes which are related to this error.
  * @property {Error|null} [cause]
  *     The root cause error instance.
+ */
+
+/**
+ * @typedef {OperationalErrorStrictData & Record<string, any>} OperationalErrorData
  */
 
 /**
@@ -71,7 +75,7 @@ class OperationalError extends Error {
 	/**
 	 * Create an operational error.
 	 *
-	 * @param {(string | OperationalErrorData & Record<string, any>)} [data = {}]
+	 * @param {string | OperationalErrorData} [data]
 	 *     The error message if it's a string, or full error information if an object.
 	 */
 	constructor(data = {}) {

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -15,7 +15,7 @@ class UpstreamServiceError extends HttpError {
 	/**
 	 * Create an upstream service error.
 	 *
-	 * @param {(string | number | HttpError.HttpErrorData & import('./operational-error').OperationalErrorData & Record<string, any>)} [data = {}]
+	 * @param {string | number | HttpError.HttpErrorData} [data = {}]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
 	 */

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -15,7 +15,7 @@ class UserInputError extends HttpError {
 	/**
 	 * Create a user input error.
 	 *
-	 * @param {(string | HttpError.HttpErrorData & import('./operational-error').OperationalErrorData & Record<string, any>)} [data = {}]
+	 * @param {string | HttpError.HttpErrorData} [data = {}]
 	 *     The error message if it's a string or full error information if an object.
 	 */
 	constructor(data = {}) {


### PR DESCRIPTION
This is preparatory work to make sure that #438 can be completed easily without copying a lot of complex types around.

We move the union of the `Record<string, any>` type into the `OperationalErrorData` type itself which massively simplifies the types in the constructors for all the other errors.