### PR TITLE
chore: disable exactOptionalPropertyTypes

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"alwaysStrict": true,
 		"checkJs": true,
-		"exactOptionalPropertyTypes": true,
 		"module": "commonjs",
 		"noEmit": true,
 		"noImplicitOverride": true,


### PR DESCRIPTION
This option causes issues when we upgrade to TypeScript 5.0. Removing it relaxes object types a little, making it valid to pass `undefined` when an object has an optional property. I think this is generally better as it allows a user to do things like

```js
registerCrashHandler({
    logger: process.env.USE_ANOTHER_LOGGER ? newLogger : undefined
});
```