### PR TITLE
chore: eslint warnings for object type defs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
 		"jsdoc/check-access": "error",
 		"jsdoc/require-description-complete-sentence": "error",
 		"jsdoc/tag-lines": ["warn", "any", { "startLines": 1 }],
+		"jsdoc/no-undefined-types": ["error", {"definedTypes": ["Iterable"]}],
 		"prettier/prettier": "error",
 		"quotes": 0,
 		"space-before-function-paren": 0

--- a/packages/crash-handler/lib/index.js
+++ b/packages/crash-handler/lib/index.js
@@ -2,7 +2,7 @@ const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
 
 /**
  * @typedef {object} CrashHandlerOptions
- * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
+ * @property {import('@dotcom-reliability-kit/log-error').Logger & {[key: string]: any}} [logger]
  *     The logger to use to output errors. Defaults to n-logger.
  * @property {import('process')} [process]
  *     The Node.js process to add crash handlers for.
@@ -12,7 +12,7 @@ const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
  * Register a crash handler on a process.
  *
  * @public
- * @param {CrashHandlerOptions} [options = {}]
+ * @param {CrashHandlerOptions} [options]
  *     Options to configure the crash handler.
  */
 function registerCrashHandler(options = {}) {

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -125,7 +125,7 @@ class HttpError extends OperationalError {
 	 *
 	 * @override
 	 * @protected
-	 * @type {Array<string>}
+	 * @type {string[]}
 	 */
 	static reservedKeys = [
 		...OperationalError.reservedKeys,

--- a/packages/errors/lib/http-error.js
+++ b/packages/errors/lib/http-error.js
@@ -6,7 +6,7 @@ const OperationalError = require('./operational-error');
  * is a string. If we don't do this then TypeScript will complain.
  *
  * @see HttpError.getMessageForStatusCode
- * @type {Object<any, string>}
+ * @type {{[key: string]: any}}
  */
 const STATUS_CODES = require('http').STATUS_CODES;
 

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -68,7 +68,7 @@ class OperationalError extends Error {
 	 *
 	 * @readonly
 	 * @public
-	 * @type {Object<string, any>}
+	 * @type {{[key: string]: any}}
 	 */
 	data = {};
 

--- a/packages/errors/lib/operational-error.js
+++ b/packages/errors/lib/operational-error.js
@@ -4,7 +4,7 @@
  *     A machine-readable error code which identifies the specific type of error.
  * @property {string} [message]
  *     A human readable message which describes the error.
- * @property {Array<string>} [relatesToSystems]
+ * @property {string[]} [relatesToSystems]
  *     An array of FT system codes which are related to this error.
  * @property {Error|null} [cause]
  *     The root cause error instance.
@@ -50,7 +50,7 @@ class OperationalError extends Error {
 	 *
 	 * @readonly
 	 * @public
-	 * @type {Array<string>}
+	 * @type {string[]}
 	 */
 	relatesToSystems = [];
 
@@ -135,7 +135,7 @@ class OperationalError extends Error {
 	 * Reserved keys that should not appear in `OperationalError.prototype.data`.
 	 *
 	 * @protected
-	 * @type {Array<string>}
+	 * @type {string[]}
 	 */
 	static reservedKeys = ['code', 'message', 'relatesToSystems', 'cause'];
 

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -19,7 +19,7 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  * @typedef {object} ErrorLoggingOptions
  * @property {(string | Error & Record<string, any>)} error
  *     The error to log.
- * @property {Array<string>} [includeHeaders]
+ * @property {string[]} [includeHeaders]
  *     An array of request headers to include in the log.
  * @property {Logger & {[key: string]: any}} [logger]
  *     The logger to use to output errors. Defaults to n-logger.

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -21,7 +21,7 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  *     The error to log.
  * @property {Array<string>} [includeHeaders]
  *     An array of request headers to include in the log.
- * @property {Logger & Object<string, any>} [logger]
+ * @property {Logger & {[key: string]: any}} [logger]
  *     The logger to use to output errors. Defaults to n-logger.
  * @property {(string | import('@dotcom-reliability-kit/serialize-request').Request)} [request]
  *     An request object to include in the log.

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -34,9 +34,9 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
 
 /**
  * @callback LogTransform
- * @param {Object<string, any>} logData
+ * @param {{[key: string]: any}} logData
  *     The log data to transform.
- * @returns {Object<string, any>}
+ * @returns {{[key: string]: any}}
  *     Returns the transformed log data.
  */
 
@@ -71,7 +71,7 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  * should be called when a log of that level is sent, as
  * well as the deprecation status of the log level.
  *
- * @type {Object<string, LogLevelInfo>}
+ * @type {{[key: string]: LogLevelInfo}}
  */
 const logLevelToTransportMethodMap = {
 	data: { logLevel: 'debug', isDeprecated: true },
@@ -528,7 +528,7 @@ class Logger {
 	 * @private
 	 * @param {...LogData} logData
 	 *     The log data.
-	 * @returns {Object<string, any>}
+	 * @returns {{[key: string]: any}}
 	 *     Returns a single zipped object containing all log data.
 	 */
 	static zipLogData(...logData) {

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -18,7 +18,7 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  * @property {LogLevel} [logLevel = "debug"]
  *     The maximum log level to output during logging. Logs at levels
  *     beneath this will be ignored.
- * @property {Array<LogTransform>} [transforms = []]
+ * @property {LogTransform[]} [transforms = []]
  *     Transforms to apply to logs before sending.
  * @property {boolean} [withPrettifier = true]
  *     Whether to prettify log output if it's possible.
@@ -129,7 +129,7 @@ class Logger {
 	#baseLogData = {};
 
 	/**
-	 * @type {Array<LogTransform>}
+	 * @type {LogTransform[]}
 	 */
 	#transforms = [];
 
@@ -139,7 +139,7 @@ class Logger {
 	#logTransport;
 
 	/**
-	 * @type {Array<string>}
+	 * @type {string[]}
 	 */
 	#deprecatedMethodTracker = [];
 

--- a/packages/logger/lib/transforms/legacy-mask.js
+++ b/packages/logger/lib/transforms/legacy-mask.js
@@ -1,8 +1,8 @@
 /**
  * @typedef {object} LegacyMaskTransformOptions
- * @property {Array<string>} [denyList]
+ * @property {string[]} [denyList]
  *     Additional field names to apply masking to.
- * @property {Array<string>} [allowList]
+ * @property {string[]} [allowList]
  *     Field names to allow from the default deny list.
  * @property {string} [maskString]
  *     The mask string to apply to discovered sensitive values.
@@ -24,7 +24,7 @@
  * The default masked fields.
  *
  * @private
- * @type {Array<string>}
+ * @type {string[]}
  */
 const DEFAULT_MASKED_FIELDS = [
 	'email',
@@ -46,7 +46,7 @@ const DEFAULT_MASKED_FIELDS = [
  * Properties of an error object we need to mask.
  *
  * @private
- * @type {Array<string>}
+ * @type {string[]}
  */
 const ERROR_OBJECT_PROPERTIES = [
 	'name',

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -14,7 +14,7 @@
  *     The method and arguments to call on each logging library.
  * @property {string} call.method
  *     The log method to call.
- * @property {Array<any>} call.args
+ * @property {any[]} call.args
  *     An array of arguments to call the method with.
  * @property {object} expectedOutput
  *     The outputs expected for each logging library.
@@ -25,7 +25,7 @@
  */
 
 /**
- * @type {Array<CompatibilityTestCase>}
+ * @type {CompatibilityTestCase[]}
  */
 module.exports = [
 	// Test cases based on the n-logger documentation

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -18,9 +18,9 @@
  *     An array of arguments to call the method with.
  * @property {object} expectedOutput
  *     The outputs expected for each logging library.
- * @property {Object<string, any>} [expectedOutput.nextLogger]
+ * @property {{[key: string]: any}} [expectedOutput.nextLogger]
  *     What the expected output is for n-logger when called with the given arguments.
- * @property {Object<string, any>} [expectedOutput.reliabilityKit]
+ * @property {{[key: string]: any}} [expectedOutput.reliabilityKit]
  *     What the expected output is for Reliability Kit logger when called with the given arguments.
  */
 

--- a/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
+++ b/packages/logger/test/end-to-end/helpers/clean-log-for-testing.js
@@ -2,9 +2,9 @@
  * Remove properties from a log object which cause
  * issues in testing.
  *
- * @param {Object<string, any>} log
+ * @param {{[key: string]: any}} log
  *     The log object to clean.
- * @returns {Object<string, any>}
+ * @returns {{[key: string]: any}}
  *     Returns the cleaned log.
  */
 function cleanLogFortesting(log) {

--- a/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
+++ b/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
@@ -2,7 +2,7 @@
  * Find the first log in an array of logs which has the
  * specified `property` set to `value`.
  *
- * @param {Array<object>} logs
+ * @param {{[key: string]: any}[]} logs
  *     The logs to search.
  * @param {string} property
  *     The property to search on.

--- a/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
+++ b/packages/logger/test/end-to-end/helpers/find-log-with-property-value.js
@@ -8,7 +8,7 @@
  *     The property to search on.
  * @param {any} value
  *     The property value to find.
- * @returns {Object<string, any>|null}
+ * @returns {{[key: string]: any}|null}
  *     Returns the found log or null if one isn't found.
  */
 function findLogWithPropertyValue(logs, property, value) {

--- a/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
+++ b/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
@@ -3,7 +3,7 @@
  *
  * @param {string} logString
  *     The log string to parse.
- * @returns {Array<{[key: string]: any}>}
+ * @returns {{[key: string]: any}[]}
  *     Returns the parsed JSON logs as an array of log objects.
  */
 function splitAndParseJsonLogs(logString) {

--- a/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
+++ b/packages/logger/test/end-to-end/helpers/split-and-parse-json-logs.js
@@ -3,7 +3,7 @@
  *
  * @param {string} logString
  *     The log string to parse.
- * @returns {Array<Object<string, any>>}
+ * @returns {Array<{[key: string]: any}>}
  *     Returns the parsed JSON logs as an array of log objects.
  */
 function splitAndParseJsonLogs(logString) {

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -15,7 +15,7 @@ const {
 
 /**
  * @typedef {object} ErrorLoggingOptions
- * @property {Array<string>} [includeHeaders]
+ * @property {string[]} [includeHeaders]
  *     An array of request headers to include in the log.
  * @property {ErrorLoggingFilter} [filter]
  *     A filter function to determine whether an error should be logged.

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -19,7 +19,7 @@ const {
  *     An array of request headers to include in the log.
  * @property {ErrorLoggingFilter} [filter]
  *     A filter function to determine whether an error should be logged.
- * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
+ * @property {import('@dotcom-reliability-kit/log-error').Logger & {[key: string]: any}} [logger]
  *     The logger to use to output errors. Defaults to n-logger.
  */
 
@@ -27,7 +27,7 @@ const {
  * Create a middleware function to log errors.
  *
  * @public
- * @param {ErrorLoggingOptions} [options = {}]
+ * @param {ErrorLoggingOptions} [options]
  *     Options to configure the middleware.
  * @returns {import('express').ErrorRequestHandler}
  *     Returns error logging middleware.

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -232,7 +232,7 @@ function renderResponse(response) {
  *     The section id.
  * @param {string} section.title
  *     The section title.
- * @param {Array<Field>} section.fields
+ * @param {Field[]} section.fields
  *     The fields to render in the section.
  * @param {string} [section.body]
  *     The section body content.
@@ -343,7 +343,7 @@ function renderBoolean(
  * Render a list of systems, linking them to Biz Ops.
  *
  * @private
- * @param {Array<string>} systems
+ * @param {string[]} systems
  *     An array of system codes.
  * @returns {string}
  *     Returns the rendered systems.

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -8,7 +8,7 @@
  *     A human readable message which describes the error.
  * @property {boolean} isOperational
  *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
- * @property {Array<string>} relatesToSystems
+ * @property {string[]} relatesToSystems
  *     An array of FT system codes which are related to this error.
  * @property {(Error | null)} cause
  *     The root cause error instance.

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -16,7 +16,7 @@
  *     The full error stack.
  * @property {(number | null)} statusCode
  *     An HTTP status code to represent the error.
- * @property {Object<string, any>} data
+ * @property {{[key: string]: any}} data
  *     Any additional error information.
  */
 

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -22,7 +22,7 @@
 
 /**
  * @typedef {object} SerializeRequestOptions
- * @property {Array<string>} [includeHeaders]
+ * @property {string[]} [includeHeaders]
  *     An array of request headers to include.
  */
 
@@ -60,7 +60,7 @@
  * The default request headers to include in the serialization.
  *
  * @public
- * @type {Array<string>}
+ * @type {string[]}
  */
 const DEFAULT_INCLUDED_HEADERS = [
 	'accept',
@@ -158,7 +158,7 @@ function serializeRequest(request, options = {}) {
  * @private
  * @param {Headers | Record<string, any> | Iterable<[string, string]>} headers
  *     The headers object to serialize.
- * @param {Array<string>} includeHeaders
+ * @param {string[]} includeHeaders
  *     An array of request headers to include.
  * @returns {SerializedRequestHeaders}
  *     Returns the serialized request headers.

--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -8,7 +8,7 @@
 
 /**
  * @typedef {object} BasicRequest
- * @property {Headers | Object<string, string> | Iterable<[string, string]>} [headers]
+ * @property {Headers | {[key: string]: string} | Iterable<[string, string]>} [headers]
  *     The request HTTP headers.
  * @property {string} [method]
  *     The request HTTP method.
@@ -27,11 +27,11 @@
  */
 
 /**
- * @typedef {Object<string, string>} SerializedRequestHeaders
+ * @typedef {{[key: string]: string}} SerializedRequestHeaders
  */
 
 /**
- * @typedef {Object<string, string>} SerializedRequestRouteParams
+ * @typedef {{[key: string]: string}} SerializedRequestRouteParams
  */
 
 /**
@@ -79,7 +79,7 @@ const DEFAULT_INCLUDED_HEADERS = [
  *     The request object to serialize. Either an Express Request object, a
  *     built-in Node.js IncomingMessage object, or an object with the expected
  *     `headers`, `method`, and `url` properties.
- * @param {SerializeRequestOptions} [options = {}]
+ * @param {SerializeRequestOptions} [options]
  *     Options to configure the serialization.
  * @returns {SerializedRequest}
  *     Returns the serialized request object.

--- a/resources/logos/scripts/build.js
+++ b/resources/logos/scripts/build.js
@@ -23,7 +23,7 @@ const sharp = require('sharp');
 	 *
 	 * @param {string} name
 	 *     The name of the logo within the `src` directory.
-	 * @param {Array<number>} pngSizes
+	 * @param {number[]} pngSizes
 	 *     The pixel sizes to export PNG files at.
 	 * @returns {Promise<void>}
 	 */


### PR DESCRIPTION
This PR fixes the ESlint warnings for JSDoc type checking (issue #509). All the 25 warnings have been fixed 🎉 

For the `Iterable` type warning problem, this was fixed based on [github issue help](https://github.com/gajus/eslint-plugin-jsdoc/issues/280)

[JIRA](https://financialtimes.atlassian.net/browse/CPREL-650)

<img width="1143" alt="image" src="https://github.com/Financial-Times/dotcom-reliability-kit/assets/72040367/ce763319-48ac-4253-a9a6-2a2741b5e68a">
