### PR TITLE
chore: use the new ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
 	},
 	"extends": [
 		"@financial-times/eslint-config-next",
+		"@dotcom-reliability-kit/eslint-config",
 		"plugin:jsdoc/recommended"
 	],
 	"parser": "@babel/eslint-parser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10178,7 +10178,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -81,7 +81,6 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 				}
 			};
 			response = {
-				status: 'mock response status',
 				send: jest.fn(),
 				set: jest.fn(),
 				status: jest.fn()
@@ -178,7 +177,6 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 				appInfo.environment = 'production';
 				middleware = createErrorRenderingMiddleware();
 				response = {
-					status: 'mock response status',
 					send: jest.fn(),
 					set: jest.fn(),
 					status: jest.fn()


### PR DESCRIPTION
This uncovered one issue in some of our tests where we were setting a duplicate key.