### PR TITLE
fix: address logging infinite recursion issue

### DIFF
--- a/packages/logger/test/unit/lib/transforms/legacy-mask.spec.js
+++ b/packages/logger/test/unit/lib/transforms/legacy-mask.spec.js
@@ -217,6 +217,18 @@ describe('@dotcom-reliability-kit/logger', () => {
 					expect(transform({ mock: 123 })).toEqual({ mock: 123 });
 				});
 			});
+
+			describe('when called with an object that references itself', () => {
+				it('does not recurse infinitely', () => {
+					const logData = {
+						email: 'mock'
+					};
+					logData.naughtyLittleSelfReference = logData;
+					const result = transform(logData);
+					expect(result.email).toEqual('*****');
+					expect(result.naughtyLittleSelfReference.email).toEqual('*****');
+				});
+			});
 		});
 
 		describe('when `options.denyList` is set', () => {


### PR DESCRIPTION
This cropped up as a bug recently where Content Discovery were trying to log an entire Request object, which references itself. This resulted in Node.js running out of memory because we were infinitely recursing over the properties.

This is a bug that's always been present in n-mask-logger.

I've addressed the issue with my first legit use of `WeakSet` and I'm quite pleased with myself about it 😁