### PR TITLE
docs: fix note blocks

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,7 +72,7 @@ It's important that you run `npm install` before committing. This ensures that t
 
 You'll need to manually add the package to the list of packages in the README once it's ready to be used by other teams.
 
-> [!WARNING]<br />
+> [!IMPORTANT]<br />
 > Normally we want the first release of a new package to be a pre-release (e.g. `0.1.0`). To do this, you'll need to [hard-code the release version in a commit](#hard-coding-the-release-version).
 
 > [!NOTE]<br />

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,10 +72,10 @@ It's important that you run `npm install` before committing. This ensures that t
 
 You'll need to manually add the package to the list of packages in the README once it's ready to be used by other teams.
 
-> **Warning**
+> [!WARNING]<br />
 > Normally we want the first release of a new package to be a pre-release (e.g. `0.1.0`). To do this, you'll need to [hard-code the release version in a commit](#hard-coding-the-release-version).
 
-> **Note**
+> [!NOTE]<br />
 > Wherever the package version appears, you should leave it as `0.0.0` to allow Release Please to correctly bump and release the first version.
 
 

--- a/docs/getting-started/handling-errors.md
+++ b/docs/getting-started/handling-errors.md
@@ -87,7 +87,7 @@ app.get('/', async (request, response, next) => {
 
 This way of handling async errors will also be [built-in in Express v5](https://expressjs.com/en/guide/migrating-5.html#rejected-promises).
 
-> **Note**
+> [!NOTE]<br />
 > The rest of the examples in this documentation assume that you're _not_ including `express-async-errors`. If you do use this library then you can simplify a lot when you're implementing in your own app.
 
 ### Registering error handlers

--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -45,7 +45,7 @@ Errors can contain a lot of information about what happened, but passing an erro
 
 Extracting the information we do want can result in a lot of boilerplate code littered around our systems. To aid this, Reliability Kit provides a couple of packages to help with this task.
 
-> **Note**
+> [!NOTE]<br />
 > The code examples in this section are illustrative to help understand what we're doing under the hood. For our recommended implementation of error logging, see the [One way of logging](#one-way-of-logging) section.
 
 [`@dotcom-reliability-kit/serialize-error`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme)  provides a `serializeError` function which accepts an error object and converts it to a plain object with all of the data extracted for logging. If you were logging something manually you could get all error information like this:
@@ -203,7 +203,7 @@ There are times where an unexpected error can occur in your app and your code is
 
 Uncaught exception handling should never attempt to keep the app alive. If an error is thrown in a place where no handling is present then it's correct for the application to crash, _however_ if the app is crashing then we need to be sure that the fatal error is logged somewhere:
 
-> **Note**
+> [!NOTE]<br />
 > This code example is illustrative, you should not use this in your application but it helps us explain how logging fatal errors works. For a production solution, see the later example under this heading.
 
 ```js

--- a/docs/getting-started/logging-errors.md
+++ b/docs/getting-started/logging-errors.md
@@ -45,7 +45,7 @@ Errors can contain a lot of information about what happened, but passing an erro
 
 Extracting the information we do want can result in a lot of boilerplate code littered around our systems. To aid this, Reliability Kit provides a couple of packages to help with this task.
 
-> [!NOTE]<br />
+> [!TIP]<br />
 > The code examples in this section are illustrative to help understand what we're doing under the hood. For our recommended implementation of error logging, see the [One way of logging](#one-way-of-logging) section.
 
 [`@dotcom-reliability-kit/serialize-error`](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/serialize-error#readme)  provides a `serializeError` function which accepts an error object and converts it to a plain object with all of the data extracted for logging. If you were logging something manually you could get all error information like this:
@@ -203,7 +203,7 @@ There are times where an unexpected error can occur in your app and your code is
 
 Uncaught exception handling should never attempt to keep the app alive. If an error is thrown in a place where no handling is present then it's correct for the application to crash, _however_ if the app is crashing then we need to be sure that the fatal error is logged somewhere:
 
-> [!NOTE]<br />
+> [!IMPORTANT]<br />
 > This code example is illustrative, you should not use this in your application but it helps us explain how logging fatal errors works. For a production solution, see the later example under this heading.
 
 ```js

--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -80,7 +80,7 @@ app.get('/pokemon/:name', async (request, response, next) => {
 });
 ```
 
-> [!NOTE]<br />
+> [!TIP]<br />
 > We do provide many more error classes in Reliability Kit, and it's always good to use the most specific one. Most of our examples use `OperationalError` for simplicity (and to not overload you with information), but the section on [error classes](#error-classes) covers some of these other error types.
 
 ### Operational errors in library code

--- a/docs/getting-started/throwing-errors.md
+++ b/docs/getting-started/throwing-errors.md
@@ -80,7 +80,7 @@ app.get('/pokemon/:name', async (request, response, next) => {
 });
 ```
 
-> **Note**
+> [!NOTE]<br />
 > We do provide many more error classes in Reliability Kit, and it's always good to use the most specific one. Most of our examples use `OperationalError` for simplicity (and to not overload you with information), but the section on [error classes](#error-classes) covers some of these other error types.
 
 ### Operational errors in library code

--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -36,7 +36,7 @@ The `registerCrashHandler` function can be used to bind an event handler to the 
 
 This function should only ever be called once in your app, normally alongside all your setup code (e.g. alongside creating an Express app).
 
-> **Note**
+> [!NOTE]<br />
 > It's not a requirement, but generally the earlier the better with registering an uncaught exception handler – the sooner you register it the more likely you are to catch uncaught exceptions.
 
 ```js

--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -36,7 +36,7 @@ The `registerCrashHandler` function can be used to bind an event handler to the 
 
 This function should only ever be called once in your app, normally alongside all your setup code (e.g. alongside creating an Express app).
 
-> [!NOTE]<br />
+> [!TIP]<br />
 > It's not a requirement, but generally the earlier the better with registering an uncaught exception handler – the sooner you register it the more likely you are to catch uncaught exceptions.
 
 ```js

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -3,7 +3,7 @@
 
 Properly handle fetch errors and avoid a lot of boilerplate in your app. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
-> [!WARNING]  
+> [!WARNING]<br />
 > This package is in beta and hasn't been tested extensively in production yet. Feel free to use, and any feedback is greatly appreciated.
 
   * [Usage](#usage)
@@ -112,7 +112,7 @@ error.code // FETCH_DNS_LOOKUP_ERROR
 error.cause // The underlying DNS error that was caught
 ```
 
-> [!NOTE]  
+> [!NOTE]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Abort and timeout errors
@@ -124,7 +124,7 @@ error.code // FETCH_ABORT_ERROR or FETCH_TIMEOUT_ERROR
 error.cause // The underlying abort or timeout error that was caught
 ```
 
-> [!NOTE]  
+> [!NOTE]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Socket errors
@@ -136,7 +136,7 @@ error.code // FETCH_SOCKET_HANGUP_ERROR
 error.cause // The underlying socket error that was caught
 ```
 
-> [!NOTE]  
+> [!NOTE]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Unknown errors

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -112,7 +112,7 @@ error.code // FETCH_DNS_LOOKUP_ERROR
 error.cause // The underlying DNS error that was caught
 ```
 
-> [!NOTE]<br />
+> [!IMPORTANT]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Abort and timeout errors
@@ -124,7 +124,7 @@ error.code // FETCH_ABORT_ERROR or FETCH_TIMEOUT_ERROR
 error.cause // The underlying abort or timeout error that was caught
 ```
 
-> [!NOTE]<br />
+> [!IMPORTANT]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Socket errors
@@ -136,7 +136,7 @@ error.code // FETCH_SOCKET_HANGUP_ERROR
 error.cause // The underlying socket error that was caught
 ```
 
-> [!NOTE]<br />
+> [!IMPORTANT]<br />
 > This type of error will only be thrown if you use the ["wrap the fetch function"](#wrap-the-fetch-function) API.
 
 #### Unknown errors

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -197,7 +197,7 @@ logRecoverableError({
 });
 ```
 
-> **Note**
+> [!NOTE]<br />
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 
 #### `options.logger`

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -258,7 +258,7 @@ It's generally easier and less error-prone to use one of the shortcut methods ra
 
 As well as the valid log levels, there are a couple of deprecated legacy levels. These are only present to maintain backwards-compatibility with [n-logger](https://github.com/Financial-Times/n-logger).
 
-> **Warning**
+> [!WARNING]<br />
 > These methods are deprecated and will log a warning message the first time they're used.
 
   * `logger.data(...logData)`: Aliases `logger.debug()`
@@ -313,7 +313,7 @@ app.get('/mock-url', (request, response) => {
 
 Add additional [base log data](#optionsbaselogdata) to the logger via merging objects together. You must pass an `Object` which will be merged with the existing base log data.
 
-> **Warning**
+> [!WARNING]<br />
 > This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with n-logger and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
 
 ```js
@@ -341,7 +341,7 @@ logger.info('Example');
 
 Add a `context` property to the logger's [base log data](#optionsbaselogdata). You must pass an `Object` which will be added as a `context` property to all logs.
 
-> **Warning**
+> [!WARNING]<br />
 > This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger) and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
 
 ```js
@@ -366,7 +366,7 @@ logger.info('Example');
 
 Remove the `context` property from the logger's [base log data](#optionsbaselogdata).
 
-> **Warning**
+> [!WARNING]<br />
 > This method is deprecated and will log a warning message the first time it's used. This is just for compatibility with [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger) and you should use either `baseLogData` or [`createChildLogger`](#loggercreatechildlogger) instead.
 
 ```js
@@ -491,7 +491,7 @@ Different types of data are serialized differently before being output as JSON:
       // }
       ```
 
-    > **Warning:**
+    > [!WARNING]<br />
     > It's important to note that only properties that are [serializable as JSON](https://www.rfc-editor.org/rfc/rfc7159) can be logged. Any non-serializable properties (e.g. functions) will not be output.
 
   * **Strings** are moved into the `message` property of the output log. E.g.

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -33,7 +33,7 @@ const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors
 
 The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger).
 
-> [!WARNING]<br />
+> [!CAUTION]<br />
 > This middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware.
 
 ```js

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -33,7 +33,7 @@ const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors
 
 The `createErrorLogger` function can be used to generate Express middleware which logs errors to the console and Splunk via [Reliability Kit logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger).
 
-> **Warning**
+> [!WARNING]<br />
 > This middleware **must** be added to your Express app _after_ all your application routes – you won't get error logs for any routes which are mounted after this middleware.
 
 ```js
@@ -94,7 +94,7 @@ type ErrorLoggingFilter = (error: any, request: express.Request) => boolean;
 
 If the function returns `true` then the error and request details will be logged. Otherwise no logs will be output.
 
-> **Warning**
+> [!WARNING]<br />
 > This option can be dangerous, misconfiguring it can result in a loss of log information. Consider whether you _definitely_ need to filter logs before using, sometimes it's better to have a few too many logs than miss an important one.
 
 Example of usage:
@@ -153,7 +153,7 @@ app.use(createErrorLogger({
 }));
 ```
 
-> **Note**
+> [!NOTE]<br />
 > There's no need to include the `x-request-id` header in this array, as this is automatically included as `request.id` in the logs.
 
 #### `options.logger`

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -31,7 +31,7 @@ The `renderErrorInfoPage` function can be used to generate Express middleware wh
 
 When the `NODE_ENV` environment variable is either **empty** or set to **`"development"`** then a full debug page will be rendered. Otherwise only the error status code and message will be output, e.g. `500 Server Error`. This ensures that we don't leak important error information in production.
 
-> **Warning**
+> [!WARNING]<br />
 > This middleware **must** be added to your Express app _after_ all your application routes – you won't get rendered errors for any routes which are mounted after this middleware.
 
 ```js
@@ -40,7 +40,7 @@ const app = express();
 app.use(renderErrorInfoPage());
 ```
 
-> **Warning**
+> [!WARNING]<br />
 > If you're using [@dotcom-reliability-kit/middleware-log-errors](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#readme) in your app, it's best to mount the error page middleware _after_ the logging middleware. Otherwise the error will never be logged.
 
 Once you've mounted the middleware, if you're working locally you should now see a detailed error page when you encounter an error in your app (assuming you're [relying on the Express error handler to serve errors](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/handling-errors.md#bubbling-up-in-express)):

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -31,7 +31,7 @@ The `renderErrorInfoPage` function can be used to generate Express middleware wh
 
 When the `NODE_ENV` environment variable is either **empty** or set to **`"development"`** then a full debug page will be rendered. Otherwise only the error status code and message will be output, e.g. `500 Server Error`. This ensures that we don't leak important error information in production.
 
-> [!WARNING]<br />
+> [!CAUTION]<br />
 > This middleware **must** be added to your Express app _after_ all your application routes – you won't get rendered errors for any routes which are mounted after this middleware.
 
 ```js
@@ -40,7 +40,7 @@ const app = express();
 app.use(renderErrorInfoPage());
 ```
 
-> [!WARNING]<br />
+> [!CAUTION]<br />
 > If you're using [@dotcom-reliability-kit/middleware-log-errors](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#readme) in your app, it's best to mount the error page middleware _after_ the logging middleware. Otherwise the error will never be logged.
 
 Once you've mounted the middleware, if you're working locally you should now see a detailed error page when you encounter an error in your app (assuming you're [relying on the Express error handler to serve errors](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/docs/getting-started/handling-errors.md#bubbling-up-in-express)):

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -72,7 +72,7 @@ The `SerializedError` type documents the return value of the [`serializeError` f
 
 This is a hash of the first part of the error stack, used to help group errors that occurred in the same part of the codebase. The fingerprint is `null` if the error does not include a stack trace.
 
-> **Warning**
+> [!WARNING]<br />
 > Do not rely on the format or length of the error fingerprint as the underlying hash may change without warning. You _can_ rely on the fingerprint being unique to the type of error being thrown.
 
 #### `SerializedError.name`


### PR DESCRIPTION
This fixes and revises the [Markdown note/warning blocks](https://github.com/orgs/community/discussions/16925), which GitHub changed the display of a while ago.