### PR TITLE
feat: add useIsoTimeFormat option to format log timestamps

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -12,6 +12,7 @@ A simple and fast logger based on [Pino](https://getpino.io/), with FT preferenc
       * [`options.transforms`](#optionstransforms)
       * [`options.withPrettifier`](#optionswithprettifier)
       * [`options.withTimestamps`](#optionswithtimestamps)
+      * [`options.useIsoTimeFormat`](#optionsuseisotimeformat)
     * [`logger.log()` and shortcut methods](#loggerlog-and-shortcut-methods)
     * [`logger.flush()`](#loggerflush)
     * [`logger.createChildLogger()`](#loggercreatechildlogger)
@@ -216,6 +217,26 @@ logger.info('This is a log');
 //     "level": "info",
 //     "message": "This is a log",
 //     "time": 1234567890
+// }
+```
+
+#### `options.useIsoTimeFormat`
+
+Whether to format the `time` property as an [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard datetime format. This overrides the `withTimestamps` option.
+
+Must be a `Boolean` and defaults to `false` for backwards-compatibility with previous timestamps, which were formatted as [Unix time](https://en.wikipedia.org/wiki/Unix_time) seconds.
+
+```js
+const logger = new Logger({
+    useIsoTimeFormat: true
+});
+
+logger.info('This is a log');
+// Outputs:
+// {
+//     "level": "info",
+//     "message": "This is a log",
+//     "time": "2020-01-01T12:00:00.000Z"
 // }
 ```
 

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -12,6 +12,10 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  */
 
 /**
+ * @typedef {typeof import('pino').stdTimeFunctions.isoTime} TimeFn
+ */
+
+/**
  * @typedef {object} LoggerOptions
  * @property {LogData} [baseLogData = {}]
  *     Base log data which is added to every log output.
@@ -24,6 +28,8 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
  *     Whether to prettify log output if it's possible.
  * @property {boolean} [withTimestamps = true]
  *     Whether to send the timestamp that each log method was called.
+ * @property {boolean} [useIsoTimeFormat = false]
+ *     Whether to format the timestamps as ISO8601.
  */
 
 /**
@@ -191,7 +197,12 @@ class Logger {
 				: !Boolean(process.env.LOG_DISABLE_PRETTIFIER);
 
 		// Default and set the timestamps option.
-		const withTimestamps = options.withTimestamps !== false;
+		/** @type {boolean | TimeFn} */
+		let withTimestamps = options.withTimestamps !== false;
+
+		if (options.useIsoTimeFormat) {
+			withTimestamps = pino.stdTimeFunctions.isoTime;
+		}
 
 		if (options._transport) {
 			// If we have a configured transport, use it. This means


### PR DESCRIPTION
Simeon reported in the cp-reliability Slack channel that they would prefer to have more human readable timestamps in logs. Pino supports this with the stdTimeFunctions object which can be set on the withTimestamps option (that we're using already).

This commit exposes the Pino configuration with a new Reliability Kit logger option called useIsoTimeFormat.

We anticipate that in the future we will probably switch this to be the default (which will be a breaking change) and potentially remove the option completely so that timestamps are always logged.

Note that this timestamp option is on the log body. We do already have the log ingestion datetime recorded, even when withTimestamps is false.