### PR TITLE
Handle log method detachment

### DIFF
--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -86,6 +86,13 @@ const logLevelToTransportMethodMap = {
 };
 
 /**
+ * A list of supported log levels.
+ *
+ * @type {string[]}
+ */
+const logLevels = Object.keys(logLevelToTransportMethodMap);
+
+/**
  * Whether log prettification is available. This is based
  * on two things: the pino-pretty module being installed
  * in the application, and the `NODE_ENV` environment
@@ -220,6 +227,14 @@ class Logger {
 			}
 			this.#logTransport = pino(pinoOptions);
 			this.#logTransport.level = this.#logLevel;
+		}
+
+		// Bind the log level methods so that they can be used without
+		// the `this` context, e.g. as event handlers
+		for (const logLevel of logLevels) {
+			if (typeof this[logLevel] === 'function') {
+				this[logLevel] = this[logLevel].bind(this);
+			}
 		}
 	}
 

--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -493,6 +493,18 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 				it(`calls .log() with a level of '${levelMethod}'`, () => {
 					expect(logger.log).toBeCalledTimes(1);
 				});
+
+				describe(`when the method is detatched from the logger instance`, () => {
+					beforeEach(() => {
+						logger.log.mockReset();
+						const detatchedLogMethod = logger[levelMethod];
+						detatchedLogMethod('mock message', { mockData: true });
+					});
+
+					it(`calls .log() with a level of '${levelMethod}'`, () => {
+						expect(logger.log).toBeCalledTimes(1);
+					});
+				});
 			});
 		}
 


### PR DESCRIPTION
Currently we're seeing errors in Content Discovery repos because they're using the logger like this:

```js
eventEmitter.on('error', logger.error);
```

This doesn't work because the log method can no longer access `this` – the method has been detached from the parent class. For better or worse, n-logger [did resolve this](https://github.com/Financial-Times/n-logger/blob/main/src/lib/logger.js#L47). I think for compatibility we should replicate this behaviour.