### PR TITLE
chore: fix the JSDoc linting after the last major

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
 	"rules": {
 		"jsdoc/check-access": "error",
 		"jsdoc/require-description-complete-sentence": "error",
+		"jsdoc/tag-lines": ["warn", "any", { "startLines": 1 }],
 		"prettier/prettier": "error",
 		"quotes": 0,
 		"space-before-function-paren": 0


### PR DESCRIPTION
PR #523 bumped the ESLint JSDoc plugin from v41 to v43. I assumed a breaking change in v43 wouldn't impact us but it does. https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v43.0.0

We need to change this configuration to continue enforcing the rule that there's a line break between a JSDoc description and the tags. I'm not super attached to this rule but I think maybe updating the config to reflect our current code is better than removing the line break from all functions and creating noise in the diffs.

Before this change we were getting hundreds of ESLint warnings.