### PR TITLE
fix: correct types for the logger

### DIFF
--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -15,14 +15,16 @@ const legacyMask = require('./transforms/legacy-mask');
  *     Built-in log transforms.
  */
 
-/**
- * @type {Logger & DefaultLogger}
- */
-module.exports = new Logger();
+/** @type {Transforms} */
+const transforms = { legacyMask };
 
-module.exports.Logger = Logger;
+/** @type {Logger & DefaultLogger} */
+const defaultLogger = Object.assign(new Logger(), {
+	Logger,
+	transforms
+});
 
-module.exports.transforms = { legacyMask };
+module.exports = defaultLogger;
 
 // @ts-ignore
 module.exports.default = module.exports;


### PR DESCRIPTION
The types that were generated weren't working properly in TypeScript projects that imported and created a new `Logger` instance, this is because we were assigning directly to `module.exports` instead of creating a new instance of the logger and _then_ assigning it.

I generated the new type files and tested them in a TS project (n-user-api-client), they now work as expected.