### PR TITLE
feat: allow disabling log prettification

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -10,6 +10,7 @@ A simple and fast logger based on [Pino](https://getpino.io/), with FT preferenc
       * [`options.baseLogData`](#optionsbaselogdata)
       * [`options.logLevel`](#optionsloglevel)
       * [`options.transforms`](#optionstransforms)
+      * [`options.withPrettifier`](#optionswithprettifier)
       * [`options.withTimestamps`](#optionswithtimestamps)
     * [`logger.log()` and shortcut methods](#loggerlog-and-shortcut-methods)
     * [`logger.flush()`](#loggerflush)
@@ -188,6 +189,14 @@ logger.info({
 ```
 
 You can also use [built-in transforms](#built-in-transforms) to do things like mask sensitive data.
+
+####  `options.withPrettifier`
+
+Whether to send prettified logs if available. This option has no effect if you have the `NODE_ENV` environment variable set to either `production` or if you have not installed [pino-pretty](https://github.com/pinojs/pino-pretty#readme). See [local development usage](#local-development-usage) for more information.
+
+Must be a `Boolean` and defaults to `true`.
+
+It's also possible to set this option as an environment variable, which is how you configure the default logger. Set the `LOG_DISABLE_PRETTIFIER` environment variable to `true` if you want to force the prettifier not to load.
 
 #### `options.withTimestamps`
 
@@ -552,6 +561,8 @@ To get formatted and colourised logs locally, you need to meet two conditions:
       ```sh
       npm install -D pino-pretty
       ```
+
+  3. Ensure you don't disable prettification via the [`withPrettifier` option](#optionswithprettifier).
 
 ### Production usage
 

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -20,6 +20,8 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  *     beneath this will be ignored.
  * @property {Array<LogTransform>} [transforms = []]
  *     Transforms to apply to logs before sending.
+ * @property {boolean} [withPrettifier = true]
+ *     Whether to prettify log output if it's possible.
  * @property {boolean} [withTimestamps = true]
  *     Whether to send the timestamp that each log method was called.
  */
@@ -180,6 +182,12 @@ class Logger {
 			this.#transforms = options.transforms;
 		}
 
+		// Default and set the prettifier option
+		const withPrettifier =
+			typeof options.withPrettifier === 'boolean'
+				? options.withPrettifier
+				: !Boolean(process.env.LOG_DISABLE_PRETTIFIER);
+
 		// Default and set the timestamps option.
 		const withTimestamps = options.withTimestamps !== false;
 
@@ -201,7 +209,7 @@ class Logger {
 				messageKey: 'message', // This is for backwards compatibility with our existing logs
 				timestamp: withTimestamps
 			};
-			if (PRETTIFICATION_AVAILABLE) {
+			if (withPrettifier && PRETTIFICATION_AVAILABLE) {
 				pinoOptions.transport = {
 					target: 'pino-pretty',
 					options: {

--- a/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
+++ b/packages/logger/test/end-to-end/scripts/run-loggers-with-test-case.js
@@ -3,6 +3,10 @@
 process.env.MIGRATE_TO_HEROKU_LOG_DRAINS = 'true';
 process.env.SPLUNK_LOG_LEVEL = 'silly';
 
+// This environment variable is required to ensure that Reliability
+// Kit logger outputs JSON regardless of NODE_ENV
+process.env.LOG_DISABLE_PRETTIFIER = 'true';
+
 const nLogger = require('@financial-times/n-logger').default;
 const MaskLogger = require('@financial-times/n-mask-logger');
 const reliabilityKitLogger = require('../../../lib');

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -806,6 +806,59 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 			});
 		});
 
+		describe('when pino-pretty is installed and the `withPrettifier` option is set to `false`', () => {
+			beforeEach(() => {
+				jest.mock('pino-pretty', () => 'mock pino pretty', { virtual: true });
+				appInfo.environment = 'development';
+
+				// We have to reset all modules because the checks for pino-pretty are done
+				// on module load for performance reasons. This resets the cache and reloads
+				// everything with a new environment.
+				jest.isolateModules(() => {
+					Logger = require('../../../lib/logger');
+				});
+
+				pino.mockClear();
+				logger = new Logger({ withPrettifier: false });
+			});
+
+			afterEach(() => {
+				jest.unmock('pino-pretty');
+			});
+
+			it('does not configure the created Pino logger with prettification', () => {
+				const pinoOptions = pino.mock.calls[0][0];
+				expect(pinoOptions.transport).toBeUndefined();
+			});
+		});
+
+		describe('when pino-pretty is installed and the `LOG_DISABLE_PRETTIFIER` environment variable is set', () => {
+			beforeEach(() => {
+				jest.mock('pino-pretty', () => 'mock pino pretty', { virtual: true });
+				appInfo.environment = 'development';
+				process.env.LOG_DISABLE_PRETTIFIER = 'true';
+
+				// We have to reset all modules because the checks for pino-pretty are done
+				// on module load for performance reasons. This resets the cache and reloads
+				// everything with a new environment.
+				jest.isolateModules(() => {
+					Logger = require('../../../lib/logger');
+				});
+
+				pino.mockClear();
+				logger = new Logger();
+			});
+
+			afterEach(() => {
+				jest.unmock('pino-pretty');
+			});
+
+			it('does not configure the created Pino logger with prettification', () => {
+				const pinoOptions = pino.mock.calls[0][0];
+				expect(pinoOptions.transport).toBeUndefined();
+			});
+		});
+
 		describe('when pino-pretty is installed and the environment is "production"', () => {
 			beforeEach(() => {
 				jest.mock('pino-pretty', () => 'mock pino pretty', { virtual: true });


### PR DESCRIPTION
This resolves #474 by allowing an application to completely disable the internal log prettification. We now allow setting a `withPrettifier` option to `false`. This is also possible with a new environment variable named `LOG_DISABLE_PRETTIFIER`.

This is also required before I can properly work on #516.