### PR TITLE
chore!: drop support for Node.js 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,21 +157,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - release-please:
           filters:
             <<: *filters_only_main
@@ -189,7 +189,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - test:
           filters:
             <<: *filters_release_build
@@ -198,7 +198,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -207,7 +207,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - publish:
           context: npm-publish-token
           filters:
@@ -226,7 +226,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -235,7 +235,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -244,7 +244,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - prepublish:
           context: npm-publish-token
           filters:
@@ -267,7 +267,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -275,4 +275,4 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19", "14.21" ]
+              node-version: [ "18.13", "16.19" ]

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -5,7 +5,7 @@ To use Reliability Kit you'll need a few things set up in advance.
 
   1. A Node.js application (ideally built with either [Express](https://expressjs.com/) or AWS Lambda with [Serverless](https://www.serverless.com/), but you should get some benefits even if you're not using these)
 
-  2. For your application to be running on [Node.js](https://nodejs.org/) 14 or above
+  2. For your application to be running on [Node.js](https://nodejs.org/) 16 or above
 
 
 | ← Previous | Next →                                  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10372,7 +10372,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10384,7 +10384,7 @@
         "@dotcom-reliability-kit/log-error": "^1.5.4"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10393,7 +10393,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10411,7 +10411,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10432,7 +10432,7 @@
         "@types/ungap__structured-clone": "^0.3.0"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10449,7 +10449,7 @@
         "node-fetch": "^2.6.9"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10467,7 +10467,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10476,7 +10476,7 @@
       "version": "1.1.4",
       "license": "MIT",
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10488,7 +10488,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10505,7 +10505,7 @@
         "@types/svgo": "^3.0.0"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "volta": {

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: app-info\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: crash-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: errors\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: log-error\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: logger\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-log-errors\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-error\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-request\"",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/resources/logos/package.json
+++ b/resources/logos/package.json
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x"
   },
   "scripts": {


### PR DESCRIPTION
If your apps are using Node.js 16 or above then it's safe to immediately migrate to the new major versions of Reliability Kit packages. There are no code changes in this release.