### PR TITLE
fix: start running builds on Node.js 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>
     parameters:
       node-version:
-        default: "18.13" # We default to the highest active LTS
+        default: "18.16" # We default to the highest active LTS
         type: string
 
   workspace_root: &workspace_root ~/project
@@ -157,29 +157,29 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - release-please:
           filters:
             <<: *filters_only_main
           requires:
             # We release on the highest active LTS version of
             # Node.js that we support
-            - test-v18.13
-            - lint-v18.13
+            - test-v18.16
+            - lint-v18.16
 
   build-test-publish:
     jobs:
@@ -189,7 +189,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - test:
           filters:
             <<: *filters_release_build
@@ -198,7 +198,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -207,7 +207,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - publish:
           context: npm-publish-token
           filters:
@@ -215,8 +215,8 @@ workflows:
           requires:
             # We release on the highest active LTS version of
             # Node.js that we support
-            - lint-v18.13
-            - test-v18.13
+            - lint-v18.16
+            - test-v18.16
 
   build-test-prepublish:
     jobs:
@@ -226,7 +226,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -235,7 +235,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -244,7 +244,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - prepublish:
           context: npm-publish-token
           filters:
@@ -252,8 +252,8 @@ workflows:
           requires:
             # We release on the highest active LTS version of
             # Node.js that we support
-            - lint-v18.13
-            - test-v18.13
+            - lint-v18.16
+            - test-v18.16
 
   nightly:
     triggers:
@@ -267,7 +267,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -275,4 +275,4 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "18.13", "16.19" ]
+              node-version: [ "20.0", "18.16", "16.20" ]

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10353,7 +10353,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10365,7 +10365,7 @@
         "@dotcom-reliability-kit/log-error": "^2.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10374,20 +10374,20 @@
       "version": "2.0.0",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       },
       "peerDependencies": {
-        "eslint": "^8.27.0"
+        "eslint": ">=8.27.0"
       }
     },
     "packages/log-error": {
@@ -10404,7 +10404,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10425,7 +10425,7 @@
         "@types/ungap__structured-clone": "^0.3.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10442,7 +10442,7 @@
         "node-fetch": "^2.6.9"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10460,7 +10460,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10469,7 +10469,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10481,7 +10481,7 @@
         "@types/express": "^4.17.17"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -10498,7 +10498,7 @@
         "@types/svgo": "^3.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
+        "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "volta": {
-    "node": "18.13.0",
-    "npm": "8.19.2"
+    "node": "20.0.0",
+    "npm": "9.6.4"
   },
   "lint-staged": {
     "**/*.js": [

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: app-info\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: crash-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: errors\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: eslint-config\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: log-error\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: logger\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-log-errors\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-error\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib"

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-request\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "main": "lib",

--- a/resources/logos/package.json
+++ b/resources/logos/package.json
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x",
+    "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x"
   },
   "scripts": {


### PR DESCRIPTION
This starts running builds against Node.js 20 to make sure that we support it ahead of it going LTS. This doesn't make Node.js 20 the default build as Node.js 18 is still the latest LTS version.