### PR TITLE
fix: throw an error when log level is not a string

### DIFF
--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -337,6 +337,9 @@ class Logger {
 	 * @returns {void}
 	 */
 	log(level, ...logData) {
+		if (typeof level !== 'string') {
+			throw new TypeError('The log `level` argument must be a string');
+		}
 		try {
 			const { logLevel, isDeprecated } = Logger.getLogLevelInfo(level);
 

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -462,6 +462,14 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 					);
 				});
 			});
+
+			describe('when `level` is not a string', () => {
+				it('throws a type error', () => {
+					expect(() => logger.log({})).toThrow(
+						new TypeError('The log `level` argument must be a string')
+					);
+				});
+			});
 		});
 
 		const logMethods = [


### PR DESCRIPTION
If `log()` is called with a non-string first argument then we can't actually do anything useful with it - it's not valid based on the TypeScript types and so we should also error when we encounter this issue at runtime.

I'm throwing outside of the catch block because this is a rare occasion where we _do_ want logging to fully fail and an error to be thrown as it's a clear programmer error - the only resolution is to change the code to use a string.

An alternative would be to use a log level of `info` but avoid the deprecation message, but I think it's better to avoid this issue entirely rather than try to paper over it.

Resolves #547.