### PR TITLE
Simplify errors

### DIFF
--- a/packages/errors/lib/data-store-error.js
+++ b/packages/errors/lib/data-store-error.js
@@ -11,18 +11,6 @@ class DataStoreError extends OperationalError {
 	 * @type {string}
 	 */
 	name = 'DataStoreError';
-
-	/**
-	 * Create a data store error.
-	 *
-	 * @param {string | OperationalError.OperationalErrorData} [message]
-	 *     The error message if it's a string, or full error information if an object.
-	 * @param {OperationalError.OperationalErrorData} [data]
-	 *     Additional error information if `message` is a string.
-	 */
-	constructor(message, data = {}) {
-		super(message, data);
-	}
 }
 
 module.exports = DataStoreError;

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -55,8 +55,36 @@ class HttpError extends OperationalError {
 	}
 
 	/**
-	 * Create an HTTP error.
+	 * Create an error with no arguments.
 	 *
+	 * @overload
+	 */
+	/**
+	 * Create an error with error data.
+	 *
+	 * @overload
+	 * @param {HttpErrorData} data
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a message and optional error data.
+	 *
+	 * @overload
+	 * @param {string} message
+	 *     The error message.
+	 * @param {HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a status and optional error data.
+	 *
+	 * @overload
+	 * @param {number} status
+	 *     The error HTTP status code.
+	 * @param {HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
 	 * @param {string | number | HttpErrorData} [message]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -73,8 +73,27 @@ class OperationalError extends Error {
 	data = {};
 
 	/**
-	 * Create an operational error.
+	 * Create an error with no arguments.
 	 *
+	 * @overload
+	 */
+	/**
+	 * Create an error with error data.
+	 *
+	 * @overload
+	 * @param {OperationalErrorData} data
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a message and optional error data.
+	 *
+	 * @overload
+	 * @param {string} message
+	 *     The error message.
+	 * @param {OperationalErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
 	 * @param {string | OperationalErrorData} [message]
 	 *     The error message if it's a string, or full error information if an object.
 	 * @param {OperationalErrorData} [data]

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -42,7 +42,7 @@ class OperationalError extends Error {
 	 * @public
 	 * @type {string}
 	 */
-	code = 'UNKNOWN';
+	code = OperationalError.defaultCode;
 
 	/**
 	 * An array of valid FT system codes (found in Biz Ops) which this error is related to.
@@ -105,7 +105,7 @@ class OperationalError extends Error {
 		} else {
 			data = message || data;
 		}
-		super(data.message || 'An operational error occurred');
+		super(data.message || OperationalError.defaultMessage);
 
 		if (typeof data.code === 'string') {
 			this.code = OperationalError.normalizeErrorCode(data.code);
@@ -138,6 +138,20 @@ class OperationalError extends Error {
 	 * @type {Array<string>}
 	 */
 	static reservedKeys = ['code', 'message', 'relatesToSystems', 'cause'];
+
+	/**
+	 * @protected
+	 * @readonly
+	 * @type {string}
+	 */
+	static defaultCode = 'UNKNOWN';
+
+	/**
+	 * @protected
+	 * @readonly
+	 * @type {string}
+	 */
+	static defaultMessage = 'An operational error occurred';
 
 	/**
 	 * Get whether an error object is marked as operational (it has a truthy `isOperational` property).

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -13,8 +13,36 @@ class UpstreamServiceError extends HttpError {
 	name = 'UpstreamServiceError';
 
 	/**
-	 * Create an upstream service error.
+	 * Create an error with no arguments.
 	 *
+	 * @overload
+	 */
+	/**
+	 * Create an error with error data.
+	 *
+	 * @overload
+	 * @param {HttpError.HttpErrorData} data
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a message and optional error data.
+	 *
+	 * @overload
+	 * @param {string} message
+	 *     The error message.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a status and optional error data.
+	 *
+	 * @overload
+	 * @param {number} status
+	 *     The error HTTP status code.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
 	 * @param {string | number | HttpError.HttpErrorData} [message]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.

--- a/packages/errors/lib/upstream-service-error.js
+++ b/packages/errors/lib/upstream-service-error.js
@@ -13,63 +13,12 @@ class UpstreamServiceError extends HttpError {
 	name = 'UpstreamServiceError';
 
 	/**
-	 * Create an error with no arguments.
-	 *
-	 * @overload
+	 * @override
+	 * @protected
+	 * @readonly
+	 * @type {number}
 	 */
-	/**
-	 * Create an error with error data.
-	 *
-	 * @overload
-	 * @param {HttpError.HttpErrorData} data
-	 *     Additional error information.
-	 */
-	/**
-	 * Create an error with a message and optional error data.
-	 *
-	 * @overload
-	 * @param {string} message
-	 *     The error message.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information.
-	 */
-	/**
-	 * Create an error with a status and optional error data.
-	 *
-	 * @overload
-	 * @param {number} status
-	 *     The error HTTP status code.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information.
-	 */
-	/**
-	 * @param {string | number | HttpError.HttpErrorData} [message]
-	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
-	 *     information if an object.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information if `message` is a string or number.
-	 */
-	constructor(message, data = {}) {
-		if (typeof message === 'string') {
-			data.message = message;
-		} else if (typeof message === 'number') {
-			data.statusCode = message;
-		} else {
-			data = message || data;
-		}
-
-		// Make sure that we don't modify the original data object
-		// by shallow-cloning it
-		data = { ...data };
-
-		// Default the status code
-		data.statusCode =
-			typeof data.statusCode === 'number'
-				? UpstreamServiceError.normalizeErrorStatusCode(data.statusCode)
-				: 502;
-
-		super(data);
-	}
+	static defaultStatusCode = 502;
 }
 
 module.exports = UpstreamServiceError;

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -13,8 +13,36 @@ class UserInputError extends HttpError {
 	name = 'UserInputError';
 
 	/**
-	 * Create a user input error.
+	 * Create an error with no arguments.
 	 *
+	 * @overload
+	 */
+	/**
+	 * Create an error with error data.
+	 *
+	 * @overload
+	 * @param {HttpError.HttpErrorData} data
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a message and optional error data.
+	 *
+	 * @overload
+	 * @param {string} message
+	 *     The error message.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
+	 * Create an error with a status and optional error data.
+	 *
+	 * @overload
+	 * @param {number} status
+	 *     The error HTTP status code.
+	 * @param {HttpError.HttpErrorData} [data]
+	 *     Additional error information.
+	 */
+	/**
 	 * @param {string | number | HttpError.HttpErrorData} [message]
 	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
 	 *     information if an object.

--- a/packages/errors/lib/user-input-error.js
+++ b/packages/errors/lib/user-input-error.js
@@ -13,63 +13,12 @@ class UserInputError extends HttpError {
 	name = 'UserInputError';
 
 	/**
-	 * Create an error with no arguments.
-	 *
-	 * @overload
+	 * @override
+	 * @protected
+	 * @readonly
+	 * @type {number}
 	 */
-	/**
-	 * Create an error with error data.
-	 *
-	 * @overload
-	 * @param {HttpError.HttpErrorData} data
-	 *     Additional error information.
-	 */
-	/**
-	 * Create an error with a message and optional error data.
-	 *
-	 * @overload
-	 * @param {string} message
-	 *     The error message.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information.
-	 */
-	/**
-	 * Create an error with a status and optional error data.
-	 *
-	 * @overload
-	 * @param {number} status
-	 *     The error HTTP status code.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information.
-	 */
-	/**
-	 * @param {string | number | HttpError.HttpErrorData} [message]
-	 *     The error message if it's a string, the HTTP status code if it's a number, or full error
-	 *     information if an object.
-	 * @param {HttpError.HttpErrorData} [data]
-	 *     Additional error information if `message` is a string or number.
-	 */
-	constructor(message, data = {}) {
-		if (typeof message === 'string') {
-			data.message = message;
-		} else if (typeof message === 'number') {
-			data.statusCode = message;
-		} else {
-			data = message || data;
-		}
-
-		// Make sure that we don't modify the original data object
-		// by shallow-cloning it
-		data = { ...data };
-
-		// Default the status code
-		data.statusCode =
-			typeof data.statusCode === 'number'
-				? UserInputError.normalizeErrorStatusCode(data.statusCode)
-				: 400;
-
-		super(data);
-	}
+	static defaultStatusCode = 400;
 }
 
 module.exports = UserInputError;


### PR DESCRIPTION
I had a brainwave about how we could reduce the amount of code we maintain in the error classes, removing a lot of boilerplate constructor code. We now have a tiny bit more complexity in the core errors (`OperationalError` and `HttpError`) and a large amount of reduced complexity in the more specific errors (`DataStoreError`, `UpstreamServiceError`, `UserInputError`).

Shouldn't be merged until #639 is in.