### PR TITLE
chore: group dev dependency PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     commit-message:
       prefix: "fix:"
       prefix-development: "chore:"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/resources/logos"


### PR DESCRIPTION
This will reduce the amount of PR churn in this repo by grouping together dev dependency updates into a single PR if they're a `minor` or `patch` level change. [See docs for more info on this configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).