### PR TITLE
feat: expose error fingerprints as an HTTP header

### DIFF
--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -49,7 +49,7 @@ Once you've mounted the middleware, if you're working locally you should now see
 
 #### Debug headers
 
-As well as rendering an error page, the middleware also sends an `x-error-fingerprint` HTTP header in the response. This contains the [error fingerprint](../serialize-error/README.md#serializederrorfingerprint) and is available in development and production. Inspecting this header on a generic error page can help identify the root cause of an issue.
+As well as rendering an error page, the middleware also sends an `error-fingerprint` HTTP header in the response. This contains the [error fingerprint](../serialize-error/README.md#serializederrorfingerprint) and is available in development and production. Inspecting this header on a generic error page can help identify the root cause of an issue.
 
 
 ## Contributing

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -47,6 +47,10 @@ Once you've mounted the middleware, if you're working locally you should now see
 
 ![Reliability Kit Error Info Page](https://user-images.githubusercontent.com/138944/183625949-fff25554-5c7e-4616-b717-963d472e5d35.png)
 
+#### Debug headers
+
+As well as rendering an error page, the middleware also sends an `x-error-fingerprint` HTTP header in the response. This contains the [error fingerprint](../serialize-error/README.md#serializederrorfingerprint) and is available in development and production. Inspecting this header on a generic error page can help identify the root cause of an issue.
+
 
 ## Contributing
 

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -53,9 +53,7 @@ function createErrorRenderingMiddleware(options = {}) {
 
 		// If the error has a fingerprint, output it as a header to aid debugging in production
 		if (serializedError.fingerprint) {
-			// Note: we use x-error-fingerprint rather than ft-error-fingerprint to make
-			// it easier to reuse this middleware outside of FT-branded applications
-			response.set('x-error-fingerprint', serializedError.fingerprint);
+			response.set('error-fingerprint', serializedError.fingerprint);
 		}
 
 		// Render a full error page in non-production environments

--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -51,6 +51,13 @@ function createErrorRenderingMiddleware(options = {}) {
 		response.status(statusCode);
 		response.set('content-type', 'text/html');
 
+		// If the error has a fingerprint, output it as a header to aid debugging in production
+		if (serializedError.fingerprint) {
+			// Note: we use x-error-fingerprint rather than ft-error-fingerprint to make
+			// it easier to reuse this middleware outside of FT-branded applications
+			response.set('x-error-fingerprint', serializedError.fingerprint);
+		}
+
 		// Render a full error page in non-production environments
 		if (appInfo.environment === 'development') {
 			// It's unlikely that this will fail but we want to be sure

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -174,9 +174,9 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 				middleware(error, request, response, next);
 			});
 
-			it('responds with an x-error-fingerprint header', () => {
+			it('responds with an error-fingerprint header', () => {
 				expect(response.set).toBeCalledWith(
-					'x-error-fingerprint',
+					'error-fingerprint',
 					'mockfingerprint'
 				);
 			});

--- a/packages/middleware-render-error-info/test/unit/lib/index.spec.js
+++ b/packages/middleware-render-error-info/test/unit/lib/index.spec.js
@@ -162,6 +162,26 @@ describe('@dotcom-reliability-kit/middleware-render-error-info', () => {
 			});
 		});
 
+		describe('when the serialized error has a `fingerprint` property', () => {
+			beforeEach(() => {
+				serializeError.mockReturnValue({
+					fingerprint: 'mockfingerprint',
+					statusCode: null,
+					data: {}
+				});
+				response.status = jest.fn();
+
+				middleware(error, request, response, next);
+			});
+
+			it('responds with an x-error-fingerprint header', () => {
+				expect(response.set).toBeCalledWith(
+					'x-error-fingerprint',
+					'mockfingerprint'
+				);
+			});
+		});
+
 		describe('when the serialized error does not have a `statusCode` property', () => {
 			beforeEach(() => {
 				serializeError.mockReturnValue({


### PR DESCRIPTION
This sets a new header in the error rendering middleware which exposes the fingerprint of an error if it has one. This allows us to better debug in production environments - our logs also include this fingerprint so that you can map our generic error pages to the type of error that occurred and where in the code it was thrown.

## How it works

  * Complete: the `serializeError` method, used in our logging _and_ error rendering, [now adds a `fingerprint` property](https://github.com/Financial-Times/dotcom-reliability-kit/pull/787) to an error object. This fingerprint is a hash of the first two lines of the error stack trace, meaning that the fingerprint can locate an error in our codebase without giving away error information to end-users or attackers

 * Complete: the latest version Reliability Kit error logging middleware already logs this alongside the rest of the error. This allows us to easily group errors that occur in the same part of the source code

  * **The change in this PR:** we now expose this fingerprint as an `error-fingerprint` HTTP header in the error rendering middleware. This is a safe way of exposing error information to the end user and we can match it to the error in our logs to extract the full error details

  * Future: once this header is present on our error pages, we'll be able to use it to aid debugging production issues. We have a couple of ideas:

    * Expose the error fingerprint in the UI: we already do this with "customer care codes", giving customers a code to quote to Customer Care which then speeds up their diagnosis of which team to contact. If we expose the error fingerprint then the engineer who picks up the bug report will be able to find the exact error being thrown via our logs

    * Read the error fingerprint in a browser extension: if the header is present in the browser then we could use it in an internal-facing browser extension. We could allow Operations and Customer Care to navigate directly from an error page to a Splunk search for the error fingerprint, reducing the time required to identify the responsible system

## Some considerations

  * If an app is behind a CDN and error pages are cached, then we will need to vary on the `error-fingerprint` header in order for this to be useful - otherwise the first fingerprint will get cached

  * Not all apps will get this functionality at the same time. They'll need to either start using the error rendering middleware or bump the major version, because this is landing as part of a breaking change