### PR TITLE
feat: add some basic app info to error pages

### DIFF
--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -40,6 +40,7 @@ function renderErrorPage({ request, response, serializedError }) {
 			${renderError(serializedError)}
 			${renderRequest(request)}
 			${renderResponse(response)}
+			${renderAppInfo(appInfo)}
 		`,
 		request,
 		title: escape(`${serializedError.name} in ${appName}`)
@@ -205,6 +206,59 @@ function renderResponse(response) {
 				label: 'Status Code',
 				value: response.statusCode,
 				formatter: renderCodeBlock
+			}
+		]
+	});
+}
+
+/**
+ * Render application info to HTML.
+ *
+ * @private
+ * @param {typeof appInfo} appInfo
+ *     The app information to render.
+ * @returns {string}
+ *     Returns the rendered app info.
+ */
+function renderAppInfo(appInfo) {
+	return renderSection({
+		id: 'app',
+		title: 'App Info',
+		fields: [
+			{
+				label: 'System',
+				helpText: 'The system this error is being served by',
+				value: appInfo.systemCode,
+				formatter: renderBizOpsSystem
+			},
+			{
+				label: 'Environment',
+				helpText:
+					'The environment (production/development) that the app is running in',
+				value: appInfo.environment
+			},
+			{
+				label: 'Cloud provider',
+				helpText: 'The cloud provider the app is running on.',
+				value: appInfo.cloudProvider
+			},
+			{
+				label: 'Region',
+				helpText: 'The cloud region that the app is running in',
+				value: appInfo.region
+			},
+			{
+				label: 'Release date',
+				helpText: 'When the app was last released',
+				value: appInfo.releaseDate
+			},
+			{
+				label: 'Release version',
+				value: appInfo.releaseVersion
+			},
+			{
+				label: 'Commit hash',
+				value: appInfo.commitHash
 			}
 		]
 	});

--- a/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
@@ -326,6 +326,32 @@ See the <a href="https://github.com/Financial-Times/dotcom-reliability-kit/blob/
 </dl>
 </section>
 
+
+<section class="o-layout__main__full-span">
+<h2 id="app">App Info</h2>
+
+<dl class="kv-list">
+
+<dt class="kv-list__key">
+<span class="kv-list__label">System:</span>
+<br/><small>The system this error is being served by</small>
+</dt>
+<dd class="kv-list__value">
+<a
+href="https://biz-ops.in.ft.com/System/mock-system-code"
+target="_blank"
+>mock-system-code</a>
+</dd>
+
+<dt class="kv-list__key">
+<span class="kv-list__label">Environment:</span>
+<br/><small>The environment (production/development) that the app is running in</small>
+</dt>
+<dd class="kv-list__value">development</dd>
+
+</dl>
+</section>
+
 </main>
 <div class="o-layout__footer">
 <footer class="o-footer-services">


### PR DESCRIPTION
This is a first step towards serving nicer error pages in production. We want to show application information so that a non-engineer would be able to tell which system an error is served by. This doesn't make error pages available in production yet, that'd be a later step if we decide we want to add it.

In the meantime this makes the error page more useful.

It looks like this:

![Screenshot 2023-11-13 at 14 06 40](https://github.com/Financial-Times/dotcom-reliability-kit/assets/138944/5349d1b1-daf5-48c8-a833-bfcb968c973d)
