### PR TITLE
chore: attempt to replicate Jest logger exit issue

### DIFF
--- a/packages/logger/test/end-to-end/express.spec.js
+++ b/packages/logger/test/end-to-end/express.spec.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const logger = require('../..');
+
+const PORT = 13700;
+const BASE_URL = `http://localhost:${PORT}`;
+
+describe('testing jest exit', () => {
+	/** @type {express.Application} */
+	let app;
+
+	/** @type {import('node:http').Server} */
+	let server;
+
+	beforeAll((done) => {
+		app = express();
+		app.get('/', (request, response) => {
+			logger.debug('this is debug');
+			logger.info('this is info');
+			logger.warn('this is warn');
+			logger.error('this is error');
+			response.send('ok');
+		});
+		server = app.listen(PORT, done);
+	});
+
+	afterAll((done) => {
+		server.close(done);
+	});
+
+	it('is OK', async () => {
+		const response = await fetch(BASE_URL);
+		expect(response.ok).toBe(true);
+	});
+});


### PR DESCRIPTION
I'm trying to replicate the issue that Artem reported on Slack about the logger not allowing Jest to exit the process. So far I haven't had any luck but maybe I've reduced the test case down too much.

To try this locally checkout this branch and run:

```
jest packages/logger/test/end-to-end/express.spec.js
```

---

Note: the Node.js 16 test failing is unrelated – I'm using native fetch which is only available in Node.js 18+