### PR TITLE
fix: correct a broken exports

### DIFF
--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -191,14 +191,16 @@ function createSerializedRequest(properties) {
 	);
 }
 
-exports = module.exports = serializeRequest;
+module.exports = serializeRequest;
 
 // We freeze this object so that we avoid any side-effects
 // introduced by the way Node.js caches modules. If this
 // array is edited within a dependent app, then any changes
 // will apply to _all_ uses of `serializeRequest`. This
 // could cause some weird issues so we lock it down.
-exports.DEFAULT_INCLUDED_HEADERS = Object.freeze([...DEFAULT_INCLUDED_HEADERS]);
+module.exports.DEFAULT_INCLUDED_HEADERS = Object.freeze([
+	...DEFAULT_INCLUDED_HEADERS
+]);
 
 // @ts-ignore
 module.exports.default = module.exports;


### PR DESCRIPTION
It's invalid to reassign the `exports` global and it doesn't work as expected. I think this has only not been spotted because nobody is depending on the request serializer directly.

I only spotted this because TypeScript 5.0 can now detect this issue. So this PR blocks us being able to upgrade.