### PR TITLE
fix!: remove Sentry workarounds

### DIFF
--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -45,9 +45,6 @@ registerCrashHandler();
 
 If an error is thrown which will crash your application, error information will be logged and then the process will exit with the value of `process.exitCode` or `1`.
 
-> **Warning**
-> This function will not work as expected if your app is using [n-raven](https://github.com/Financial-Times/n-raven) or n-express without [the `withSentry` option](https://github.com/Financial-Times/n-express#optional) set to `false`. This is because the way we set up Sentry prevents registering any other uncaught exception handlers. You'll need to [migrate away from Sentry](#migrating-from-sentry) to use this module.
-
 ### Configuration options
 
 Config options can be passed into the `registerCrashHandler` function as an object with any of the keys below.

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -74,9 +74,6 @@ This will automatically [serialize error objects](https://github.com/Financial-T
 }
 ```
 
-> **Note**
-> If you're also using [n-raven v6.1+](https://github.com/Financial-Times/n-raven) in your application then the Raven error logging will be deactivated so that you don't get double-logged errors.
-
 ### Configuration options
 
 Config options can be passed into the `createErrorLogger` function as an object with any of the keys below.

--- a/packages/middleware-log-errors/lib/index.js
+++ b/packages/middleware-log-errors/lib/index.js
@@ -87,11 +87,6 @@ function createErrorLoggingMiddleware(options = {}) {
 				logger: options.logger,
 				request
 			});
-
-			// HACK: this suppresses the Raven error logger. We can remove this
-			// code without a breaking change if/when we pull Raven logging into
-			// this module and deprecate n-raven
-			response.locals.suppressRavenLogger = true;
 		} catch (_) {
 			// Not a lot we can do here
 		}

--- a/packages/middleware-log-errors/test/unit/lib/index.spec.js
+++ b/packages/middleware-log-errors/test/unit/lib/index.spec.js
@@ -47,10 +47,6 @@ describe('@dotcom-reliability-kit/middleware-log-errors', () => {
 			});
 		});
 
-		it('suppresses Raven error logging', () => {
-			expect(response.locals.suppressRavenLogger).toStrictEqual(true);
-		});
-
 		it('calls `next` with the original error', () => {
 			expect(next).toBeCalledWith(error);
 		});

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -20,10 +20,6 @@ const serializeError = require('@dotcom-reliability-kit/serialize-error');
  */
 function createErrorRenderingMiddleware(options = {}) {
 	// Only render the error info page if we're not in production.
-	// Note: if we ever want to get this working in production, we
-	// will need to make this middleware play nicely with
-	// Sentry/n-raven – right now it will render a page and skip
-	// any later middleware so Sentry will never run.
 	const performRendering = appInfo.environment === 'development';
 
 	return function errorRenderingMiddleware(error, request, response, next) {


### PR DESCRIPTION
This removes all the places across Reliability Kit where we have to work around the existence of Sentry/n-raven. This is breaking because we now require the latest version of n-express which doesn't include n-raven.

Part of [CPREL-668](https://financialtimes.atlassian.net/browse/CPREL-668).

[CPREL-668]: https://financialtimes.atlassian.net/browse/CPREL-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ