### PR TITLE
feat: add a fetch-error-handler package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,11 +2,12 @@
   "packages/app-info": "2.1.0",
   "packages/crash-handler": "3.0.0",
   "packages/errors": "2.2.0",
+  "packages/eslint-config": "2.0.1",
+  "packages/fetch-error-handler": "0.0.0",
   "packages/log-error": "3.0.0",
   "packages/logger": "2.2.7",
   "packages/middleware-log-errors": "3.0.0",
   "packages/middleware-render-error-info": "3.0.0",
   "packages/serialize-error": "2.1.0",
-  "packages/serialize-request": "2.2.0",
-  "packages/eslint-config": "2.0.1"
+  "packages/serialize-request": "2.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,6 +1068,10 @@
       "resolved": "packages/eslint-config",
       "link": true
     },
+    "node_modules/@dotcom-reliability-kit/fetch-error-handler": {
+      "resolved": "packages/fetch-error-handler",
+      "link": true
+    },
     "node_modules/@dotcom-reliability-kit/log-error": {
       "resolved": "packages/log-error",
       "link": true
@@ -10622,6 +10626,18 @@
         "eslint": ">=8.27.0"
       }
     },
+    "packages/fetch-error-handler": {
+      "name": "@dotcom-reliability-kit/fetch-error-handler",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/errors": "^2.2.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
       "version": "3.0.0",
@@ -11551,6 +11567,12 @@
       "version": "file:packages/eslint-config",
       "requires": {
         "@types/eslint": "^8.44.2"
+      }
+    },
+    "@dotcom-reliability-kit/fetch-error-handler": {
+      "version": "file:packages/fetch-error-handler",
+      "requires": {
+        "@dotcom-reliability-kit/errors": "^2.2.0"
       }
     },
     "@dotcom-reliability-kit/log-error": {

--- a/packages/fetch-error-handler/.npmignore
+++ b/packages/fetch-error-handler/.npmignore
@@ -1,0 +1,5 @@
+!*.d.ts
+!*.d.ts.map
+CHANGELOG.md
+docs
+test

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -1,0 +1,150 @@
+
+## @dotcom-reliability-kit/fetch-error-handler
+
+Properly handle fetch errors and avoid a lot of boilerplate in your app. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
+
+> [!WARNING]  
+> This package is in beta and hasn't been tested extensively in production yet. Feel free to use, and any feedback is greatly appreciated.
+
+  * [Usage](#usage)
+    * [Errors thrown](#errors-thrown)
+      * [Client errors](#client-errors)
+      * [Server errors](#server-errors)
+      * [Unknown errors](#unknown-errors)
+    * [Creating your own handler](#creating-your-own-handler)
+    * [`createFetchErrorHandler` configuration options](#createfetcherrorhandler-configuration-options)
+      * [`options.upstreamSystemCode`](#optionsupstreamsystemcode)
+  * [Contributing](#contributing)
+  * [License](#license)
+
+
+## Usage
+
+Install `@dotcom-reliability-kit/fetch-error-handler` as a dependency:
+
+```bash
+npm install --save @dotcom-reliability-kit/fetch-error-handler
+```
+
+Include in your code:
+
+```js
+import { handleFetchErrors } from '@dotcom-reliability-kit/fetch-error-handler';
+// or
+const { handleFetchErrors } = require('@dotcom-reliability-kit/fetch-error-handler');
+```
+
+You can use this function with any `fetch` call to throw appropriate errors based on the [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that you get back.
+
+There are many ways to use it, as long as it is `await`ed and is called with either a `Response` object or a `Promise` that resolves to a `Response`. The function is asynchronous and resolves with the `Response` that it was called with:
+
+```js
+// Pass the function into the `then` function of a `fetch`.
+// Note: this must be `then` and not `catch`
+const response = await fetch('https://httpbin.org/status/500').then(handleFetchErrors);
+
+// Wrap the fetch function. You can do this safely without
+// awaiting the fetch itself
+const response = await handleFetchErrors(
+    fetch('https://httpbin.org/status/500')
+);
+
+// Pass in a response manually:
+const response = await fetch('https://httpbin.org/status/500');
+await handleFetchErrors(response);
+```
+
+If the reponse `ok` property is `false`, i.e. when the status code is `400` or greater, then errors will be thrown.
+
+### Errors thrown
+
+We throw different errors depending on the status code we get back from the `fetch` call.
+
+#### Client errors
+
+If the URL you fetched responds with a status code in the range of `400–499` then this normally indicates that  something is wrong with the _current_ system. Maybe we're sending data in an invalid format or our API key is invalid. For this we throw a generic `500` error to indicate an issue with _our_ system. It'll be an [`HTTPError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror). This error will have the following properties to help you debug:
+
+```js
+error.statusCode // 500
+error.code // FETCH_CLIENT_ERROR
+error.data.upstreamUrl // The URL that was fetched
+error.data.upstreamStatusCode // The status code that the URL responded with
+```
+
+#### Server errors
+
+If the URL you fetched responds with a status code in the range of `500–599` then this indicates something is wrong with the _upstream_ system. For this we can output an [`UpstreamServiceError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror) and attribute it to the system we're fetching from. This error will have the following properties to help you debug:
+
+```js
+error.statusCode // 502
+error.code // FETCH_SERVER_ERROR
+error.data.upstreamUrl // The URL that was fetched
+error.data.upstreamStatusCode // The status code that the URL responded with
+```
+
+#### Unknown errors
+
+If the URL you fetched responds with an `ok` property of `false` and a status code outside of the `400–599` range, then it's unclear what's happened but we reject with an error anyway to make sure we're able to debug. We output an [`HTTPError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror):
+
+```js
+error.statusCode // 500
+error.code // FETCH_UNKNOWN_ERROR
+error.data.upstreamUrl // The URL that was fetched
+error.data.upstreamStatusCode // The status code that the URL responded with
+```
+
+### Creating your own handler
+
+You can customise the thrown errors by creating your own fetch handler and passing in [options](#createfetcherrorhandler-configuration-options).
+
+Include in your code:
+
+```js
+import { createFetchErrorHandler } from '@dotcom-reliability-kit/fetch-error-handler';
+// or
+const { createFetchErrorHandler } = require('@dotcom-reliability-kit/fetch-error-handler');
+```
+
+Create and use your own handler (the handler supports all the same usage methods as [outlined here](#usage)):
+
+```js
+const handleFetchErrors = createFetchErrorHandler({
+    upstreamSystemCode: 'httpbin'
+});
+const response = await fetch('https://httpbin.org/status/500').then(handleFetchErrors);
+```
+
+If you want a custom handler just for one `fetch` call, then you can shorten the above example to:
+
+```js
+const response = await fetch('https://httpbin.org/status/500').then(createFetchErrorHandler({
+    upstreamSystemCode: 'httpbin'
+}))
+```
+
+### `createFetchErrorHandler` configuration options
+
+Config options can be passed into the `createFetchErrorHandler` function to change the behaviour of the handler.
+
+#### `options.upstreamSystemCode`
+
+Attribute any fetch errors to a given [Biz Ops system](https://biz-ops.in.ft.com/list/Systems). This allows you to easily spot in your logs when an upstream system is the cause of an error. This must be an `String` and a valid [system code](https://tech.in.ft.com/tech-topics/operability/biz-ops/unique-identifiers).
+
+```js
+const handleFetchErrors = createFetchErrorHandler({
+    upstreamSystemCode: 'next-navigation-api'
+});
+```
+
+When this is set, any errors thrown by `handleFetchErrors` will have a [`relatesToSystems` property](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#operationalerrorrelatestosystems) which includes the given system code.
+
+
+## Contributing
+
+See the [central contributing guide for Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/contributing.md).
+
+
+## License
+
+Licensed under the [MIT](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/LICENSE) license.<br/>
+Copyright &copy; 2023, The Financial Times Ltd.

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -128,7 +128,7 @@ Config options can be passed into the `createFetchErrorHandler` function to chan
 
 #### `options.upstreamSystemCode`
 
-Attribute any fetch errors to a given [Biz Ops system](https://biz-ops.in.ft.com/list/Systems). This allows you to easily spot in your logs when an upstream system is the cause of an error. This must be an `String` and a valid [system code](https://tech.in.ft.com/tech-topics/operability/biz-ops/unique-identifiers).
+Attribute any fetch errors to a given [Biz Ops system](https://biz-ops.in.ft.com/list/Systems). This allows you to easily spot in your logs when an upstream system is the cause of an error. This must be a `String` and a valid [system code](https://tech.in.ft.com/tech-topics/operability/biz-ops/unique-identifiers).
 
 ```js
 const handleFetchErrors = createFetchErrorHandler({

--- a/packages/fetch-error-handler/lib/create-handler.js
+++ b/packages/fetch-error-handler/lib/create-handler.js
@@ -72,7 +72,11 @@ function createFetchErrorHandler(options = {}) {
 				try {
 					const url = new URL(response.url);
 					responseHostName = url.hostname;
-				} catch (_) {}
+				} catch (_) {
+					// We ignore this error because having a valid URL isn't essential – it
+					// just helps debug if we do have one. If someone's using a weird non-standard
+					// `fetch` implementation or mocking then this error could be fired
+				}
 			}
 
 			// Some common error options which we'll include in any that are thrown

--- a/packages/fetch-error-handler/lib/create-handler.js
+++ b/packages/fetch-error-handler/lib/create-handler.js
@@ -1,0 +1,141 @@
+const {
+	HttpError,
+	UpstreamServiceError
+} = require('@dotcom-reliability-kit/errors');
+
+/**
+ * @typedef {object} ErrorHandlerOptions
+ * @property {string} [upstreamSystemCode]
+ *     The system code of the upstream system that the `fetch` makes a request to.
+ */
+
+/**
+ * @typedef {object} FetchResponse
+ * @property {boolean} ok
+ *     Whether the fetch was successful.
+ * @property {number} status
+ *     The response HTTP status code.
+ * @property {string} url
+ *     The URL of the response.
+ */
+
+/* eslint-disable jsdoc/valid-types */
+// The ESLint JSDoc plugin we're using marks this as invalid despite it being fine.
+// This is covered by the following GitHub issues. If these are closed then this should
+// no longer be an issue:
+// https://github.com/gajus/eslint-plugin-jsdoc/issues/145
+// https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/96
+// https://github.com/jsdoctypeparser/jsdoctypeparser/issues/50
+/**
+ * @typedef {<Response extends FetchResponse>(fetchPromise: Response | Promise<Response>) => Promise<Response>} FetchErrorHandler
+ */
+/* eslint-enable jsdoc/valid-types */
+
+/**
+ * Create an fetch error handler function.
+ *
+ * @param {ErrorHandlerOptions} [options]
+ *     Configuration options for the handler.
+ * @returns {FetchErrorHandler}
+ *     Returns an error handler for use with a `fetch` function.
+ */
+function createFetchErrorHandler(options = {}) {
+	const { upstreamSystemCode } = options;
+	const relatesToSystems =
+		typeof upstreamSystemCode === 'string' ? [upstreamSystemCode] : [];
+
+	return async function handleFetchErrors(input) {
+		let response = input;
+
+		// If input is a promise, resolve it
+		if (input instanceof Promise) {
+			response = await input;
+		}
+
+		// Check whether the value we were given is a valid response object
+		if (!isFetchResponse(response)) {
+			// This is not an operational error because the invalid
+			// input is highly likely to be a programmer error
+			throw Object.assign(
+				new TypeError(
+					'Fetch handler must be called with a `fetch` response object or a `fetch` promise'
+				),
+				{ code: 'FETCH_ERROR_HANDLER_INVALID_INPUT' }
+			);
+		}
+
+		// If the response isn't OK, we start throwing errors
+		if (!response.ok) {
+			// Parse the response URL so we can use the hostname in error messages
+			let responseHostName = 'unknown';
+			if (typeof response.url === 'string') {
+				try {
+					const url = new URL(response.url);
+					responseHostName = url.hostname;
+				} catch (_) {}
+			}
+
+			// Some common error options which we'll include in any that are thrown
+			const baseErrorOptions = {
+				message: `The upstream service at "${responseHostName}" responded with a ${response.status} status`,
+				relatesToSystems,
+				upstreamUrl: response.url,
+				upstreamStatusCode: response.status
+			};
+
+			// If the back end responds with a `4xx` error then it normally indicates
+			// that something is wrong with the _current_ system. Maybe we're sending data
+			// in an invalid format or our API key is invalid. For this we throw a generic
+			// `500` error to indicate an issue with our system.
+			if (response.status >= 400 && response.status < 500) {
+				throw new HttpError(
+					Object.assign(
+						{ code: 'FETCH_CLIENT_ERROR', statusCode: 500 },
+						baseErrorOptions
+					)
+				);
+			}
+
+			// If the back end responds with a `5xx` error then it normally indicates
+			// that something is wrong with the _upstream_ system. For this we can output
+			// an upstream service error and attribute the error to this system.
+			if (response.status >= 500 && response.status < 600) {
+				throw new UpstreamServiceError(
+					Object.assign({ code: 'FETCH_SERVER_ERROR' }, baseErrorOptions)
+				);
+			}
+
+			// If we get here then it's unclear what's wrong – `response.ok` is false but the status
+			// isn't in the 400–599 range. We throw a generic 500 error so that we have visibility.
+			throw new HttpError(
+				Object.assign(
+					{ code: 'FETCH_UNKNOWN_ERROR', statusCode: 500 },
+					baseErrorOptions
+				)
+			);
+		}
+
+		return response;
+	};
+}
+
+/**
+ * @param {any} value
+ *     The value to test.
+ * @returns {value is FetchResponse}
+ *     Returns `true` if the value is a fetch response.
+ */
+function isFetchResponse(value) {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	if (typeof value.ok !== 'boolean') {
+		return false;
+	}
+	if (typeof value.status !== 'number') {
+		return false;
+	}
+	return true;
+}
+
+module.exports = createFetchErrorHandler;

--- a/packages/fetch-error-handler/lib/create-handler.js
+++ b/packages/fetch-error-handler/lib/create-handler.js
@@ -32,7 +32,7 @@ const {
 /* eslint-enable jsdoc/valid-types */
 
 /**
- * Create an fetch error handler function.
+ * Create a fetch error handler function.
  *
  * @param {ErrorHandlerOptions} [options]
  *     Configuration options for the handler.

--- a/packages/fetch-error-handler/lib/index.js
+++ b/packages/fetch-error-handler/lib/index.js
@@ -1,0 +1,4 @@
+const createFetchErrorHandler = require('./create-handler');
+
+exports.createFetchErrorHandler = createFetchErrorHandler;
+exports.handleFetchErrors = createFetchErrorHandler();

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dotcom-reliability-kit/fetch-error-handler",
+  "version": "0.0.0",
+  "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Financial-Times/dotcom-reliability-kit.git",
+    "directory": "packages/fetch-error-handler"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/fetch-error-handler#readme",
+  "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: fetch-error-handler\"",
+  "license": "MIT",
+  "engines": {
+    "node": "16.x || 18.x || 20.x",
+    "npm": "7.x || 8.x || 9.x"
+  },
+  "main": "lib",
+  "dependencies": {
+    "@dotcom-reliability-kit/errors": "^2.2.0"
+  }
+}

--- a/packages/fetch-error-handler/test/unit/lib/create-handler.spec.js
+++ b/packages/fetch-error-handler/test/unit/lib/create-handler.spec.js
@@ -1,0 +1,250 @@
+const createFetchErrorHandler = require('../../../lib/create-handler');
+
+describe('@dotcom-reliability-kit/fetch-error-handler', () => {
+	let fetchErrorHandler;
+
+	describe('createFetchErrorHandler()', () => {
+		beforeEach(() => {
+			fetchErrorHandler = createFetchErrorHandler();
+		});
+
+		it('returns a handler function', () => {
+			expect(fetchErrorHandler).toBeInstanceOf(Function);
+		});
+
+		describe('fetchErrorHandler(response)', () => {
+			let mockResponse;
+			let resolvedValue;
+
+			beforeEach(async () => {
+				mockResponse = {
+					ok: true,
+					status: 200,
+					url: 'https://mock.com/example'
+				};
+				resolvedValue = await fetchErrorHandler(mockResponse);
+			});
+
+			it('resolves with the response object', () => {
+				expect(resolvedValue).toStrictEqual(mockResponse);
+			});
+
+			describe('when `response.ok` is `false` and `response.status` is 400', () => {
+				it('rejects with an error describing the issue', async () => {
+					expect.assertions(3);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 400;
+						await fetchErrorHandler(mockResponse);
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+						expect(error.message).toStrictEqual(
+							'The upstream service at "mock.com" responded with a 400 status'
+						);
+						expect(error).toMatchObject({
+							code: 'FETCH_CLIENT_ERROR',
+							statusCode: 500,
+							relatesToSystems: [],
+							data: {
+								upstreamUrl: 'https://mock.com/example',
+								upstreamStatusCode: 400
+							}
+						});
+					}
+				});
+			});
+
+			describe('when `response.ok` is `false` and `response.status` is 500', () => {
+				it('rejects with an error describing the issue', async () => {
+					expect.assertions(3);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 500;
+						await fetchErrorHandler(mockResponse);
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+						expect(error.message).toStrictEqual(
+							'The upstream service at "mock.com" responded with a 500 status'
+						);
+						expect(error).toMatchObject({
+							code: 'FETCH_SERVER_ERROR',
+							statusCode: 502,
+							relatesToSystems: [],
+							data: {
+								upstreamUrl: 'https://mock.com/example',
+								upstreamStatusCode: 500
+							}
+						});
+					}
+				});
+			});
+
+			describe('when `response.ok` is `false` and `response.status` is 600', () => {
+				it('rejects with an error describing the issue', async () => {
+					expect.assertions(3);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 600;
+						await fetchErrorHandler(mockResponse);
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+						expect(error.message).toStrictEqual(
+							'The upstream service at "mock.com" responded with a 600 status'
+						);
+						expect(error).toMatchObject({
+							code: 'FETCH_UNKNOWN_ERROR',
+							statusCode: 500,
+							relatesToSystems: [],
+							data: {
+								upstreamUrl: 'https://mock.com/example',
+								upstreamStatusCode: 600
+							}
+						});
+					}
+				});
+			});
+
+			describe('when `response.ok` is `false` and `response.url` is not a string', () => {
+				it('uses "unknown" in the error message rather than a hostname', async () => {
+					expect.assertions(2);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 400;
+						mockResponse.url = null;
+						await fetchErrorHandler(mockResponse);
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+						expect(error.message).toStrictEqual(
+							'The upstream service at "unknown" responded with a 400 status'
+						);
+					}
+				});
+			});
+
+			describe('when `response.ok` is `false` and `response.url` is a string but is not a valid URL', () => {
+				it('uses "unknown" in the error message rather than a hostname', async () => {
+					expect.assertions(2);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 400;
+						mockResponse.url = 'mock-url';
+						await fetchErrorHandler(mockResponse);
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+						expect(error.message).toStrictEqual(
+							'The upstream service at "unknown" responded with a 400 status'
+						);
+					}
+				});
+			});
+		});
+
+		describe('fetchErrorHandler(responsePromise)', () => {
+			let mockResponse;
+			let resolvedValue;
+
+			beforeEach(async () => {
+				mockResponse = {
+					ok: true,
+					status: 200,
+					url: 'https://mock.com/example'
+				};
+				resolvedValue = await fetchErrorHandler(Promise.resolve(mockResponse));
+			});
+
+			it('resolves with the response object', () => {
+				expect(resolvedValue).toStrictEqual(mockResponse);
+			});
+
+			describe('when `response.ok` is `false` and `response.status` is >= 400', () => {
+				it('rejects with an error', async () => {
+					expect.assertions(1);
+					try {
+						mockResponse.ok = false;
+						mockResponse.status = 400;
+						await fetchErrorHandler(Promise.resolve(mockResponse));
+					} catch (error) {
+						expect(error).toBeInstanceOf(Error);
+					}
+				});
+			});
+		});
+
+		describe('fetchErrorHandler(nonResponse)', () => {
+			describe('when nonResponse is a non-object', () => {
+				it('rejects with an error', async () => {
+					expect.assertions(2);
+					try {
+						await fetchErrorHandler(null);
+					} catch (error) {
+						expect(error).toBeInstanceOf(TypeError);
+						expect(error.code).toStrictEqual(
+							'FETCH_ERROR_HANDLER_INVALID_INPUT'
+						);
+					}
+				});
+			});
+
+			describe('when nonResponse has a non-boolean `ok` property', () => {
+				it('rejects with an error', async () => {
+					expect.assertions(2);
+					try {
+						await fetchErrorHandler({
+							ok: 'nope',
+							status: 400
+						});
+					} catch (error) {
+						expect(error).toBeInstanceOf(TypeError);
+						expect(error.code).toStrictEqual(
+							'FETCH_ERROR_HANDLER_INVALID_INPUT'
+						);
+					}
+				});
+			});
+
+			describe('when nonResponse has a non-number `status` property', () => {
+				it('rejects with an error', async () => {
+					expect.assertions(2);
+					try {
+						await fetchErrorHandler({
+							ok: false,
+							status: '400'
+						});
+					} catch (error) {
+						expect(error).toBeInstanceOf(TypeError);
+						expect(error.code).toStrictEqual(
+							'FETCH_ERROR_HANDLER_INVALID_INPUT'
+						);
+					}
+				});
+			});
+		});
+	});
+
+	describe('createFetchErrorHandler(options)', () => {
+		describe('when `options.upstreamSystemCode` is set', () => {
+			beforeEach(() => {
+				fetchErrorHandler = createFetchErrorHandler({
+					upstreamSystemCode: 'mock-system'
+				});
+			});
+
+			describe('fetchErrorHandler(response)', () => {
+				describe('when `response.ok` is `false` and `response.status` is >= 400', () => {
+					it('rejects with an error that includes the upstream system code', async () => {
+						expect.assertions(2);
+						try {
+							await fetchErrorHandler({
+								ok: false,
+								status: 400
+							});
+						} catch (error) {
+							expect(error).toBeInstanceOf(Error);
+							expect(error.relatesToSystems).toEqual(['mock-system']);
+						}
+					});
+				});
+			});
+		});
+	});
+});

--- a/packages/fetch-error-handler/test/unit/lib/index.spec.js
+++ b/packages/fetch-error-handler/test/unit/lib/index.spec.js
@@ -1,0 +1,25 @@
+jest.mock('../../../lib/create-handler', () =>
+	jest.fn().mockReturnValue('mock-handler')
+);
+const createHandler = require('../../../lib/create-handler');
+
+const { createFetchErrorHandler, handleFetchErrors } = require('../../..');
+
+describe('@dotcom-reliability-kit/fetch-error-handler', () => {
+	it('creates a fetch error handler', () => {
+		expect(createHandler).toBeCalledTimes(1);
+		expect(createHandler).toBeCalledWith();
+	});
+
+	describe('.createFetchErrorHandler', () => {
+		it('aliases lib/create-handler', () => {
+			expect(createFetchErrorHandler).toStrictEqual(createHandler);
+		});
+	});
+
+	describe('.handleFetchErrors', () => {
+		it('is the created fetch error handler', () => {
+			expect(handleFetchErrors).toStrictEqual('mock-handler');
+		});
+	});
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,12 +33,13 @@
 		"packages/app-info": {},
 		"packages/crash-handler": {},
 		"packages/errors": {},
+		"packages/eslint-config": {},
+		"packages/fetch-error-handler": {},
 		"packages/log-error": {},
 		"packages/logger": {},
 		"packages/middleware-log-errors": {},
 		"packages/middleware-render-error-info": {},
 		"packages/serialize-error": {},
-		"packages/serialize-request": {},
-		"packages/eslint-config": {}
+		"packages/serialize-request": {}
 	}
 }


### PR DESCRIPTION
This introduces a new package named @dotcom-reliability-kit/fetch-error-handler. It's designed to reduce boilerplate when handling `fetch` errors and provide better debugging information when fetches fail.

There was discussion about this feature in a [discussion on GitHub here](https://github.com/Financial-Times/dotcom-reliability-kit/discussions/643). Big thanks to @AniaMakes, @phelipemaia, @vbachev, and @wheresrhys for their contributions.

There are a few key differences in the implementation:

  1. We decided not to catch network and timeout errors as a first pass. `fetch` already throws errors for these and they could be added in a future version without a breaking change.

  2. We decided not to try and handle JSON parsing of the body. Again we wanted to get an MVP out and then see how people use it before tackling invalid response bodies.

A copy of the usage guide is outlined below, this appears in the `README`. This will be released as `v0.1.0` to indicate that it's an experimental package. We'll test in a few Customer Products systems and gather feedback ahead of a `v1.0.0` release at some point in the near future.

---

## Usage

Install `@dotcom-reliability-kit/fetch-error-handler` as a dependency:

```bash
npm install --save @dotcom-reliability-kit/fetch-error-handler
```

Include in your code:

```js
import { handleFetchErrors } from '@dotcom-reliability-kit/fetch-error-handler';
// or
const { handleFetchErrors } = require('@dotcom-reliability-kit/fetch-error-handler');
```

You can use this function with any `fetch` call to throw appropriate errors based on the [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that you get back.

There are many ways to use it, as long as it is `await`ed and is called with either a `Response` object or a `Promise` that resolves to a `Response`. The function is asynchronous and resolves with the `Response` that it was called with:

```js
// Pass the function into the `then` function of a `fetch`.
// Note: this must be `then` and not `catch`
const response = await fetch('https://httpbin.org/status/500').then(handleFetchErrors);

// Wrap the fetch function. You can do this safely without
// awaiting the fetch itself
const response = await handleFetchErrors(
    fetch('https://httpbin.org/status/500')
);

// Pass in a response manually:
const response = await fetch('https://httpbin.org/status/500');
await handleFetchErrors(response);
```

If the reponse `ok` property is `false`, i.e. when the status code is `400` or greater, then errors will be thrown.

### Errors thrown

We throw different errors depending on the status code we get back from the `fetch` call.

#### Client errors

If the URL you fetched responds with a status code in the range of `400–499` then this normally indicates that  something is wrong with the _current_ system. Maybe we're sending data in an invalid format or our API key is invalid. For this we throw a generic `500` error to indicate an issue with _our_ system. It'll be an [`HTTPError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror). This error will have the following properties to help you debug:

```js
error.statusCode // 500
error.code // FETCH_CLIENT_ERROR
error.data.upstreamUrl // The URL that was fetched
error.data.upstreamStatusCode // The status code that the URL responded with
```

#### Server errors

If the URL you fetched responds with a status code in the range of `500–599` then this indicates something is wrong with the _upstream_ system. For this we can output an [`UpstreamServiceError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror) and attribute it to the system we're fetching from. This error will have the following properties to help you debug:

```js
error.statusCode // 502
error.code // FETCH_SERVER_ERROR
error.data.upstreamUrl // The URL that was fetched
error.data.upstreamStatusCode // The status code that the URL responded with
```

#### Unknown errors

If the URL you fetched responds with an `ok` property of `false` and a status code outside of the `400–599` range, then it's unclear what's happened but we reject with an error anyway to make sure we're able to debug. We output an [`HTTPError`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#httperror):

```js
error.statusCode // 500
error.code // FETCH_UNKNOWN_ERROR
error.data.upstreamUrl // The URL that was fetched
error.data.upstreamStatusCode // The status code that the URL responded with
```

### Creating your own handler

You can customise the thrown errors by creating your own fetch handler and passing in [options](#createfetcherrorhandler-configuration-options).

Include in your code:

```js
import { createFetchErrorHandler } from '@dotcom-reliability-kit/fetch-error-handler';
// or
const { createFetchErrorHandler } = require('@dotcom-reliability-kit/fetch-error-handler');
```

Create and use your own handler (the handler supports all the same usage methods as [outlined here](#usage)):

```js
const handleFetchErrors = createFetchErrorHandler({
    upstreamSystemCode: 'httpbin'
});
const response = await fetch('https://httpbin.org/status/500').then(handleFetchErrors);
```

If you want a custom handler just for one `fetch` call, then you can shorten the above example to:

```js
const response = await fetch('https://httpbin.org/status/500').then(createFetchErrorHandler({
    upstreamSystemCode: 'httpbin'
}))
```

### `createFetchErrorHandler` configuration options

Config options can be passed into the `createFetchErrorHandler` function to change the behaviour of the handler.

#### `options.upstreamSystemCode`

Attribute any fetch errors to a given [Biz Ops system](https://biz-ops.in.ft.com/list/Systems). This allows you to easily spot in your logs when an upstream system is the cause of an error. This must be an `String` and a valid [system code](https://tech.in.ft.com/tech-topics/operability/biz-ops/unique-identifiers).

```js
const handleFetchErrors = createFetchErrorHandler({
    upstreamSystemCode: 'next-navigation-api'
});
```

When this is set, any errors thrown by `handleFetchErrors` will have a [`relatesToSystems` property](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/errors#operationalerrorrelatestosystems) which includes the given system code.