### PR TITLE
fix: widen the pino-pretty version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10208,7 +10208,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
@@ -10227,7 +10227,7 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
-        "pino-pretty": "^10.0.0"
+        "pino-pretty": ">=7.0.0 <11.0.0"
       }
     },
     "packages/middleware-log-errors": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -22,7 +22,7 @@
     "pino": "^8.12.1"
   },
   "peerDependencies": {
-    "pino-pretty": "^10.0.0"
+    "pino-pretty": ">=7.0.0 <11.0.0"
   },
   "peerDependencyMeta": {
     "pino-pretty": {


### PR DESCRIPTION
I've gone through versions and verified that Reliability Kit logger works with pino-pretty v7+. pino-pretty v6 does not work with Reliability Kit and never has.

This means that v2.2.0 of the logger is no longer a breaking change for some applications and will not give them pointless warnings.