### PR TITLE
chore!: drop support for Node.js 16 and npm 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,21 +157,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - release-please:
           filters:
             <<: *filters_only_main
@@ -189,7 +189,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - test:
           filters:
             <<: *filters_release_build
@@ -198,7 +198,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -207,7 +207,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
@@ -226,7 +226,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -235,7 +235,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -244,7 +244,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - prepublish:
           context: npm-publish-token
           filters:
@@ -267,7 +267,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -275,4 +275,4 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "20.0", "18.16", "16.20" ]
+              node-version: [ "20.0", "18.16" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10313,20 +10313,20 @@
       "version": "2.3.0",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^3.1.6"
+        "@dotcom-reliability-kit/log-error": "^3.1.7"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/errors": {
@@ -10334,8 +10334,8 @@
       "version": "2.2.0",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/eslint-config": {
@@ -10346,8 +10346,8 @@
         "@types/eslint": "^8.56.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       },
       "peerDependencies": {
         "eslint": ">=8.27.0"
@@ -10355,7 +10355,7 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^2.2.0"
@@ -10368,35 +10368,35 @@
         "undici": "^5.28.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/logger": "^2.4.1",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/logger": "^2.4.2",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "@dotcom-reliability-kit/serialize-request": "^2.2.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^8.17.1"
       },
@@ -10408,8 +10408,8 @@
         "@types/ungap__structured-clone": "^0.3.3"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       },
       "peerDependencies": {
         "pino-pretty": ">=7.0.0 <11.0.0"
@@ -10417,10 +10417,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^3.1.6"
+        "@dotcom-reliability-kit/log-error": "^3.1.7"
       },
       "devDependencies": {
         "@financial-times/n-express": "^28.3.0",
@@ -10428,35 +10428,35 @@
         "node-fetch": "^2.7.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/log-error": "^3.1.6",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/log-error": "^3.1.7",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "entities": "^4.5.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "packages/serialize-request": {
@@ -10467,8 +10467,8 @@
         "@types/express": "^4.17.21"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "resources/logos": {
@@ -10484,8 +10484,8 @@
         "@types/svgo": "^3.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x"
       }
     },
     "resources/splunk-dashboards": {
@@ -11297,7 +11297,7 @@
     "@dotcom-reliability-kit/crash-handler": {
       "version": "file:packages/crash-handler",
       "requires": {
-        "@dotcom-reliability-kit/log-error": "^3.1.6"
+        "@dotcom-reliability-kit/log-error": "^3.1.7"
       }
     },
     "@dotcom-reliability-kit/errors": {
@@ -11324,8 +11324,8 @@
       "version": "file:packages/log-error",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/logger": "^2.4.1",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/logger": "^2.4.2",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "@dotcom-reliability-kit/serialize-request": "^2.2.1",
         "@types/express": "^4.17.21"
       }
@@ -11334,7 +11334,7 @@
       "version": "file:packages/logger",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "@financial-times/n-logger": "^10.3.0",
         "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.3",
@@ -11356,7 +11356,7 @@
     "@dotcom-reliability-kit/middleware-log-errors": {
       "version": "file:packages/middleware-log-errors",
       "requires": {
-        "@dotcom-reliability-kit/log-error": "^3.1.6",
+        "@dotcom-reliability-kit/log-error": "^3.1.7",
         "@financial-times/n-express": "^28.3.0",
         "@types/express": "^4.17.21",
         "node-fetch": "^2.7.0"
@@ -11366,8 +11366,8 @@
       "version": "file:packages/middleware-render-error-info",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/log-error": "^3.1.6",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.0",
+        "@dotcom-reliability-kit/log-error": "^3.1.7",
+        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
         "@types/express": "^4.17.21",
         "entities": "^4.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "volta": {
     "node": "20.0.0",

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: app-info\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib"
 }

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: crash-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: errors\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: eslint-config\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "peerDependencies": {

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: fetch-error-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: log-error\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: logger\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-log-errors\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "dependencies": {

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-error\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib"
 }

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -11,8 +11,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-request\"",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "main": "lib",
   "devDependencies": {

--- a/resources/logos/package.json
+++ b/resources/logos/package.json
@@ -12,8 +12,8 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x"
   },
   "scripts": {
     "build": "./scripts/build.js"


### PR DESCRIPTION
This can't be merged until January 2024 when we're dropping Node.js 16 support from packages. Just getting it ready to save us a job in the new year.

This resolves #806.