### PR TITLE
chore: add end-to-end tests for errors

### DIFF
--- a/packages/errors/test/end-to-end/__snapshots__/snapshots.spec.js.snap
+++ b/packages/errors/test/end-to-end/__snapshots__/snapshots.spec.js.snap
@@ -1,0 +1,567 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with cause matches the snapshot 1`] = `
+{
+  "cause": [Error: mock cause],
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with extra data matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {
+    "mockData": 123,
+  },
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with message and code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "DataStoreError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end DataStoreError with related systems matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "DataStoreError",
+  "relatesToSystems": [
+    "mock-system",
+  ],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_500",
+  "data": {},
+  "isOperational": true,
+  "message": "Internal Server Error",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with cause matches the snapshot 1`] = `
+{
+  "cause": [Error: mock cause],
+  "code": "HTTP_500",
+  "data": {},
+  "isOperational": true,
+  "message": "Internal Server Error",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "Internal Server Error",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with extra data matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_500",
+  "data": {
+    "mockData": 123,
+  },
+  "isOperational": true,
+  "message": "Internal Server Error",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with message and code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_500",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with related systems matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_500",
+  "data": {},
+  "isOperational": true,
+  "message": "Internal Server Error",
+  "name": "HttpError",
+  "relatesToSystems": [
+    "mock-system",
+  ],
+  "statusCode": 500,
+  "statusMessage": "Internal Server Error",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with status code as message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end HttpError with status code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "HttpError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with cause matches the snapshot 1`] = `
+{
+  "cause": [Error: mock cause],
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with extra data matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {
+    "mockData": 123,
+  },
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with message and code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "OperationalError",
+  "relatesToSystems": [],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end OperationalError with related systems matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "UNKNOWN",
+  "data": {},
+  "isOperational": true,
+  "message": "An operational error occurred",
+  "name": "OperationalError",
+  "relatesToSystems": [
+    "mock-system",
+  ],
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_502",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Gateway",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with cause matches the snapshot 1`] = `
+{
+  "cause": [Error: mock cause],
+  "code": "HTTP_502",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Gateway",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Gateway",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with extra data matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_502",
+  "data": {
+    "mockData": 123,
+  },
+  "isOperational": true,
+  "message": "Bad Gateway",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with message and code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_502",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with related systems matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_502",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Gateway",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [
+    "mock-system",
+  ],
+  "statusCode": 502,
+  "statusMessage": "Bad Gateway",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with status code as message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UpstreamServiceError with status code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "UpstreamServiceError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_400",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Request",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with cause matches the snapshot 1`] = `
+{
+  "cause": [Error: mock cause],
+  "code": "HTTP_400",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Request",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Request",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with extra data matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_400",
+  "data": {
+    "mockData": 123,
+  },
+  "isOperational": true,
+  "message": "Bad Request",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with message and code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "MOCK_CODE",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_400",
+  "data": {},
+  "isOperational": true,
+  "message": "mock message",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with related systems matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_400",
+  "data": {},
+  "isOperational": true,
+  "message": "Bad Request",
+  "name": "UserInputError",
+  "relatesToSystems": [
+    "mock-system",
+  ],
+  "statusCode": 400,
+  "statusMessage": "Bad Request",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with status code as message matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;
+
+exports[`@dotcom-reliability-kit/errors end-to-end UserInputError with status code matches the snapshot 1`] = `
+{
+  "cause": null,
+  "code": "HTTP_404",
+  "data": {},
+  "isOperational": true,
+  "message": "Not Found",
+  "name": "UserInputError",
+  "relatesToSystems": [],
+  "statusCode": 404,
+  "statusMessage": "Not Found",
+}
+`;

--- a/packages/errors/test/end-to-end/errors.js
+++ b/packages/errors/test/end-to-end/errors.js
@@ -1,0 +1,124 @@
+const {
+	DataStoreError,
+	HttpError,
+	OperationalError,
+	UpstreamServiceError,
+	UserInputError
+} = require('../../lib');
+
+module.exports = {
+	// DataStoreError tests
+	DataStoreError: new DataStoreError(),
+	'DataStoreError with message': new DataStoreError('mock message'),
+	'DataStoreError with code': new DataStoreError({
+		code: 'mock_code'
+	}),
+	'DataStoreError with message and code': new DataStoreError('mock message', {
+		code: 'mock_code'
+	}),
+	'DataStoreError with cause': new DataStoreError({
+		cause: new Error('mock cause')
+	}),
+	'DataStoreError with related systems': new DataStoreError({
+		relatesToSystems: ['mock-system']
+	}),
+	'DataStoreError with extra data': new DataStoreError({
+		mockData: 123
+	}),
+
+	// HttpError tests
+	HttpError: new HttpError(),
+	'HttpError with message': new HttpError('mock message'),
+	'HttpError with status code as message': new HttpError(404),
+	'HttpError with code': new HttpError({
+		code: 'mock_code'
+	}),
+	'HttpError with message and code': new HttpError('mock message', {
+		code: 'mock_code'
+	}),
+	'HttpError with cause': new HttpError({
+		cause: new Error('mock cause')
+	}),
+	'HttpError with related systems': new HttpError({
+		relatesToSystems: ['mock-system']
+	}),
+	'HttpError with status code': new HttpError({
+		statusCode: 404
+	}),
+	'HttpError with extra data': new HttpError({
+		mockData: 123
+	}),
+
+	// OperationalError tests
+	OperationalError: new OperationalError(),
+	'OperationalError with message': new OperationalError('mock message'),
+	'OperationalError with code': new OperationalError({
+		code: 'mock_code'
+	}),
+	'OperationalError with message and code': new OperationalError(
+		'mock message',
+		{
+			code: 'mock_code'
+		}
+	),
+	'OperationalError with cause': new OperationalError({
+		cause: new Error('mock cause')
+	}),
+	'OperationalError with related systems': new OperationalError({
+		relatesToSystems: ['mock-system']
+	}),
+	'OperationalError with extra data': new OperationalError({
+		mockData: 123
+	}),
+
+	// UpstreamServiceError tests
+	UpstreamServiceError: new UpstreamServiceError(),
+	'UpstreamServiceError with message': new UpstreamServiceError('mock message'),
+	'UpstreamServiceError with status code as message': new UpstreamServiceError(
+		404
+	),
+	'UpstreamServiceError with code': new UpstreamServiceError({
+		code: 'mock_code'
+	}),
+	'UpstreamServiceError with message and code': new UpstreamServiceError(
+		'mock message',
+		{
+			code: 'mock_code'
+		}
+	),
+	'UpstreamServiceError with cause': new UpstreamServiceError({
+		cause: new Error('mock cause')
+	}),
+	'UpstreamServiceError with related systems': new UpstreamServiceError({
+		relatesToSystems: ['mock-system']
+	}),
+	'UpstreamServiceError with status code': new UpstreamServiceError({
+		statusCode: 404
+	}),
+	'UpstreamServiceError with extra data': new UpstreamServiceError({
+		mockData: 123
+	}),
+
+	// UserInputError tests
+	UserInputError: new UserInputError(),
+	'UserInputError with message': new UserInputError('mock message'),
+	'UserInputError with status code as message': new UserInputError(404),
+	'UserInputError with code': new UserInputError({
+		code: 'mock_code'
+	}),
+	'UserInputError with message and code': new UserInputError('mock message', {
+		code: 'mock_code'
+	}),
+	'UserInputError with cause': new UserInputError({
+		cause: new Error('mock cause')
+	}),
+	'UserInputError with related systems': new UserInputError({
+		relatesToSystems: ['mock-system']
+	}),
+	'UserInputError with status code': new UserInputError({
+		statusCode: 404
+	}),
+	'UserInputError with extra data': new UserInputError({
+		mockData: 123
+	})
+};

--- a/packages/errors/test/end-to-end/snapshots.spec.js
+++ b/packages/errors/test/end-to-end/snapshots.spec.js
@@ -1,0 +1,11 @@
+const errors = require('./errors');
+
+describe('@dotcom-reliability-kit/errors end-to-end', () => {
+	for (const [name, error] of Object.entries(errors)) {
+		describe(name, () => {
+			it('matches the snapshot', () => {
+				expect({ ...error, message: error.message }).toMatchSnapshot();
+			});
+		});
+	}
+});


### PR DESCRIPTION
I wanted to do this before making any broader changes to errors in #638. This gives me more confidence that my change hasn't changed the error interfaces.