### PR TITLE
chore: upgrades node module imports to use built in node modules

### DIFF
--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 // This package relies on Heroku and AWS Lambda environment variables.
 // Documentation for these variables is available here:

--- a/packages/logger/test/end-to-end/compatibility.spec.js
+++ b/packages/logger/test/end-to-end/compatibility.spec.js
@@ -1,5 +1,5 @@
 const cleanLogForTesting = require('./helpers/clean-log-for-testing');
-const { exec } = require('child_process');
+const { exec } = require('node:child_process');
 const findLogWithPropertyValue = require('./helpers/find-log-with-property-value');
 const testCases = require('./compatibility-test-cases');
 const splitAndParseJsonLogs = require('./helpers/split-and-parse-json-logs');

--- a/packages/middleware-log-errors/test/end-to-end/index.spec.js
+++ b/packages/middleware-log-errors/test/end-to-end/index.spec.js
@@ -1,4 +1,4 @@
-const fetch = require('node:node-fetch');
+const fetch = require('node-fetch');
 const { fork } = require('node:child_process');
 
 describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {

--- a/packages/middleware-log-errors/test/end-to-end/index.spec.js
+++ b/packages/middleware-log-errors/test/end-to-end/index.spec.js
@@ -1,5 +1,5 @@
-const fetch = require('node-fetch');
-const { fork } = require('child_process');
+const fetch = require('node:node-fetch');
+const { fork } = require('node:child_process');
 
 describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {
 	let child;

--- a/packages/middleware-render-error-info/lib/render-layout.js
+++ b/packages/middleware-render-error-info/lib/render-layout.js
@@ -1,5 +1,5 @@
 const appInfo = require('@dotcom-reliability-kit/app-info');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const buildServiceBaseUrl = 'https://www.ft.com/__origami/service/build/v3';
 const buildServiceComponents = [

--- a/resources/logos/scripts/build.js
+++ b/resources/logos/scripts/build.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const { mkdir, readFile, writeFile } = require('fs/promises');
-const path = require('path');
+const { mkdir, readFile, writeFile } = require('node:fs/promises');
+const path = require('node:path');
 const { optimize: optimizeSvg } = require('svgo');
 const sharp = require('sharp');
 

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const fs = require('fs/promises');
-const path = require('path');
+const fs = require('node:fs/promises');
+const path = require('node:path');
 const rootManifest = require('../package.json');
 const releasePleaseConfig = require('../release-please-config.json');
 const releasePleaseManifest = require('../.release-please-manifest.json');


### PR DESCRIPTION
GitHub Issue #527 
[JIRA](https://financialtimes.atlassian.net/browse/CPREL-706)

This PR replaces some built-in module references (e.g. path, http, child_process, fs, and fs/promises) with the `node:`-prefixed versions