### PR TITLE
fix: trim long request URLs

### DIFF
--- a/packages/serialize-request/lib/index.js
+++ b/packages/serialize-request/lib/index.js
@@ -72,6 +72,14 @@ const DEFAULT_INCLUDED_HEADERS = [
 ];
 
 /**
+ * The maximum length of a URL, any longer than this will be truncated.
+ *
+ * @private
+ * @type {number}
+ */
+const URL_TRUNCATION_LENGTH = 200;
+
+/**
  * Serialize a request object so that it can be consistently logged or output as JSON.
  *
  * @public
@@ -121,9 +129,14 @@ function serializeRequest(request, options = {}) {
 		requestProperties.method = `${request.method}`.toUpperCase();
 	}
 
-	// If set, request URL is cast to a string
+	// If set, request URL is cast to a string and truncated to avoid
+	// us exceeding log event size limits
 	if (request.url) {
-		requestProperties.url = `${request.url}`;
+		let url = `${request.url}`;
+		if (url.length > URL_TRUNCATION_LENGTH) {
+			url = url.slice(0, URL_TRUNCATION_LENGTH) + ' [truncated]';
+		}
+		requestProperties.url = url;
 	}
 
 	// Serialize the headers

--- a/packages/serialize-request/test/unit/lib/index.spec.js
+++ b/packages/serialize-request/test/unit/lib/index.spec.js
@@ -197,6 +197,19 @@ describe('@dotcom-reliability-kit/serialize-request', () => {
 			});
 		});
 
+		describe('when `request.url` is longer than 200 characters', () => {
+			beforeEach(() => {
+				request.url =
+					'/url-that-is-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long';
+			});
+
+			it('casts the url to a string and truncates it', () => {
+				expect(serializeRequest(request)).toMatchObject({
+					url: '/url-that-is-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-ve [truncated]'
+				});
+			});
+		});
+
 		describe('when `request.headers` is undefined', () => {
 			beforeEach(() => {
 				delete request.headers;


### PR DESCRIPTION
When the request URL is particularly long, Splunk events break because they're concatenated if they exceed a certain length. This causes the JSON to be invalid and so we don't parse out fields.

We probably shouldn't blindly trust the URL as it's user input. We now truncate request URLs at 200 characters and add an indicator so that it's clear in the logs when the URL was too long.