### PR TITLE
feat: add a crashing errors dashboard

### DIFF
--- a/resources/splunk-dashboards/README.md
+++ b/resources/splunk-dashboards/README.md
@@ -14,6 +14,8 @@ This package includes JSON files which can be used to create Splunk dashboards. 
 
   * **[Heroku](./src/heroku.json):** A dashboard to view issues with apps which use Reliability Kit and Heroku Log Drains. This template includes an input to set system code, so there's no need to create your own copy of this dashboard – just use the [live dashboard](https://financialtimes.splunkcloud.com/en-US/app/search/reliability_kit_heroku) and change the system code.
 
+  * **[Crashes](./src/crashes.json):** A dashboard to view crashing errors across all applications based on an optional filter. You can use the [live dashboard](https://financialtimes.splunkcloud.com/en-US/app/search/reliability_kit_crashes) and change the filter to suit your team or group's needs.
+
 If you're set on creating your own dashboard using these templates, then you can [create a dashboard in Splunk here](https://financialtimes.splunkcloud.com/en-US/app/search/dashboards), making sure to select "Dashboard Studio" when asked how you want to build your dashboard.
 
 Once you have a dashboard on the edit view (the one that opens by default), you can click the "Source" button in the toolbar (the last one which has angle brackets inside a window icon). Paste the relevant template JSON into the new JSON editing view that opens.

--- a/resources/splunk-dashboards/src/crashes.json
+++ b/resources/splunk-dashboards/src/crashes.json
@@ -1,0 +1,78 @@
+{
+	"title": "Reliability Kit: Crashes",
+	"description": "A dashboard to view unhandled errors across apps which use Reliability Kit.",
+	"visualizations": {
+		"viz_common_errors": {
+			"type": "splunk.table",
+			"dataSources": {
+				"primary": "ds_search_table_grouped_errors"
+			},
+			"title": "Common crashing errors",
+			"description": "Crashing errors grouped by system, name, code, and error stack",
+			"options": {
+				"count": 0,
+				"headerVisibility": "fixed"
+			}
+		}
+	},
+	"dataSources": {
+		"ds_search_table_grouped_errors": {
+			"type": "ds.search",
+			"options": {
+				"enableSmartSources": true,
+				"query": "index=\"heroku\" sourcetype=\"heroku:app\" event=\"UNHANDLED_ERROR\" source=*\n| rex field=error.stack \"(?<stackTraceHeader>[^\\r\\n]+[\\r\\n]+[^\\r\\n]+)\"\n| rex field=error.stack \"[^\\r\\n]+[\\r\\n]+[^\\r\\n\\(]*\\((?<filePointer>[^\\)]+)\\)\" \n| rename error.name as name, error.code as code, error.message as message\n| eval hash=md5(name.\"__\".code.\"__\".stackTraceHeader)\n| stats sparkline() as timeline count by hash, source, name, code, message, filePointer \n| table count timeline source name code message filePointer\n| sort count desc"
+			},
+			"name": "search_table_grouped_errors"
+		}
+	},
+	"defaults": {
+		"dataSources": {
+			"ds.search": {
+				"options": {
+					"queryParameters": {
+						"latest": "$global_time.latest$",
+						"earliest": "$global_time.earliest$"
+					}
+				}
+			}
+		}
+	},
+	"inputs": {
+		"input_global_trp": {
+			"type": "input.timerange",
+			"options": {
+				"token": "global_time",
+				"defaultValue": "-7d@h,now"
+			},
+			"title": "Time range"
+		},
+		"input_text_filter": {
+			"options": {
+				"defaultValue": "source=*",
+				"token": "text_filter"
+			},
+			"title": "Filter",
+			"type": "input.text"
+		}
+	},
+	"layout": {
+		"type": "grid",
+		"options": {},
+		"structure": [
+			{
+				"item": "viz_common_errors",
+				"type": "block",
+				"position": {
+					"x": 0,
+					"y": 0,
+					"w": 1200,
+					"h": 600
+				}
+			}
+		],
+		"globalInputs": [
+			"input_global_trp",
+			"input_text_filter"
+		]
+	}
+}


### PR DESCRIPTION
This adds a dashboard to get visibility of crashing errors across all apps which use Reliability Kit. It's similar to the Heroku dashboard that we already have but with a focus on crashes (`UNHANDLED_ERROR` events) across all apps.

You can apply a filter if you need to limit to a specific team or group.

[You can see the live dashboard here](https://financialtimes.splunkcloud.com/en-US/app/search/reliability_kit_crashes).