### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,13 +1,13 @@
 {
   "packages/app-info": "2.3.0",
-  "packages/crash-handler": "3.0.8",
+  "packages/crash-handler": "3.0.9",
   "packages/errors": "2.2.0",
   "packages/eslint-config": "2.0.1",
-  "packages/fetch-error-handler": "0.1.1",
-  "packages/log-error": "3.1.6",
-  "packages/logger": "2.4.1",
-  "packages/middleware-log-errors": "3.0.8",
-  "packages/middleware-render-error-info": "4.1.0",
-  "packages/serialize-error": "2.2.0",
+  "packages/fetch-error-handler": "0.1.2",
+  "packages/log-error": "3.1.7",
+  "packages/logger": "2.4.2",
+  "packages/middleware-log-errors": "3.0.9",
+  "packages/middleware-render-error-info": "4.1.1",
+  "packages/serialize-error": "2.2.1",
   "packages/serialize-request": "2.2.1"
 }

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,21 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.8...crash-handler-v3.0.9) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v2.1.2...crash-handler-v3.0.0) (2023-08-07)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^3.1.6"
+    "@dotcom-reliability-kit/log-error": "^3.1.7"
   }
 }

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.1...fetch-error-handler-v0.1.2) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))
+
 ## [0.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.0...fetch-error-handler-v0.1.1) (2023-09-19)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,21 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [3.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.6...log-error-v3.1.7) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^2.4.1 to ^2.4.2
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.0.1...log-error-v3.1.0) (2023-09-19)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/logger": "^2.4.1",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+    "@dotcom-reliability-kit/logger": "^2.4.2",
+    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
     "@dotcom-reliability-kit/serialize-request": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,25 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [2.4.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.1...logger-v2.4.2) (2023-12-21)
+
+
+### Bug Fixes
+
+* bump pino from 8.16.2 to 8.17.1 ([433e70d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/433e70d49bd4206b725b5d171ad325c86c8808cc))
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
+
 ## [2.4.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.3.1...logger-v2.4.0) (2023-11-23)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^8.17.1"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,21 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.8...middleware-log-errors-v3.0.9) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v2.1.1...middleware-log-errors-v3.0.0) (2023-08-07)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^3.1.6"
+    "@dotcom-reliability-kit/log-error": "^3.1.7"
   },
   "devDependencies": {
     "@financial-times/n-express": "^28.3.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,22 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.1.0...middleware-render-error-info-v4.1.1) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
+
 ## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.0.2...middleware-render-error-info-v4.1.0) (2023-12-05)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/log-error": "^3.1.6",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+    "@dotcom-reliability-kit/log-error": "^3.1.7",
+    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
     "entities": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.2.0...serialize-error-v2.2.1) (2023-12-21)
+
+
+### Documentation Changes
+
+* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
+
 ## [2.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.1.0...serialize-error-v2.2.0) (2023-11-15)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 3.0.9</summary>

## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.8...crash-handler-v3.0.9) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
</details>

<details><summary>fetch-error-handler: 0.1.2</summary>

## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.1...fetch-error-handler-v0.1.2) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))
</details>

<details><summary>log-error: 3.1.7</summary>

## [3.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.6...log-error-v3.1.7) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^2.4.1 to ^2.4.2
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
</details>

<details><summary>logger: 2.4.2</summary>

## [2.4.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.1...logger-v2.4.2) (2023-12-21)


### Bug Fixes

* bump pino from 8.16.2 to 8.17.1 ([433e70d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/433e70d49bd4206b725b5d171ad325c86c8808cc))


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
</details>

<details><summary>middleware-log-errors: 3.0.9</summary>

## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.8...middleware-log-errors-v3.0.9) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
</details>

<details><summary>middleware-render-error-info: 4.1.1</summary>

## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.1.0...middleware-render-error-info-v4.1.1) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
* revise the note/warning levels ([917abc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/917abc60a0891f3a9110bafca96fe924a5b76a80))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
</details>

<details><summary>serialize-error: 2.2.1</summary>

## [2.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.2.0...serialize-error-v2.2.1) (2023-12-21)


### Documentation Changes

* fix the markdown note/warning blocks ([c7f69f2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c7f69f20a8b000f4a40c4cd25be23fcee2ecd85d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).