### PR TITLE
fix: stop requiring bound log methods

### DIFF
--- a/packages/log-error/lib/index.js
+++ b/packages/log-error/lib/index.js
@@ -72,7 +72,7 @@ function logError({
 
 	try {
 		const logMethod = logger[level] || logger.error;
-		logMethod(logData);
+		logMethod.call(logger, logData);
 	} catch (/** @type {any} */ loggingError) {
 		// We allow use of `console.log` here to ensure that critical
 		// logging failures are caught and logged. This ensures that we


### PR DESCRIPTION
This caused a bug in next-subscribe who are providing a custom logger to Reliability Kit which does not have methods bound to `this`. Because we _can_ fix this in Reliability Kit I think we should - ideally we want as few code changes as possible when teams migrate.