### PR TITLE
feat!: switch to Reliability Kit logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
       "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
@@ -2756,7 +2757,8 @@
     "node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -3496,6 +3498,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3789,6 +3792,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4248,9 +4252,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.459",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.459.tgz",
-      "integrity": "sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==",
+      "version": "1.4.460",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.460.tgz",
+      "integrity": "sha512-kKiHnbrHME7z8E6AYaw0ehyxY5+hdaRmeUbjBO22LZMdqTYCO29EvF0T1cQ3pJ1RN5fyMcHl1Lmcsdt9WWJpJQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4284,6 +4288,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4294,6 +4299,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -4848,6 +4854,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -5938,7 +5945,8 @@
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -6685,7 +6693,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7562,6 +7571,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9138,7 +9148,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sax": {
       "version": "1.2.1",
@@ -9554,6 +9564,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -9981,7 +9992,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -10362,7 +10374,8 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
@@ -10374,6 +10387,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -10426,6 +10440,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
       "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "dev": true,
       "dependencies": {
         "async": "^3.2.3",
         "colors": "1.0.x",
@@ -10696,9 +10711,9 @@
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-        "@dotcom-reliability-kit/serialize-request": "^2.2.0",
-        "@financial-times/n-logger": "^10.3.1"
+        "@dotcom-reliability-kit/serialize-request": "^2.2.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.17"
@@ -11572,9 +11587,9 @@
       "version": "file:packages/log-error",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/logger": "^2.2.6",
         "@dotcom-reliability-kit/serialize-error": "^2.1.0",
         "@dotcom-reliability-kit/serialize-request": "^2.2.0",
-        "@financial-times/n-logger": "^10.3.1",
         "@types/express": "^4.17.17"
       }
     },
@@ -11723,6 +11738,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
       "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
+      "dev": true,
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.7",
@@ -13027,7 +13043,8 @@
     "async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "async-retry": {
       "version": "1.3.3",
@@ -13560,7 +13577,8 @@
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true
     },
     "commander": {
       "version": "10.0.0",
@@ -13778,7 +13796,8 @@
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
     },
     "dargs": {
       "version": "7.0.0",
@@ -14094,9 +14113,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.459",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.459.tgz",
-      "integrity": "sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==",
+      "version": "1.4.460",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.460.tgz",
+      "integrity": "sha512-kKiHnbrHME7z8E6AYaw0ehyxY5+hdaRmeUbjBO22LZMdqTYCO29EvF0T1cQ3pJ1RN5fyMcHl1Lmcsdt9WWJpJQ==",
       "dev": true
     },
     "emittery": {
@@ -14121,6 +14140,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
@@ -14131,6 +14151,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
           "optional": true,
           "peer": true,
           "requires": {
@@ -14535,7 +14556,8 @@
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
     },
     "fast-copy": {
       "version": "3.0.1",
@@ -15335,7 +15357,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -15908,7 +15931,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.2.3",
@@ -16563,6 +16587,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -17667,7 +17692,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "sax": {
       "version": "1.2.1",
@@ -17997,7 +18022,8 @@
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -18314,7 +18340,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -18590,7 +18617,8 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "whatwg-fetch": {
       "version": "3.6.2",
@@ -18602,6 +18630,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -18642,6 +18671,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
       "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "dev": true,
       "requires": {
         "async": "^3.2.3",
         "colors": "1.0.x",

--- a/packages/crash-handler/lib/index.js
+++ b/packages/crash-handler/lib/index.js
@@ -6,7 +6,7 @@ const {
 /**
  * @typedef {object} CrashHandlerOptions
  * @property {import('@dotcom-reliability-kit/log-error').Logger & {[key: string]: any}} [logger]
- *     The logger to use to output errors. Defaults to n-logger.
+ *     The logger to use to output errors. Defaults to Reliability Kit logger.
  * @property {import('process')} [process]
  *     The Node.js process to add crash handlers for.
  */

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -34,7 +34,7 @@ const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
 
 ### `logHandledError`
 
-The `logHandledError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged has been correctly handled and the application can continue to run.
+The `logHandledError` function can be used to log errors consistently to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger). This method is used to indicate that the error being logged has been correctly handled and the application can continue to run.
 
 ```js
 logHandledError({
@@ -68,7 +68,7 @@ This will automatically [serialize error objects](https://github.com/Financial-T
 
 ### `logRecoverableError`
 
-The `logRecoverableError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged was completely recoverable, with no error page sent to a user.
+The `logRecoverableError` function can be used to log errors consistently to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger). This method is used to indicate that the error being logged was completely recoverable, with no error page sent to a user.
 
 ```js
 logRecoverableError({
@@ -102,7 +102,7 @@ The information logged looks like this:
 
 ### `logUnhandledError`
 
-The `logUnhandledError` function can be used to log errors consistently to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger). This method is used to indicate that the error being logged was not recoverable and resulted in an application crashing.
+The `logUnhandledError` function can be used to log errors consistently to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger). This method is used to indicate that the error being logged was not recoverable and resulted in an application crashing.
 
 ```js
 logUnhandledError({
@@ -210,17 +210,7 @@ type LogMethod = (...logData: any) => any;
 
 Though it's best if they can accept a single object and output results as JSON.
 
-This option defaults to [n-logger](https://github.com/Financial-Times/n-logger) and is compatible with [n-mask-logger](https://github.com/Financial-Times/n-mask-logger):
-
-```js
-const {logRecoverableError} = require('@dotcom-reliability-kit/log-error');
-const MaskLogger = require('@financial-times/n-mask-logger');
-
-logRecoverableError({
-    error: new Error('Oops'),
-    logger: new MaskLogger()
-});
-```
+This option defaults to [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger).
 
 #### `options.request`
 

--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -1,5 +1,5 @@
 const appInfo = require('@dotcom-reliability-kit/app-info');
-const nLogger = require('@financial-times/n-logger').default;
+const reliabilityKitLogger = require('@dotcom-reliability-kit/logger');
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
 const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
 
@@ -22,7 +22,7 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  * @property {string[]} [includeHeaders]
  *     An array of request headers to include in the log.
  * @property {Logger & {[key: string]: any}} [logger]
- *     The logger to use to output errors. Defaults to n-logger.
+ *     The logger to use to output errors. Defaults to Reliability Kit logger.
  * @property {(string | import('@dotcom-reliability-kit/serialize-request').Request)} [request]
  *     An request object to include in the log.
  */
@@ -48,7 +48,7 @@ function logError({
 	event,
 	includeHeaders,
 	level = 'error',
-	logger = nLogger,
+	logger = reliabilityKitLogger,
 	request
 }) {
 	const serializedError = serializeError(error);

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -17,9 +17,9 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^2.1.0",
+    "@dotcom-reliability-kit/logger": "^2.2.6",
     "@dotcom-reliability-kit/serialize-error": "^2.1.0",
-    "@dotcom-reliability-kit/serialize-request": "^2.2.0",
-    "@financial-times/n-logger": "^10.3.1"
+    "@dotcom-reliability-kit/serialize-request": "^2.2.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17"

--- a/packages/log-error/test/unit/lib/index.spec.js
+++ b/packages/log-error/test/unit/lib/index.spec.js
@@ -1,13 +1,11 @@
 const logError = require('../../../lib');
 const { logHandledError, logRecoverableError, logUnhandledError } = logError;
 
-jest.mock('@financial-times/n-logger', () => ({
-	default: {
-		error: jest.fn(),
-		warn: jest.fn()
-	}
+jest.mock('@dotcom-reliability-kit/logger', () => ({
+	error: jest.fn(),
+	warn: jest.fn()
 }));
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger');
 
 jest.mock('@dotcom-reliability-kit/serialize-error', () =>
 	jest.fn().mockReturnValue({

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -31,7 +31,7 @@ const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors
 
 ### `createErrorLogger`
 
-The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [n-logger](https://github.com/Financial-Times/n-logger).
+The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger).
 
 > **Warning**
 > This middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware.

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -20,7 +20,7 @@ const {
  * @property {ErrorLoggingFilter} [filter]
  *     A filter function to determine whether an error should be logged.
  * @property {import('@dotcom-reliability-kit/log-error').Logger & {[key: string]: any}} [logger]
- *     The logger to use to output errors. Defaults to n-logger.
+ *     The logger to use to output errors. Defaults to Reliability Kit logger.
  */
 
 /**

--- a/packages/middleware-log-errors/test/end-to-end/fixtures/app.js
+++ b/packages/middleware-log-errors/test/end-to-end/fixtures/app.js
@@ -1,7 +1,9 @@
 // Environment overrides must come before module imports
 process.env.HEROKU_RELEASE_CREATED_AT = 'mock-release-date';
 process.env.HEROKU_SLUG_COMMIT = 'mock-commit-hash';
+process.env.LOG_LEVEL = 'debug';
 process.env.MIGRATE_TO_HEROKU_LOG_DRAINS = 'true';
+process.env.NODE_ENV = 'production';
 process.env.REGION = 'mock-region';
 process.env.SYSTEM_CODE = 'reliability-kit/middleware-log-errors';
 

--- a/packages/middleware-log-errors/test/end-to-end/index.spec.js
+++ b/packages/middleware-log-errors/test/end-to-end/index.spec.js
@@ -3,13 +3,16 @@ const { fork } = require('child_process');
 
 describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {
 	let child;
-	let stderr = '';
+	let stdout = '';
 	let baseUrl;
 
 	beforeAll((done) => {
 		child = fork(`${__dirname}/fixtures/app.js`, { stdio: 'pipe' });
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk.toString();
+		});
 		child.stderr.on('data', (chunk) => {
-			stderr += chunk.toString();
+			stdout += chunk.toString();
 		});
 		child.on('message', (message) => {
 			if (message?.ready) {
@@ -29,7 +32,7 @@ describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {
 		});
 
 		it('logs error information to stdout', () => {
-			const jsonLogs = stderr.split('\n').map((line) => {
+			const jsonLogs = stdout.split('\n').map((line) => {
 				try {
 					return JSON.parse(line);
 				} catch (error) {
@@ -78,7 +81,7 @@ describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {
 		});
 
 		it('does not log error information to stdout', () => {
-			expect(stderr).not.toContain('FILTERED_ERROR');
+			expect(stdout).not.toContain('FILTERED_ERROR');
 		});
 	});
 });

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -4,13 +4,21 @@ const renderErrorPage = require('./render-error-page');
 const serializeError = require('@dotcom-reliability-kit/serialize-error');
 
 /**
+ * @typedef {object} ErrorRenderingOptions
+ * @property {import('@dotcom-reliability-kit/log-error').Logger & Object<string, any>} [logger]
+ *     The logger to use to output errors. Defaults to Reliability Kit logger.
+ */
+
+/**
  * Create a middleware function to render an error info page.
  *
  * @public
+ * @param {ErrorRenderingOptions} [options]
+ *     Options to configure the middleware.
  * @returns {import('express').ErrorRequestHandler}
  *     Returns error info rendering middleware.
  */
-function createErrorRenderingMiddleware() {
+function createErrorRenderingMiddleware(options = {}) {
 	// Only render the error info page if we're not in production.
 	// Note: if we ever want to get this working in production, we
 	// will need to make this middleware play nicely with
@@ -36,6 +44,7 @@ function createErrorRenderingMiddleware() {
 			} catch (/** @type {any} */ renderingError) {
 				logRecoverableError({
 					error: renderingError,
+					logger: options.logger,
 					request
 				});
 			}

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -212,12 +212,30 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 				expect(logRecoverableError).toBeCalledTimes(1);
 				expect(logRecoverableError).toBeCalledWith({
 					error: renderingError,
-					request
+					request,
+					logger: undefined
 				});
 			});
 
 			it('calls `next` with the original error', () => {
 				expect(next).toBeCalledWith(error);
+			});
+
+			describe('when the logger option is set', () => {
+				beforeEach(() => {
+					middleware = createErrorRenderingMiddleware({
+						logger: 'mock-logger'
+					});
+					middleware(error, request, response, next);
+				});
+
+				it('passes on the custom logger to the log method', () => {
+					expect(logRecoverableError).toBeCalledWith({
+						error: renderingError,
+						request,
+						logger: 'mock-logger'
+					});
+				});
 			});
 		});
 	});


### PR DESCRIPTION
This removes n-logger from all packages, switching it to Reliability Kit logger. To make sure that teams can undo this temporarily, I've added the ability to configure the logger to the only module where it wasn't possible - middleware-render-error-info.

This means that these modules will no longer log to Splunk unless the app they're used in is configured to forward `stdout` logs there.

n-logger is still installed as a development dependency in a few places, mostly for testing compatibility with Reliability Kit logger and also in places where we're importing n-express for end-to-end middleware tests. You can verify that n-logger is not installed as a production dependency with this:

```sh
npm ls --depth 100 --omit dev @financial-times/n-logger
```

Part of [CPREL-668](https://financialtimes.atlassian.net/browse/CPREL-668).

[CPREL-668]: https://financialtimes.atlassian.net/browse/CPREL-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ