### PR TITLE
feat: handle common errors thrown by fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2975,9 +2975,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -2988,7 +2988,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -3140,6 +3140,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -3536,9 +3548,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4284,8 +4296,6 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -4295,8 +4305,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4788,14 +4796,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -4814,7 +4822,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -7650,6 +7658,47 @@
         }
       }
     },
+    "node_modules/node-fetch-1": {
+      "name": "node-fetch",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/node-fetch-1/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-fetch-2": {
+      "name": "node-fetch",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-html-parser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.0.tgz",
@@ -8570,9 +8619,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -9575,6 +9624,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
@@ -10099,6 +10157,18 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.24.0.tgz",
+      "integrity": "sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
     },
     "node_modules/unist-util-is": {
       "version": "4.1.0",
@@ -10668,6 +10738,13 @@
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^2.2.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.17",
+        "express": "^4.18.2",
+        "node-fetch-1": "npm:node-fetch@^1.7.3",
+        "node-fetch-2": "npm:node-fetch@^2.7.0",
+        "undici": "^5.24.0"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -11608,7 +11685,12 @@
     "@dotcom-reliability-kit/fetch-error-handler": {
       "version": "file:packages/fetch-error-handler",
       "requires": {
-        "@dotcom-reliability-kit/errors": "^2.2.0"
+        "@dotcom-reliability-kit/errors": "^2.2.0",
+        "@types/express": "^4.17.17",
+        "express": "^4.18.2",
+        "node-fetch-1": "npm:node-fetch@^1.7.3",
+        "node-fetch-2": "npm:node-fetch@^2.7.0",
+        "undici": "^5.24.0"
       }
     },
     "@dotcom-reliability-kit/log-error": {
@@ -13185,9 +13267,9 @@
       }
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -13198,7 +13280,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -13310,6 +13392,15 @@
       "dev": true,
       "requires": {
         "run-applescript": "^5.0.0"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "bytes": {
@@ -13593,9 +13684,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -14116,8 +14207,6 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -14127,8 +14216,6 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -14472,14 +14559,14 @@
       }
     },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -14498,7 +14585,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -16591,6 +16678,33 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-fetch-1": {
+      "version": "npm:node-fetch@1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "dev": true
+        }
+      }
+    },
+    "node-fetch-2": {
+      "version": "npm:node-fetch@2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-html-parser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.0.tgz",
@@ -17247,9 +17361,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -17988,6 +18102,12 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true
+    },
     "streamx": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
@@ -18358,6 +18478,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.24.0.tgz",
+      "integrity": "sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unist-util-is": {
       "version": "4.1.0",

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -46,7 +46,7 @@ There are several ways to use it, as long as it is `await`ed and is called with 
 
 Some of the options below result in more errors being caught, you can weigh this up when implementing in your own code.
 
-In all of the APIs below, if the reponse `ok` property is `false`, i.e. when the status code is `400` or greater, then errors will be thrown.
+In all of the APIs below, if the response `ok` property is `false`, i.e. when the status code is `400` or greater, then errors will be thrown.
 
 ### Wrap the fetch function
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -17,5 +17,12 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/errors": "^2.2.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "express": "^4.18.2",
+    "node-fetch-1": "npm:node-fetch@^1.7.3",
+    "node-fetch-2": "npm:node-fetch@^2.7.0",
+    "undici": "^5.24.0"
   }
 }

--- a/packages/fetch-error-handler/test/end-to-end/fixtures/app.js
+++ b/packages/fetch-error-handler/test/end-to-end/fixtures/app.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { STATUS_CODES } = require('node:http');
+
+const app = express();
+
+app.get('/status/:status', (request, response) => {
+	setTimeout(() => {
+		let status = 200;
+		if (/^\d+$/.test(request.params.status)) {
+			status = Number(request.params.status);
+		}
+		response.status(status).send(STATUS_CODES[status]);
+	}, 50);
+});
+
+app.get('/hangup', (request, response) => {
+	response.socket.destroy();
+});
+
+const server = app.listen(() => {
+	if (process.send) {
+		process.send({
+			ready: true,
+			port: server.address().port
+		});
+	}
+});

--- a/packages/fetch-error-handler/test/end-to-end/index.spec.js
+++ b/packages/fetch-error-handler/test/end-to-end/index.spec.js
@@ -1,0 +1,164 @@
+const fetchImplementations = [
+	{
+		name: 'node-fetch-1',
+		fetch: require('node-fetch-1'),
+		supportsAbortSignal: false,
+		supportsNonStandardTimeoutOption: true
+	},
+	{
+		name: 'node-fetch-2',
+		fetch: require('node-fetch-2'),
+		supportsAbortSignal: true,
+		supportsNonStandardTimeoutOption: true
+	},
+	{
+		name: 'undici',
+		fetch: require('undici').fetch,
+		supportsAbortSignal: true,
+		supportsNonStandardTimeoutOption: false
+	},
+	{
+		name: 'native',
+		fetch: global.fetch,
+		supportsAbortSignal: true,
+		supportsNonStandardTimeoutOption: false
+	}
+];
+const { fork } = require('node:child_process');
+const { handleFetchErrors } = require('../..');
+
+describe('@dotcom-reliability-kit/fetch-error-handler end-to-end', () => {
+	let child;
+	let baseUrl;
+
+	// Set up the test app
+	beforeAll((done) => {
+		child = fork(`${__dirname}/fixtures/app.js`, { stdio: 'pipe' });
+		child.on('message', (message) => {
+			if (message?.ready) {
+				baseUrl = `http://localhost:${message.port}`;
+				done();
+			}
+		});
+	});
+
+	afterAll(() => {
+		child.kill('SIGINT');
+	});
+
+	for (const {
+		name,
+		fetch,
+		supportsAbortSignal,
+		supportsNonStandardTimeoutOption
+	} of fetchImplementations) {
+		if (typeof fetch === 'function') {
+			// eslint-disable-next-line no-loop-func
+			describe(name, () => {
+				it('handles 400 errors', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch(`${baseUrl}/status/400`));
+					} catch (error) {
+						expect(error.name).toStrictEqual('HttpError');
+						expect(error.code).toStrictEqual('FETCH_CLIENT_ERROR');
+						expect(error.statusCode).toStrictEqual(500);
+					}
+				});
+
+				it('handles 404 errors', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch(`${baseUrl}/status/404`));
+					} catch (error) {
+						expect(error.name).toStrictEqual('HttpError');
+						expect(error.code).toStrictEqual('FETCH_CLIENT_ERROR');
+						expect(error.statusCode).toStrictEqual(500);
+					}
+				});
+
+				it('handles 500 errors', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch(`${baseUrl}/status/500`));
+					} catch (error) {
+						expect(error.name).toStrictEqual('UpstreamServiceError');
+						expect(error.code).toStrictEqual('FETCH_SERVER_ERROR');
+						expect(error.statusCode).toStrictEqual(502);
+					}
+				});
+
+				it('handles 503 errors', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch(`${baseUrl}/status/503`));
+					} catch (error) {
+						expect(error.name).toStrictEqual('UpstreamServiceError');
+						expect(error.code).toStrictEqual('FETCH_SERVER_ERROR');
+						expect(error.statusCode).toStrictEqual(502);
+					}
+				});
+
+				it('handles nonexistent domains', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch('https://www.ft.not-a-tld'));
+					} catch (error) {
+						expect(error.name).toStrictEqual('OperationalError');
+						expect(error.code).toStrictEqual('FETCH_DNS_LOOKUP_ERROR');
+					}
+				});
+
+				it('handles socket hangups', async () => {
+					expect.hasAssertions();
+					try {
+						await handleFetchErrors(fetch(`${baseUrl}/hangup`));
+					} catch (error) {
+						expect(error.name).toStrictEqual('UpstreamServiceError');
+						expect(error.code).toStrictEqual('FETCH_SOCKET_HANGUP_ERROR');
+						expect(error.statusCode).toStrictEqual(502);
+					}
+				});
+
+				if (supportsAbortSignal) {
+					it('handles timeout errors via AbortController', async () => {
+						expect.hasAssertions();
+						try {
+							await handleFetchErrors(
+								fetch(`${baseUrl}/status/200`, {
+									signal: AbortSignal.timeout(10)
+								})
+							);
+						} catch (error) {
+							expect(error.name).toStrictEqual('OperationalError');
+							// This error is different depending on whether we're using
+							// Undici/native fetch vs node-fetch. That's why we have
+							// multiple potential codes here
+							expect(['FETCH_ABORT_ERROR', 'FETCH_TIMEOUT_ERROR']).toContain(
+								error.code
+							);
+						}
+					});
+				}
+
+				if (supportsNonStandardTimeoutOption) {
+					it('handles timeout errors via the non-standard timeout option', async () => {
+						expect.hasAssertions();
+						try {
+							await handleFetchErrors(
+								fetch(`${baseUrl}/status/200`, { timeout: 10 })
+							);
+						} catch (error) {
+							expect(error.name).toStrictEqual('OperationalError');
+							expect(error.code).toStrictEqual('FETCH_TIMEOUT_ERROR');
+						}
+					});
+				}
+			});
+		} else {
+			// The fetch implementation is not available (e.g. native fetch).
+			// TODO: this can be removed when we drop Node.js 16 support.
+			it.skip(`${name}`, () => {});
+		}
+	}
+});

--- a/packages/fetch-error-handler/test/unit/lib/create-handler.spec.js
+++ b/packages/fetch-error-handler/test/unit/lib/create-handler.spec.js
@@ -238,7 +238,7 @@ describe('@dotcom-reliability-kit/fetch-error-handler', () => {
 				});
 			});
 
-			describe('when the promise rejects with a abort error', () => {
+			describe('when the promise rejects with an abort error', () => {
 				it('rejects with an augmented error', async () => {
 					expect.hasAssertions();
 					try {


### PR DESCRIPTION
This adds in handling for most of the common errors that we see when making `fetch` requests. There's a lot of extra logic in here but I think it's worthwhile to augment these errors and throw ones with correct status codes that our engineers can immediately understand.

Due to the fact that we use a variety of different `fetch` implementations across the FT, this really isn't doable at the Splunk level: we can't reliably say "here's a search which shows every fetch request that has timed out".

Because of the amount of logic and the fact we're relying on error names and codes, this comes with a suite of end-to-end tests that allow us to verify that the following `fetch` implementations throw the expected errors. This way, if something changes, we'll see it immediately in a failing dependabot PR:

  - Node.js 18+ native fetch (powered by Undici)
  - Manual [Undici](https://github.com/nodejs/undici) installs
  - [node-fetch](https://github.com/node-fetch/node-fetch) v1.x
  - [node-fetch](https://github.com/node-fetch/node-fetch) v2.x

I'm unable to test using node-fetch v3 because it is written in native ES Modules which Jest has very patchy support for. I think this is acceptable as, because of the native ESM, most of our code uses node-fetch v2 and below. I think over time we're more likely to move towards native `fetch` than spend time upgrading our systems to use node-fetch v3.