### PR TITLE
feat: render the error fingerprint

### DIFF
--- a/packages/middleware-render-error-info/lib/index.js
+++ b/packages/middleware-render-error-info/lib/index.js
@@ -81,7 +81,13 @@ function createErrorRenderingMiddleware(options = {}) {
 		// Either rendering has failed or we're in production. We render a
 		// heavily stripped back error
 		const statusMessage = STATUS_CODES[statusCode] || STATUS_CODES[500];
-		const output = `${statusCode} ${statusMessage}\n`;
+		let output = `${statusCode} ${statusMessage}\n`;
+
+		// If the error has a fingerprint, add it to the output
+		if (serializedError.fingerprint) {
+			output += `(error code: ${serializedError.fingerprint})\n`;
+		}
+
 		response.send(output);
 	};
 }

--- a/packages/middleware-render-error-info/lib/render-error-page.js
+++ b/packages/middleware-render-error-info/lib/render-error-page.js
@@ -125,6 +125,12 @@ function renderError(error) {
 				};
 			}),
 			{
+				label: 'Fingerprint',
+				helpText: "A unique hash generated from this error's stack",
+				value: error.fingerprint,
+				formatter: renderCodeBlock
+			},
+			{
 				label: 'Stack',
 				helpText:
 					'The full stack trace for the error, indicating where it was thrown',

--- a/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
+++ b/packages/middleware-render-error-info/test/unit/lib/__snapshots__/index.spec.js.snap
@@ -181,6 +181,12 @@ target="_blank"
 }</code></pre></dd>
 
 <dt class="kv-list__key">
+<span class="kv-list__label">Fingerprint:</span>
+<br/><small>A unique hash generated from this error's stack</small>
+</dt>
+<dd class="kv-list__value"><pre><code>mock serialized error fingerprint</code></pre></dd>
+
+<dt class="kv-list__key">
 <span class="kv-list__label">Stack:</span>
 <br/><small>The full stack trace for the error, indicating where it was thrown</small>
 </dt>


### PR DESCRIPTION
This renders the error fingerprint on both the local development and production error pages so that apps that aren't behind FT.com will also get a fingerprint output without having to handle it themselves.