### PR TITLE
feat!: log unhandled errors with a level of "fatal"

### DIFF
--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -11,6 +11,8 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  * @typedef {object} Logger
  * @property {LogMethod} error
  *     A function to log an error.
+ * @property {LogMethod} [fatal]
+ *     A function to log a fatal error.
  * @property {LogMethod} warn
  *     A function to log a warning.
  */
@@ -31,8 +33,8 @@ const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
  * @typedef {object} InternalErrorLoggingOptions
  * @property {string} event
  *     The event to log.
- * @property {("error" | "warn")} [level="error"]
- *     The log level to use. One of "error" or "warn".
+ * @property {("error" | "fatal" | "warn")} level
+ *     The log level to use. One of "error", "fatal", or "warn".
  */
 
 /**
@@ -47,7 +49,7 @@ function logError({
 	error,
 	event,
 	includeHeaders,
-	level = 'error',
+	level,
 	logger = reliabilityKitLogger,
 	request
 }) {
@@ -69,7 +71,8 @@ function logError({
 	}
 
 	try {
-		logger[level](logData);
+		const logMethod = logger[level] || logger.error;
+		logMethod(logData);
 	} catch (/** @type {any} */ loggingError) {
 		// We allow use of `console.log` here to ensure that critical
 		// logging failures are caught and logged. This ensures that we
@@ -116,6 +119,7 @@ function logHandledError({ error, includeHeaders, logger, request }) {
 		error,
 		event: 'HANDLED_ERROR',
 		includeHeaders,
+		level: 'error',
 		logger,
 		request
 	});
@@ -153,6 +157,7 @@ function logUnhandledError({ error, includeHeaders, logger, request }) {
 		error,
 		event: 'UNHANDLED_ERROR',
 		includeHeaders,
+		level: 'fatal',
 		logger,
 		request
 	});

--- a/packages/log-error/test/unit/lib/index.spec.js
+++ b/packages/log-error/test/unit/lib/index.spec.js
@@ -3,6 +3,7 @@ const { logHandledError, logRecoverableError, logUnhandledError } = logError;
 
 jest.mock('@dotcom-reliability-kit/logger', () => ({
 	error: jest.fn(),
+	fatal: jest.fn(),
 	warn: jest.fn()
 }));
 const logger = require('@dotcom-reliability-kit/logger');
@@ -254,6 +255,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			beforeEach(() => {
 				customLogger = {
 					error: jest.fn(),
+					fatal: jest.fn(),
 					warn: jest.fn()
 				};
 				logHandledError({
@@ -520,6 +522,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			beforeEach(() => {
 				customLogger = {
 					error: jest.fn(),
+					fatal: jest.fn(),
 					warn: jest.fn()
 				};
 				logRecoverableError({
@@ -634,7 +637,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 		});
 
 		it('logs the serialized error, request, and app details', () => {
-			expect(logger.error).toBeCalledWith({
+			expect(logger.fatal).toBeCalledWith({
 				event: 'UNHANDLED_ERROR',
 				message: 'MockError: mock error',
 				error: {
@@ -672,7 +675,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 
 			it('logs the serialized error, request, and app details', () => {
-				expect(logger.error).toBeCalledWith({
+				expect(logger.fatal).toBeCalledWith({
 					event: 'UNHANDLED_ERROR',
 					message: 'MockError: mock error',
 					error: {
@@ -706,7 +709,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 
 			it('logs the serialized error and app details', () => {
-				expect(logger.error).toBeCalledWith({
+				expect(logger.fatal).toBeCalledWith({
 					event: 'UNHANDLED_ERROR',
 					message: 'MockError: mock error',
 					error: {
@@ -734,7 +737,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 
 			it('defaults the message to use "Error"', () => {
-				expect(logger.error).toBeCalledWith({
+				expect(logger.fatal).toBeCalledWith({
 					event: 'UNHANDLED_ERROR',
 					message: 'Error: mock error',
 					error: {
@@ -762,7 +765,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 
 			it('defaults the message to only use the name', () => {
-				expect(logger.error).toBeCalledWith({
+				expect(logger.fatal).toBeCalledWith({
 					event: 'UNHANDLED_ERROR',
 					message: 'MockError',
 					error: {
@@ -786,6 +789,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			beforeEach(() => {
 				customLogger = {
 					error: jest.fn(),
+					fatal: jest.fn(),
 					warn: jest.fn()
 				};
 				logUnhandledError({
@@ -796,6 +800,41 @@ describe('@dotcom-reliability-kit/log-error', () => {
 			});
 
 			it('logs the serialized error, request, and app details with the custom logger', () => {
+				expect(customLogger.fatal).toBeCalledWith({
+					event: 'UNHANDLED_ERROR',
+					message: 'MockError: mock error',
+					error: {
+						name: 'MockError',
+						message: 'mock error'
+					},
+					request: 'mock-serialized-request',
+					app: {
+						commit: 'mock-commit-hash',
+						name: 'mock-system-code',
+						nodeVersion: process.versions.node,
+						region: 'mock-region',
+						releaseDate: 'mock-release-date'
+					}
+				});
+			});
+		});
+
+		describe('when the logger does not have a `fatal` method', () => {
+			let customLogger;
+
+			beforeEach(() => {
+				customLogger = {
+					error: jest.fn(),
+					warn: jest.fn()
+				};
+				logUnhandledError({
+					error,
+					request,
+					logger: customLogger
+				});
+			});
+
+			it('logs the serialized error, request, and app details with the custom logger error method', () => {
 				expect(customLogger.error).toBeCalledWith({
 					event: 'UNHANDLED_ERROR',
 					message: 'MockError: mock error',
@@ -830,7 +869,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					name: 'MockLoggingError',
 					message: 'mock logging error'
 				});
-				logger.error.mockImplementation(() => {
+				logger.fatal.mockImplementation(() => {
 					throw loggingError;
 				});
 				logUnhandledError({
@@ -867,7 +906,7 @@ describe('@dotcom-reliability-kit/log-error', () => {
 					JSON.stringify({
 						level: 'error',
 						event: 'LOG_METHOD_FAILURE',
-						message: "Failed to log at level 'error'",
+						message: "Failed to log at level 'fatal'",
 						error: {
 							name: 'MockLoggingError',
 							message: 'mock logging error'


### PR DESCRIPTION
Now that we've moved to Reliability Kit logger we can log unhandled errors with a level of "fatal". If the logger doesn't have a fatal method then we fall back to the error method so this can continue to work with the old loggers.

This is one step towards us using appropriate log levels in all cases across our estate and being able to more easily differentiate crashing bugs without having to know the event name.

This is breaking because our tooling (Splunk alerts / searches) will need an update.

## `UNHANDLED_ERROR` event diff

```diff
  {
+ 	"level": "fatal",
- 	"level": "error",
  	"time": 1691364939967,
  	"event": "UNHANDLED_ERROR",
  	"message": "Error: bind EADDRINUSE null:46492",
  	"error": {
  		"name": "Error",
  		"code": "EADDRINUSE",
  		"message": "bind EADDRINUSE null:46492",
  		"isOperational": false,
  		"relatesToSystems": [],
  		"cause": null,
  		"stack": "...",
  		"statusCode": null,
  		"data": {}
  	},
  	"app": {
  		"commit": "1a7153b1d3c347bf50e33de6098233acc8c42b4e",
  		"name": "next-preflight",
  		"nodeVersion": "18.17.0",
  		"region": "US",
  		"releaseDate": "2023-08-02T15:28:17Z"
  	}
  }
```

## Crash alerts

The query for crash alerts was updated a while ago. It considers both log levels:

```
(index=heroku OR index=aws_cloudwatch)
(source=*cp-* OR source=*next-* OR source=*dotcom-*)
(level=error OR level=fatal)
event="UNHANDLED_ERROR"
```