### PR TITLE
chore: add type checking to the ESLint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2274,6 +2274,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.0.tgz",
+      "integrity": "sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
     "node_modules/@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2345,6 +2361,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -10159,6 +10181,9 @@
       "name": "@dotcom-reliability-kit/eslint-config",
       "version": "1.0.0",
       "license": "MIT",
+      "devDependencies": {
+        "@types/eslint": "^8.40.0"
+      },
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
@@ -11038,7 +11063,9 @@
     },
     "@dotcom-reliability-kit/eslint-config": {
       "version": "file:packages/eslint-config",
-      "requires": {}
+      "requires": {
+        "@types/eslint": "^8.40.0"
+      }
     },
     "@dotcom-reliability-kit/log-error": {
       "version": "file:packages/log-error",
@@ -12095,6 +12122,22 @@
         "@types/node": "*"
       }
     },
+    "@types/eslint": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.0.tgz",
+      "integrity": "sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -12166,6 +12209,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",

--- a/packages/eslint-config/lib/index.js
+++ b/packages/eslint-config/lib/index.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('eslint').ESLint.ConfigData}
+ */
 const config = {
 	env: {
 		browser: true,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,5 +17,8 @@
   "main": "lib",
   "peerDependencies": {
     "eslint": ">=8.27.0"
+  },
+  "devDependencies": {
+    "@types/eslint": "^8.40.0"
   }
 }


### PR DESCRIPTION
Because the ESLint config isn't in a file named `.eslintrc` or similar, it doesn't get type-hinting in VSCode and we're also not certain that the configuration is valid.

We already run type checking against the code with TypeScript, so we can validate our ESLint config the same way.