### PR TITLE
feat: Allow for NODE_ENV that is not "production" or "development"

### DIFF
--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -105,7 +105,7 @@ const PRETTIFICATION_AVAILABLE = (() => {
 		// If we get to this point, pino-pretty is installed because
 		// otherwise it would have errored. So we can just check for
 		// the environment not being "production" (which implies
-		// "development", "test" or a similar pre-production term)
+		// "development", "test" or a similar pre-production term).
 		return appInfo.environment !== 'production';
 	} catch (_) {
 		return false;

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -104,8 +104,9 @@ const PRETTIFICATION_AVAILABLE = (() => {
 
 		// If we get to this point, pino-pretty is installed because
 		// otherwise it would have errored. So we can just check for
-		// the environment being "development"
-		return appInfo.environment === 'development';
+		// the environment not being "production" (which implies
+		// "development", "test" or a similar pre-production term)
+		return appInfo.environment !== 'production';
 	} catch (_) {
 		return false;
 	}


### PR DESCRIPTION
## Why?

- We run our pre-production systems using a `NODE_ENV` value of `test`
- The logger only activates `pino` pretty log output when the NODE_ENV is `development`

## What?

- Swapped the check for **equals**`"development` for **not-equal** `production`
- Added an extra test for `test` and adjusted the existing `development` and `production` tests

