### PR TITLE
fix: properly clone error instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,6 +2367,21 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -2477,11 +2492,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.5",
@@ -6724,6 +6734,11 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -10233,13 +10248,14 @@
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-        "@ungap/structured-clone": "^1.2.0",
+        "lodash.clonedeep": "^4.5.0",
         "pino": "^8.14.1"
       },
       "devDependencies": {
         "@financial-times/n-logger": "^10.3.0",
         "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.0",
+        "@types/lodash.clonedeep": "^4.5.7",
         "@types/ungap__structured-clone": "^0.3.0"
       },
       "engines": {
@@ -11101,8 +11117,9 @@
         "@financial-times/n-logger": "^10.3.0",
         "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.0",
+        "@types/lodash.clonedeep": "^4.5.7",
         "@types/ungap__structured-clone": "^0.3.0",
-        "@ungap/structured-clone": "^1.2.0",
+        "lodash.clonedeep": "^4.5.0",
         "pino": "^8.14.1"
       }
     },
@@ -12232,6 +12249,21 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -12340,11 +12372,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@xmldom/xmldom": {
       "version": "0.8.5",
@@ -15471,6 +15498,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.isfunction": {
       "version": "3.0.9",

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -1,6 +1,6 @@
 const pino = require('pino').default;
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
-const { default: clone } = require('@ungap/structured-clone');
+const clone = require('lodash.clonedeep');
 const appInfo = require('@dotcom-reliability-kit/app-info');
 
 /**
@@ -146,7 +146,7 @@ class Logger {
 	/**
 	 * Create a logger.
 	 *
-	 * @param {LoggerOptions & PrivateLoggerOptions} [options = {}]
+	 * @param {LoggerOptions & PrivateLoggerOptions} [options]
 	 *     Options to configure the logger.
 	 */
 	constructor(options = {}) {
@@ -154,7 +154,7 @@ class Logger {
 		if (options.baseLogData) {
 			// TODO when we remove `setContext` and `clearContext` we can freeze this
 			// object with `Object.freeze` to prevent any editing after instantiation
-			this.#baseLogData = clone(options.baseLogData, { lossy: true });
+			this.#baseLogData = clone(options.baseLogData);
 		}
 
 		// Default and set the log level option. We default the log level to the
@@ -355,9 +355,7 @@ class Logger {
 			}
 
 			// Transform the log data
-			let transformedLogData = clone(sanitizedLogData, {
-				lossy: true
-			});
+			let transformedLogData = clone(sanitizedLogData);
 			if (this.#transforms.length) {
 				transformedLogData = this.#transforms.reduce(
 					(logData, transform) => transform(logData),
@@ -544,8 +542,7 @@ class Logger {
 					return Object.assign(collect, { error: serializeError(item) });
 				}
 				return Object.assign(collect, item);
-			}, {}),
-			{ lossy: true }
+			}, {})
 		);
 	}
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^2.1.0",
     "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-    "@ungap/structured-clone": "^1.2.0",
+    "lodash.clonedeep": "^4.5.0",
     "pino": "^8.14.1"
   },
   "peerDependencies": {
@@ -33,6 +33,7 @@
     "@financial-times/n-logger": "^10.3.0",
     "@financial-times/n-mask-logger": "^7.2.0",
     "@types/events": "^3.0.0",
+    "@types/lodash.clonedeep": "^4.5.7",
     "@types/ungap__structured-clone": "^0.3.0"
   }
 }

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -1027,6 +1027,19 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 			});
 		});
 
+		describe('when an object has an Error instance as a property', () => {
+			it('does not have additional error information wiped', () => {
+				const mockError = new Error('mock error');
+				mockError.name = 'MockError';
+				expect(Logger.zipLogData({ error: mockError })).toEqual({
+					error: mockError
+				});
+				expect(Logger.zipLogData({ error: mockError }).error.name).toEqual(
+					'MockError'
+				);
+			});
+		});
+
 		describe('when one of the log data items is a string', () => {
 			it('adds it as a `message` property', () => {
 				expect(Logger.zipLogData('mock message', { a: 1 })).toEqual({

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -1029,13 +1029,25 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 
 		describe('when an object has an Error instance as a property', () => {
 			it('does not have additional error information wiped', () => {
-				const mockError = new Error('mock error');
-				mockError.name = 'MockError';
+				class MockError extends Error {
+					name = 'MockError';
+					constructor(message) {
+						super(message);
+						this.code = 'MOCK_ERROR';
+					}
+				}
+				const mockError = new MockError('mock error');
 				expect(Logger.zipLogData({ error: mockError })).toEqual({
 					error: mockError
 				});
+				expect(Logger.zipLogData({ error: mockError }).error).toBeInstanceOf(
+					MockError
+				);
 				expect(Logger.zipLogData({ error: mockError }).error.name).toEqual(
 					'MockError'
+				);
+				expect(Logger.zipLogData({ error: mockError }).error.code).toEqual(
+					'MOCK_ERROR'
 				);
 			});
 		});


### PR DESCRIPTION
This switches out the library we use for cloning objects because the original one did not properly handle error objects, which resulted in a loss of log data. This works with Lodash as indicated by the now-passing test - we should now not lose error info.

This fixes an issue Artem was having when trying to use the `error` property of log data:

```js
logger.error({
    error: new Error('...')
})
```

Resolves #611. Closes #610.