### PR TITLE
feat: support Node.js 18 error signatures

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -65,6 +65,14 @@ error.message // example message
 error.code // EXAMPLE_CODE
 ```
 
+You can also combine these two ways of constructing errors, passing in both a message as well as additional options. This applies to all error types:
+
+```js
+throw new OperationalError('example message', {
+    code: 'EXAMPLE_CODE'
+});
+```
+
 You may also pass additional properties into an error object, these will be collected and stored on a `data` property on the error:
 
 ```js

--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -15,11 +15,13 @@ class DataStoreError extends OperationalError {
 	/**
 	 * Create a data store error.
 	 *
-	 * @param {string | OperationalError.OperationalErrorData} [data = {}]
+	 * @param {string | OperationalError.OperationalErrorData} [message]
 	 *     The error message if it's a string, or full error information if an object.
+	 * @param {OperationalError.OperationalErrorData} [data]
+	 *     Additional error information if `message` is a string.
 	 */
-	constructor(data = {}) {
-		super(data);
+	constructor(message, data = {}) {
+		super(message, data);
 	}
 }
 

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -57,16 +57,19 @@ class HttpError extends OperationalError {
 	/**
 	 * Create an HTTP error.
 	 *
-	 * @param {string | number | HttpErrorData} [data = {}]
+	 * @param {string | number | HttpErrorData} [message]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
+	 * @param {HttpErrorData} [data]
+	 *     Additional error information if `message` is a string or number.
 	 */
-	constructor(data = {}) {
-		if (typeof data === 'string') {
-			data = { message: data };
-		}
-		if (typeof data === 'number') {
-			data = { statusCode: data };
+	constructor(message, data = {}) {
+		if (typeof message === 'string') {
+			data.message = message;
+		} else if (typeof message === 'number') {
+			data.statusCode = message;
+		} else {
+			data = message || data;
 		}
 
 		// Make sure that we don't modify the original data object

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -75,12 +75,16 @@ class OperationalError extends Error {
 	/**
 	 * Create an operational error.
 	 *
-	 * @param {string | OperationalErrorData} [data]
+	 * @param {string | OperationalErrorData} [message]
 	 *     The error message if it's a string, or full error information if an object.
+	 * @param {OperationalErrorData} [data]
+	 *     Additional error information if `message` is a string.
 	 */
-	constructor(data = {}) {
-		if (typeof data === 'string') {
-			data = { message: data };
+	constructor(message, data = {}) {
+		if (typeof message === 'string') {
+			data.message = message;
+		} else {
+			data = message || data;
 		}
 		super(data.message || 'An operational error occurred');
 

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -15,16 +15,19 @@ class UpstreamServiceError extends HttpError {
 	/**
 	 * Create an upstream service error.
 	 *
-	 * @param {string | number | HttpError.HttpErrorData} [data = {}]
+	 * @param {string | number | HttpError.HttpErrorData} [message]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information if `message` is a string or number.
 	 */
-	constructor(data = {}) {
-		if (typeof data === 'string') {
-			data = { message: data };
-		}
-		if (typeof data === 'number') {
-			data = { statusCode: data };
+	constructor(message, data = {}) {
+		if (typeof message === 'string') {
+			data.message = message;
+		} else if (typeof message === 'number') {
+			data.statusCode = message;
+		} else {
+			data = message || data;
 		}
 
 		// Make sure that we don't modify the original data object

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -15,12 +15,19 @@ class UserInputError extends HttpError {
 	/**
 	 * Create a user input error.
 	 *
-	 * @param {string | HttpError.HttpErrorData} [data = {}]
-	 *     The error message if it's a string or full error information if an object.
+	 * @param {string | number | HttpError.HttpErrorData} [message]
+	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
+	 *     information if an object.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information if `message` is a string or number.
 	 */
-	constructor(data = {}) {
-		if (typeof data === 'string') {
-			data = { message: data };
+	constructor(message, data = {}) {
+		if (typeof message === 'string') {
+			data.message = message;
+		} else if (typeof message === 'number') {
+			data.statusCode = message;
+		} else {
+			data = message || data;
 		}
 
 		// Make sure that we don't modify the original data object

--- a/packages/errors/test/unit/lib/data-store-error.spec.js
+++ b/packages/errors/test/unit/lib/data-store-error.spec.js
@@ -122,6 +122,31 @@ describe('@dotcom-reliability-kit/errors/lib/data-store-error', () => {
 		});
 	});
 
+	describe('new DataStoreError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			instance = new DataStoreError('mock message', {
+				code: 'mock_code'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+	});
+
 	describe('.default', () => {
 		it('aliases the module exports', () => {
 			expect(DataStoreError.default).toStrictEqual(DataStoreError);

--- a/packages/errors/test/unit/lib/http-error.spec.js
+++ b/packages/errors/test/unit/lib/http-error.spec.js
@@ -281,6 +281,88 @@ describe('@dotcom-reliability-kit/errors/lib/http-error', () => {
 		});
 	});
 
+	describe('new HttpError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new HttpError('mock message', {
+				code: 'mock_code',
+				statusCode: 567
+			});
+		});
+
+		it('normalizes the passed in error code', () => {
+			expect(HttpError.normalizeErrorCode).toBeCalledWith('mock_code');
+		});
+
+		it('normalizes the passed in status code', () => {
+			expect(HttpError.normalizeErrorStatusCode).toBeCalledWith(567);
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
+	describe('new HttpError(statusCode, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new HttpError(567, {
+				message: 'mock message',
+				code: 'mock_code'
+			});
+		});
+
+		it('normalizes the passed in error code', () => {
+			expect(HttpError.normalizeErrorCode).toBeCalledWith('mock_code');
+		});
+
+		it('normalizes the passed in status code', () => {
+			expect(HttpError.normalizeErrorStatusCode).toBeCalledWith(567);
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
 	describe('.normalizeErrorStatusCode(statusCode)', () => {
 		describe('when the status code is a valid error code', () => {
 			it('returns the passed in status code', () => {

--- a/packages/errors/test/unit/lib/operational-error.spec.js
+++ b/packages/errors/test/unit/lib/operational-error.spec.js
@@ -197,6 +197,36 @@ describe('@dotcom-reliability-kit/errors/lib/operational-error', () => {
 		});
 	});
 
+	describe('new OperationalError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest
+				.spyOn(OperationalError, 'normalizeErrorCode')
+				.mockReturnValue('MOCK_CODE');
+
+			instance = new OperationalError('mock message', {
+				code: 'mock_code'
+			});
+		});
+
+		it('normalizes the passed in error code', () => {
+			expect(OperationalError.normalizeErrorCode).toBeCalledWith('mock_code');
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the message parameter', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+	});
+
 	describe('isErrorMarkedAsOperational(error)', () => {
 		describe('when called with an OperationalError instance', () => {
 			it('returns `true`', () => {

--- a/packages/errors/test/unit/lib/upstream-service-error.spec.js
+++ b/packages/errors/test/unit/lib/upstream-service-error.spec.js
@@ -243,6 +243,68 @@ describe('@dotcom-reliability-kit/errors/lib/upstream-service-error', () => {
 		});
 	});
 
+	describe('new UpstreamServiceError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new UpstreamServiceError('mock message', {
+				code: 'mock_code',
+				statusCode: 567
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
+	describe('new UpstreamServiceError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new UpstreamServiceError(567, {
+				message: 'mock message',
+				code: 'mock_code'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
 	describe('.default', () => {
 		it('aliases the module exports', () => {
 			expect(UpstreamServiceError.default).toStrictEqual(UpstreamServiceError);

--- a/packages/errors/test/unit/lib/user-input-error.spec.js
+++ b/packages/errors/test/unit/lib/user-input-error.spec.js
@@ -1,4 +1,3 @@
-const { UpstreamServiceError } = require('../../../lib');
 const HttpError = require('../../../lib/http-error');
 const UserInputError = require('../../../lib/user-input-error');
 
@@ -134,6 +133,61 @@ describe('@dotcom-reliability-kit/errors/lib/user-input-error', () => {
 		});
 	});
 
+	describe('new UserInputError(statusCode)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			jest
+				.spyOn(HttpError, 'getMessageForStatusCode')
+				.mockReturnValue('mock status message');
+			instance = new UserInputError(456);
+		});
+
+		describe('.code', () => {
+			it('is set to a code representing the normalized status code', () => {
+				expect(instance.code).toStrictEqual('HTTP_456');
+			});
+		});
+
+		describe('.data', () => {
+			it('is set to an empty object', () => {
+				expect(instance.data).toEqual({});
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.message).toStrictEqual('mock status message');
+			});
+		});
+
+		describe('.name', () => {
+			it('is set to "UserInputError"', () => {
+				expect(instance.name).toStrictEqual('UserInputError');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+
+		describe('.status', () => {
+			it('aliases the `statusCode` property', () => {
+				instance.statusCode = 'mock status';
+				expect(instance.status).toStrictEqual('mock status');
+			});
+		});
+
+		describe('.statusMessage', () => {
+			it('is set to the status message for the normalized status code', () => {
+				expect(instance.statusMessage).toStrictEqual('mock status message');
+			});
+		});
+	});
+
 	describe('new UserInputError(data)', () => {
 		let instance;
 
@@ -197,9 +251,71 @@ describe('@dotcom-reliability-kit/errors/lib/user-input-error', () => {
 		});
 	});
 
+	describe('new UserInputError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new UserInputError('mock message', {
+				code: 'mock_code',
+				statusCode: 567
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
+	describe('new UserInputError(message, data)', () => {
+		let instance;
+
+		beforeEach(() => {
+			jest.spyOn(HttpError, 'normalizeErrorCode').mockReturnValue('MOCK_CODE');
+			jest.spyOn(HttpError, 'normalizeErrorStatusCode').mockReturnValue(456);
+			instance = new UserInputError(567, {
+				message: 'mock message',
+				code: 'mock_code'
+			});
+		});
+
+		describe('.code', () => {
+			it('is set to the normalized error code', () => {
+				expect(instance.code).toStrictEqual('MOCK_CODE');
+			});
+		});
+
+		describe('.message', () => {
+			it('is set to the data.message property', () => {
+				expect(instance.message).toStrictEqual('mock message');
+			});
+		});
+
+		describe('.statusCode', () => {
+			it('is set to the normalized status code', () => {
+				expect(instance.statusCode).toStrictEqual(456);
+			});
+		});
+	});
+
 	describe('.default', () => {
 		it('aliases the module exports', () => {
-			expect(UpstreamServiceError.default).toStrictEqual(UpstreamServiceError);
+			expect(UserInputError.default).toStrictEqual(UserInputError);
 		});
 	});
 });


### PR DESCRIPTION
In Node.js 18, the constructor signatures for errors have changed to [support setting both a message and options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error).

Our custom errors did not support this new constructor signatures, this work ensures that they work in the same way as Node.js 18 native errors. See issue #438 for more information.

We now support the following signatures:

```diff
  new OperationalError();
  new OperationalError(message);
  new OperationalError(options);
+ new OperationalError(message, options);
```

This PR resolves #438.

## Caveat

As part of this work, I found that a limitation of TypeScript + JSDoc is that you can't document multiple different overloads for the same method. In TypeScript you can [write the following to document overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads):

```ts
constructor(message: String);
constructor(options: Object);
```

Whereas in JSDoc you currently have to ensure the defined types and variable names match up. This means our types aren't _optimal_ but I think it's fine for now: in TypeScript v5, [overloads will be supported in JSDoc](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#overload-support-in-jsdoc):

```js
/**
 * @overload
 * @param {string} message
 */

/**
 * @overload
 * @param {object} value
 */
```

I've captured this future change in #450.