### PR TITLE
add request headers seriealization

### DIFF
--- a/packages/serialize-request/test/unit/lib/index.spec.js
+++ b/packages/serialize-request/test/unit/lib/index.spec.js
@@ -220,6 +220,33 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 				});
 			});
 		});
+		describe('when `request.headers` is iterable', () => {
+			beforeEach(() => {
+				request.headers = new Map([
+					['Content-Type', 'application/json'],
+					['Authorization', 'Bearer token']
+				]);
+			});
+			it('should handle headers as an iterable', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					headers: { 'content-type': 'application/json' }
+				});
+			});
+		});
+
+		describe('when `request.headers` is iterable but has non-string values', () => {
+			beforeEach(() => {
+				request.headers = new Map([
+					['Content-Type', 123],
+					['accept', {}]
+				]);
+			});
+			it('should ignore the headers with non-string values', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					headers: {}
+				});
+			});
+		});
 
 		describe('when `request.route.path` is not a string', () => {
 			beforeEach(() => {


### PR DESCRIPTION
In certain contexts like Apollo Server's requestDidStart and the Headers object used by the fetch API, HTTP headers are represented as iterables rather than objects. As a result, when serializing headers for these types of requests, extra code is required to convert the iterable headers into an object.


This PR update the serializeRequest method to support iterable headers directly. The necessary changes include updating the types and modifying the code to check if the provided headers are iterable using Symbol.iterator. If the headers are iterable, they will be processed accordingly. This improvement will simplify the serialization process and eliminate the need for users to handle iterable headers in their own code.

Resolves #277 