### PR TITLE
feat: add cloudProvider as exported property for appInfo

### DIFF
--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -11,6 +11,7 @@ A utility to get application information (e.g. the system code) in a consistent 
     * [`appInfo.releaseVersion`](#appinforeleaseversion)
     * [`appInfo.systemCode`](#appinfosystemcode)
     * [`appInfo.processType`](#appinfoprocesstype)
+    * [`appInfo.cloudProvider](#appinfocloudprovider)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -76,6 +77,12 @@ For AWS Lambda, this is the name of the function, read from `process.env.AWS_LAM
 For Heroku, this is derived from the first part of `process.env.DYNO`, which is set to by Heroku, e.g. a dyno called `web.1` will have `processType` set to `web`. The process types in an application are defined by the application's `Procfile`.
 
 If neither `process.env.AWS_LAMBDA_FUNCTION_NAME` or `process.env.DYNO` are set, this property will be `null`
+
+### `appInfo.cloudProvider`
+
+Get the type of cloud provider which is set to either Heroku or AWS depending on where we think the system is hosted.
+
+This is derived from some environment variables which we have high confidence are defined by only Heroku or AWS/Lambda
 
 ## Contributing
 

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -134,8 +134,11 @@ module.exports = {
 	 * @type {string | null}
 	 */
 	cloudProvider:
-		(processType === process.env.AWS_LAMBDA_FUNCTION_NAME ? 'aws' : 'heroku') ||
-		null
+		(processType === process.env.AWS_LAMBDA_FUNCTION_NAME
+			? 'aws'
+			: processType === process.env.DYNO
+				? 'heroku'
+				: null) || null
 };
 
 // @ts-ignore

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -136,9 +136,9 @@ module.exports = {
 	cloudProvider:
 		(processType === process.env.AWS_LAMBDA_FUNCTION_NAME
 			? 'aws'
-			: processType === process.env.DYNO
-				? 'heroku'
-				: null) || null
+			: Boolean(process.env.HEROKU_RELEASE_CREATED_AT)
+			? 'heroku'
+			: null) || null
 };
 
 // @ts-ignore

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -63,6 +63,22 @@ const processType =
 	(process.env.DYNO && normalizeHerokuProcessType(process.env.DYNO)) ||
 	null;
 
+/**
+ * Sets the cloud provider type.
+ *
+ * @returns {string | null}
+ *     Returns the cloud provider type (either aws or heroku).
+ */
+const cloudProvider = () => {
+	if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
+		return 'aws';
+	}
+	if (process.env.HEROKU_RELEASE_CREATED_AT) {
+		return 'heroku';
+	}
+	return null;
+};
+
 module.exports = {
 	/**
 	 * The application commit hash.
@@ -133,12 +149,7 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	cloudProvider:
-		(processType === process.env.AWS_LAMBDA_FUNCTION_NAME
-			? 'aws'
-			: Boolean(process.env.HEROKU_RELEASE_CREATED_AT)
-			? 'heroku'
-			: null) || null
+	cloudProvider: cloudProvider()
 };
 
 // @ts-ignore

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -125,7 +125,17 @@ module.exports = {
 	 * @readonly
 	 * @type {string | null}
 	 */
-	processType
+	processType,
+
+	/**
+	 * The cloud provider type.
+	 *
+	 * @readonly
+	 * @type {string | null}
+	 */
+	cloudProvider:
+		(processType === process.env.AWS_LAMBDA_FUNCTION_NAME ? 'aws' : 'heroku') ||
+		null
 };
 
 // @ts-ignore

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -275,4 +275,31 @@ describe('@dotcom-reliability-kit/app-info', () => {
 			});
 		});
 	});
+
+	describe('.cloudProvider', () => {
+		it('is set to `aws` if processType is set to `process.env.AWS_LAMBDA_FUNCTION_NAME`', () => {
+			if (appInfo.processType === process.env.AWS_LAMBDA_FUNCTION_NAME) {
+				expect(appInfo.cloudProvider).toBe('aws');
+			}
+		});
+
+		it('is set to `heroku` if processType is set to `process.env.DYNO`', () => {
+			if (appInfo.processType === process.env.DYNO) {
+				expect(appInfo.cloudProvider).toBe('heroku');
+			}
+		});
+
+		describe('when neither `process.env.AWS_LAMBDA_FUNCTION_NAME` or `process.env.DYNO` are defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.DYNO;
+				delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to null', () => {
+				expect(appInfo.cloudProvider).toBe(null);
+			});
+		});
+	});
 });

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -283,16 +283,16 @@ describe('@dotcom-reliability-kit/app-info', () => {
 			}
 		});
 
-		it('is set to `heroku` if processType is set to `process.env.DYNO`', () => {
-			if (appInfo.processType === process.env.DYNO) {
+		it('is set to `heroku` if `process.env.HEROKU_RELEASE_CREATED_AT` is set to true', () => {
+			if (process.env.HEROKU_RELEASE_CREATED_AT) {
 				expect(appInfo.cloudProvider).toBe('heroku');
 			}
 		});
 
-		describe('when neither `process.env.AWS_LAMBDA_FUNCTION_NAME` or `process.env.DYNO` are defined', () => {
+		describe('when neither `process.env.AWS_LAMBDA_FUNCTION_NAME` or `process.env.HEROKU_RELEASE_CREATED_AT` are defined', () => {
 			beforeEach(() => {
 				jest.resetModules();
-				delete process.env.DYNO;
+				delete process.env.HEROKU_RELEASE_CREATED_AT;
 				delete process.env.AWS_LAMBDA_FUNCTION_NAME;
 				appInfo = require('../../../lib');
 			});


### PR DESCRIPTION
Adds a cloudProvider property which is set to either heroku or aws depending on where we think the system is hosted. To figure this out we’ll have to find some environment variables which we have high confidence are defined by only Heroku or AWS/Lambda.

We’re going to use this in the OpenTelemetry tracing.

[JIRA](https://financialtimes.atlassian.net/browse/CPREL-834)