### PR TITLE
docs: update the table of contents

### DIFF
--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -6,6 +6,7 @@ Express middleware to consistently log errors. This module is part of [FT.com Re
 * [Usage](#usage)
   * [`createErrorLogger`](#createerrorlogger)
   * [Configuration options](#configuration-options)
+    * [`options.filter`](#optionsfilter)
     * [`options.includeHeaders`](#optionsincludeheaders)
     * [`options.logger`](#optionslogger)
 * [Contributing](#contributing)


### PR DESCRIPTION
The table-of-contents wasn't updated in the PR which added the filter option. This adds a link to that section.