### PR TITLE
feat: serialize errors passed to the logger as object properties so that error information is not lost

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -515,13 +515,13 @@ Different types of data are serialized differently before being output as JSON:
     //     "level": "info",
     //     "error": {
     //         "cause": null,
-    //		   "code": "UNKNOWN",
-    //		   "data": {},
-    //		   "isOperational": false,
-    //		   "message": "Oops",
-    //		   "name": "Error",
-    //		   "relatesToSystems": [],
-    //		   "statusCode": null
+    //		"code": "UNKNOWN",
+    //		"data": {},
+    //		"isOperational": false,
+    //		"message": "Oops",
+    //		"name": "Error",
+    //		"relatesToSystems": [],
+    //		"statusCode": null
     //     }
     // }
     ```

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -489,7 +489,33 @@ Different types of data are serialized differently before being output as JSON:
       // }
       ```
 
-      Errors found in sub-properties of the log data are _not_ serialized like this. This is for performance reasons: looping over every nested property to check if it's an error is expensive. Do **not** do this:
+    Also note that errors found in sub-properties or as top-level errors are now automatically serialized as well:
+
+      ```js
+      logger.info({ error: new Error('Oops') });
+      // Outputs:
+      // {
+      //     "level": "info",
+      //     "error": {
+      //        "cause": null,
+      //		"code": "UNKNOWN",
+      //		"data": {},
+      //		"isOperational": false,
+      //		"message": "Oops",
+      //		"name": "Error",
+      //		"relatesToSystems": [],
+      //		"statusCode": null
+      //     }
+      // }
+      ```
+
+      Be mindful of passing in errors with an `err` property, as you'll have to serialize them yourself like below:
+
+      ```js
+      logger.info({ err: serializeError(new Error('Oops')) });
+      ```
+
+      ... else you'll get the following output:
 
       ```js
       logger.info({ err: new Error('Oops') });
@@ -498,12 +524,6 @@ Different types of data are serialized differently before being output as JSON:
       //     "level": "info",
       //     "err": {}
       // }
-      ```
-
-      If you _need_ to pass error objects as a property, you must serialize it yourself:
-
-      ```js
-      logger.info({ err: serializeError(new Error('Oops')) });
       ```
 
 #### Order of precedence

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -489,42 +489,42 @@ Different types of data are serialized differently before being output as JSON:
       // }
       ```
 
-    Also note that errors found in sub-properties or as top-level errors are now automatically serialized as well:
+    Errors found in sub-properties of the log data are _not_ serialized like this due to performance reasons: looping over every nested property to check if it's an error is expensive (do **not** do this). Also, be mindful of passing in errors with a custom error property e.g. `myErrorProperty`, as you'll have to serialize them yourself like below:
+
+    ```js
+    logger.info({ myErrorProperty: serializeError(new Error('Oops')) });
+    ```
+
+    ... if not, you'll get the following output:
+
+    ```js
+    logger.info({ myErrorProperty: new Error('Oops') });
+    // Outputs:
+    // {
+    //     "level": "info",
+    //     "myErrorProperty": {}
+    // }
+    ```
+    
+    The exception to this is if the sub-property name is either `error` or `err`, as these are automatically serialized. E.g.
 
       ```js
-      logger.info({ error: new Error('Oops') });
-      // Outputs:
-      // {
-      //     "level": "info",
-      //     "error": {
-      //        "cause": null,
-      //		"code": "UNKNOWN",
-      //		"data": {},
-      //		"isOperational": false,
-      //		"message": "Oops",
-      //		"name": "Error",
-      //		"relatesToSystems": [],
-      //		"statusCode": null
-      //     }
-      // }
-      ```
-
-      Be mindful of passing in errors with an `err` property, as you'll have to serialize them yourself like below:
-
-      ```js
-      logger.info({ err: serializeError(new Error('Oops')) });
-      ```
-
-      ... else you'll get the following output:
-
-      ```js
-      logger.info({ err: new Error('Oops') });
-      // Outputs:
-      // {
-      //     "level": "info",
-      //     "err": {}
-      // }
-      ```
+    logger.info({ error: new Error('Oops') });
+    // Outputs:
+    // {
+    //     "level": "info",
+    //     "error": {
+    //         "cause": null,
+    //		   "code": "UNKNOWN",
+    //		   "data": {},
+    //		   "isOperational": false,
+    //		   "message": "Oops",
+    //		   "name": "Error",
+    //		   "relatesToSystems": [],
+    //		   "statusCode": null
+    //     }
+    // }
+    ```
 
 #### Order of precedence
 

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -342,6 +342,10 @@ class Logger {
 				sanitizedLogData.error = serializeError(sanitizedLogData.error);
 			}
 
+			if (sanitizedLogData.err && sanitizedLogData.err instanceof Error) {
+				sanitizedLogData.err = serializeError(sanitizedLogData.err);
+			}
+
 			// Transform the log data
 			let transformedLogData = clone(sanitizedLogData, {
 				lossy: true

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -68,6 +68,7 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  * A map of log levels to the underlying log method that
  * should be called when a log of that level is sent, as
  * well as the deprecation status of the log level.
+ *
  * @type {Object<string, LogLevelInfo>}
  */
 const logLevelToTransportMethodMap = {
@@ -87,6 +88,7 @@ const logLevelToTransportMethodMap = {
  * on two things: the pino-pretty module being installed
  * in the application, and the `NODE_ENV` environment
  * variable being undefined or "development".
+ *
  * @type {boolean}
  */
 const PRETTIFICATION_AVAILABLE = (() => {
@@ -141,6 +143,7 @@ class Logger {
 
 	/**
 	 * Create a logger.
+	 *
 	 * @param {LoggerOptions & PrivateLoggerOptions} [options = {}]
 	 *     Options to configure the logger.
 	 */
@@ -238,6 +241,7 @@ class Logger {
 
 	/**
 	 * Create a child logger with additional base log data.
+	 *
 	 * @public
 	 * @param {LogData} baseLogData
 	 *     The base log data to add.
@@ -255,6 +259,7 @@ class Logger {
 
 	/**
 	 * Add additional log data to all subsequent log calls.
+	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @param {LogData} extraLogData
@@ -275,6 +280,7 @@ class Logger {
 
 	/**
 	 * Set the `context` property for all subsequent log calls.
+	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @param {LogData} contextData
@@ -295,6 +301,7 @@ class Logger {
 
 	/**
 	 * Clear the `context` property for all subsequent log calls.
+	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @returns {void}
@@ -313,6 +320,7 @@ class Logger {
 
 	/**
 	 * Send a log.
+	 *
 	 * @public
 	 * @param {LogLevel} level
 	 *     The log level to output the log as.
@@ -376,6 +384,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "data".
+	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -388,6 +397,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "debug".
+	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -399,6 +409,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "error".
+	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -410,6 +421,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "fatal".
+	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -421,6 +433,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "info".
+	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -432,6 +445,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "silly".
+	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -444,6 +458,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "verbose".
+	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -456,6 +471,7 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "warn".
+	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -467,6 +483,7 @@ class Logger {
 
 	/**
 	 * Flush any asynchronous logs in the queue when an async transport is used.
+	 *
 	 * @public
 	 * @returns {void}
 	 */
@@ -478,6 +495,7 @@ class Logger {
 
 	/**
 	 * Get information on a given log level.
+	 *
 	 * @private
 	 * @param {string} level
 	 *     The log level to get information for.
@@ -493,6 +511,7 @@ class Logger {
 
 	/**
 	 * Combine multiple log data into a single zipped object.
+	 *
 	 * @private
 	 * @param {...LogData} logData
 	 *     The log data.

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -68,7 +68,6 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  * A map of log levels to the underlying log method that
  * should be called when a log of that level is sent, as
  * well as the deprecation status of the log level.
- *
  * @type {Object<string, LogLevelInfo>}
  */
 const logLevelToTransportMethodMap = {
@@ -88,7 +87,6 @@ const logLevelToTransportMethodMap = {
  * on two things: the pino-pretty module being installed
  * in the application, and the `NODE_ENV` environment
  * variable being undefined or "development".
- *
  * @type {boolean}
  */
 const PRETTIFICATION_AVAILABLE = (() => {
@@ -143,7 +141,6 @@ class Logger {
 
 	/**
 	 * Create a logger.
-	 *
 	 * @param {LoggerOptions & PrivateLoggerOptions} [options = {}]
 	 *     Options to configure the logger.
 	 */
@@ -241,7 +238,6 @@ class Logger {
 
 	/**
 	 * Create a child logger with additional base log data.
-	 *
 	 * @public
 	 * @param {LogData} baseLogData
 	 *     The base log data to add.
@@ -259,7 +255,6 @@ class Logger {
 
 	/**
 	 * Add additional log data to all subsequent log calls.
-	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @param {LogData} extraLogData
@@ -280,7 +275,6 @@ class Logger {
 
 	/**
 	 * Set the `context` property for all subsequent log calls.
-	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @param {LogData} contextData
@@ -301,7 +295,6 @@ class Logger {
 
 	/**
 	 * Clear the `context` property for all subsequent log calls.
-	 *
 	 * @deprecated Please create a child logger with `createChildLogger` or use the `baseLogData` option.
 	 * @public
 	 * @returns {void}
@@ -320,7 +313,6 @@ class Logger {
 
 	/**
 	 * Send a log.
-	 *
 	 * @public
 	 * @param {LogLevel} level
 	 *     The log level to output the log as.
@@ -336,6 +328,10 @@ class Logger {
 			const sanitizedLogData = Logger.zipLogData(...logData, this.#baseLogData);
 			if (!sanitizedLogData.message) {
 				sanitizedLogData.message = null;
+			}
+
+			if (sanitizedLogData.error && sanitizedLogData.error instanceof Error) {
+				sanitizedLogData.error = serializeError(sanitizedLogData.error);
 			}
 
 			// Transform the log data
@@ -380,7 +376,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "data".
-	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -393,7 +388,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "debug".
-	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -405,7 +399,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "error".
-	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -417,7 +410,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "fatal".
-	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -429,7 +421,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "info".
-	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -441,7 +432,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "silly".
-	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -454,7 +444,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "verbose".
-	 *
 	 * @deprecated Please use a log level of "debug" instead.
 	 * @public
 	 * @param {...LogData} logData
@@ -467,7 +456,6 @@ class Logger {
 
 	/**
 	 * Send a log with a level of "warn".
-	 *
 	 * @public
 	 * @param {...LogData} logData
 	 *     The log data.
@@ -479,7 +467,6 @@ class Logger {
 
 	/**
 	 * Flush any asynchronous logs in the queue when an async transport is used.
-	 *
 	 * @public
 	 * @returns {void}
 	 */
@@ -491,7 +478,6 @@ class Logger {
 
 	/**
 	 * Get information on a given log level.
-	 *
 	 * @private
 	 * @param {string} level
 	 *     The log level to get information for.
@@ -507,7 +493,6 @@ class Logger {
 
 	/**
 	 * Combine multiple log data into a single zipped object.
-	 *
 	 * @private
 	 * @param {...LogData} logData
 	 *     The log data.

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -831,7 +831,16 @@ module.exports = [
 				level: 'error',
 				event: 'FAILED_TO_GET_FT_LIVE_EVENT',
 				message: null,
-				error: {} // Empty object because this is invalid, it says so in the n-logger docs
+				error: {
+					cause: null,
+					code: 'UNKNOWN',
+					data: {},
+					isOperational: false,
+					message: 'Oops',
+					name: 'Error',
+					relatesToSystems: [],
+					statusCode: null
+				}
 			}
 		}
 	},

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -347,12 +347,39 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 					expect(serializeError).toBeCalledWith(new Error('mock error'));
 				});
 
-				it('calls the relevant log transport method with a error sub-property which is set to the serialized error', () => {
+				it('calls the relevant log transport method with an error sub-property which is set to the serialized error', () => {
 					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledTimes(1);
 					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledWith({
 						isMockZippedData: true,
 						message: null,
 						error: 'mock serialized error'
+					});
+				});
+			});
+
+			describe('when the log data has an err property as a sub-property', () => {
+				beforeEach(() => {
+					mockPinoLogger.mockCanonicalLevel.mockClear();
+					jest.spyOn(Logger, 'zipLogData').mockReturnValue({
+						err: new Error('mock error'),
+						isMockZippedData: true
+					});
+					serializeError.mockClear();
+					serializeError.mockReturnValueOnce('mock serialized error');
+					logger.log('mockLevel', 'mock message', { mockData: true });
+				});
+
+				it('serializes the contents of the err sub-property', () => {
+					expect(serializeError).toBeCalledTimes(1);
+					expect(serializeError).toBeCalledWith(new Error('mock error'));
+				});
+
+				it('calls the relevant log transport method with an err sub-property which is set to the serialized error', () => {
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledTimes(1);
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledWith({
+						isMockZippedData: true,
+						message: null,
+						err: 'mock serialized error'
 					});
 				});
 			});

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -330,6 +330,33 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 				});
 			});
 
+			describe('when the log data has an error property as a sub-property', () => {
+				beforeEach(() => {
+					mockPinoLogger.mockCanonicalLevel.mockClear();
+					jest.spyOn(Logger, 'zipLogData').mockReturnValue({
+						error: new Error('mock error'),
+						isMockZippedData: true
+					});
+					serializeError.mockClear();
+					serializeError.mockReturnValueOnce('mock serialized error');
+					logger.log('mockLevel', 'mock message', { mockData: true });
+				});
+
+				it('serializes the contents of the error sub-property', () => {
+					expect(serializeError).toBeCalledTimes(1);
+					expect(serializeError).toBeCalledWith(new Error('mock error'));
+				});
+
+				it('calls the relevant log transport method with a error sub-property which is set to the serialized error', () => {
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledTimes(1);
+					expect(mockPinoLogger.mockCanonicalLevel).toBeCalledWith({
+						isMockZippedData: true,
+						message: null,
+						error: 'mock serialized error'
+					});
+				});
+			});
+
 			describe('when the given level is deprecated', () => {
 				beforeEach(() => {
 					mockPinoLogger.mockDeprecatedCanonocalLevel.mockClear();


### PR DESCRIPTION
PR for GitHub issue [#480](https://github.com/Financial-Times/dotcom-reliability-kit/issues/480).
[Jira ticket](https://financialtimes.atlassian.net/browse/CPREL-527)

Changes:
- Add an additional check in the logger file that checks if the parsed error item is an instance of Error AND has a sub-property of `error`, then serialize it.

Testing:
- Fixed e2e tests and all passing now
- Added a new unit test to get back to 100% coverage

To-Do:
Nil

---
Resolves: #480 