### PR TITLE
fix: match n-logger's function serialization

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -460,6 +460,9 @@ Different types of data are serialized differently before being output as JSON:
       // }
       ```
 
+    > **Warning:**
+    > It's important to note that only properties that are [serializable as JSON](https://www.rfc-editor.org/rfc/rfc7159) can be logged. Any non-serializable properties (e.g. functions) will not be output.
+
   * **Strings** are moved into the `message` property of the output log. E.g.
 
       ```js

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -1,6 +1,6 @@
 const pino = require('pino').default;
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
-const { default: structuredClone } = require('@ungap/structured-clone');
+const { default: clone } = require('@ungap/structured-clone');
 const appInfo = require('@dotcom-reliability-kit/app-info');
 
 /**
@@ -152,7 +152,7 @@ class Logger {
 		if (options.baseLogData) {
 			// TODO when we remove `setContext` and `clearContext` we can freeze this
 			// object with `Object.freeze` to prevent any editing after instantiation
-			this.#baseLogData = structuredClone(options.baseLogData);
+			this.#baseLogData = clone(options.baseLogData, { lossy: true });
 		}
 
 		// Default and set the log level option. We default the log level to the
@@ -339,7 +339,9 @@ class Logger {
 			}
 
 			// Transform the log data
-			let transformedLogData = structuredClone(sanitizedLogData);
+			let transformedLogData = clone(sanitizedLogData, {
+				lossy: true
+			});
 			if (this.#transforms.length) {
 				transformedLogData = this.#transforms.reduce(
 					(logData, transform) => transform(logData),
@@ -517,7 +519,7 @@ class Logger {
 		// which always uses the _first_ instance of a property or message
 		// rather than the last
 		const reversedLogData = logData.reverse();
-		return structuredClone(
+		return clone(
 			reversedLogData.reduce((collect, item) => {
 				if (typeof item === 'string') {
 					return Object.assign(collect, { message: item });
@@ -526,7 +528,8 @@ class Logger {
 					return Object.assign(collect, { error: serializeError(item) });
 				}
 				return Object.assign(collect, item);
-			}, {})
+			}, {}),
+			{ lossy: true }
 		);
 	}
 }

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -681,6 +681,29 @@ module.exports = [
 			}
 		}
 	},
+	{
+		id: 'edge-case-function-serialization',
+		description: '.info() with function in log object',
+		call: {
+			method: 'info',
+			args: [
+				'mock message',
+				{ example: () => 'hello', nested: { fn: () => {} } }
+			]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'mock message',
+				nested: {}
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'mock message',
+				nested: {}
+			}
+		}
+	},
 
 	// Test cases based on real-world usage of n-logger
 	{


### PR DESCRIPTION
This resolves #489. We were not matching n-logger in the way it serialized functions and this resulted in errors. We now match n-logger and just ignore any function properties.

I did this using the [`lossy` option of ungap's structured-clone](https://github.com/ungap/structured-clone#extra-features), which offers a few features over the native structured clone. The `lossy` option makes the clone behave more like `JSON.stringify`, ignoring properties that it can't serialize rather than throwing an error. Once Reliability Kit drops Node.js 16 support we can reassess this and perhaps move to native `structuredClone`.