### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,13 +1,13 @@
 {
-  "packages/app-info": "2.3.0",
-  "packages/crash-handler": "3.0.9",
-  "packages/errors": "2.2.0",
-  "packages/eslint-config": "2.0.1",
-  "packages/fetch-error-handler": "0.1.2",
-  "packages/log-error": "3.1.7",
-  "packages/logger": "2.4.2",
-  "packages/middleware-log-errors": "3.0.9",
-  "packages/middleware-render-error-info": "4.1.1",
-  "packages/serialize-error": "2.2.1",
-  "packages/serialize-request": "2.2.1"
+  "packages/app-info": "3.0.0",
+  "packages/crash-handler": "4.0.0",
+  "packages/errors": "3.0.0",
+  "packages/eslint-config": "3.0.0",
+  "packages/fetch-error-handler": "0.2.0",
+  "packages/log-error": "4.0.0",
+  "packages/logger": "3.0.0",
+  "packages/middleware-log-errors": "4.0.0",
+  "packages/middleware-render-error-info": "5.0.0",
+  "packages/serialize-error": "3.0.0",
+  "packages/serialize-request": "3.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10223,7 +10223,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "2.3.0",
+      "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x",
@@ -10232,10 +10232,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "3.0.9",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^3.1.7"
+        "@dotcom-reliability-kit/log-error": "^4.0.0"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -10244,7 +10244,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x",
@@ -10253,7 +10253,7 @@
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^8.56.1"
@@ -10268,10 +10268,10 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^2.2.0"
+        "@dotcom-reliability-kit/errors": "^3.0.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -10287,13 +10287,13 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "3.1.7",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/logger": "^2.4.2",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
-        "@dotcom-reliability-kit/serialize-request": "^2.2.1"
+        "@dotcom-reliability-kit/app-info": "^3.0.0",
+        "@dotcom-reliability-kit/logger": "^3.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^3.0.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21"
@@ -10305,11 +10305,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "2.4.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+        "@dotcom-reliability-kit/app-info": "^3.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^8.17.2"
       },
@@ -10329,10 +10329,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "3.0.9",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^3.1.7"
+        "@dotcom-reliability-kit/log-error": "^4.0.0"
       },
       "devDependencies": {
         "@financial-times/n-express": "^28.3.0",
@@ -10346,12 +10346,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "4.1.1",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^2.3.0",
-        "@dotcom-reliability-kit/log-error": "^3.1.7",
-        "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+        "@dotcom-reliability-kit/app-info": "^3.0.0",
+        "@dotcom-reliability-kit/log-error": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.0",
         "entities": "^4.5.0"
       },
       "devDependencies": {
@@ -10364,7 +10364,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "2.2.1",
+      "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x",
@@ -10373,7 +10373,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "2.2.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.21"

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v2.3.0...app-info-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
 ## [2.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v2.2.0...app-info-v2.3.0) (2023-12-05)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,29 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.9...crash-handler-v4.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
+
 ## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.8...crash-handler-v3.0.9) (2023-12-21)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^3.1.7"
+    "@dotcom-reliability-kit/log-error": "^4.0.0"
   }
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v2.2.0...errors-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
 ## [2.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v2.1.1...errors-v2.2.0) (2023-07-20)
 
 

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/errors",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A suite of error classes which help you throw the most appropriate error in any situation",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v2.0.1...eslint-config-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
 ## [2.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v2.0.0...eslint-config-v2.0.1) (2023-06-23)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/eslint-config",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production",
   "repository": {
     "type": "git",

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.2...fetch-error-handler-v0.2.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^2.2.0 to ^3.0.0
+
 ## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.1...fetch-error-handler-v0.1.2) (2023-12-21)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "^2.2.0"
+    "@dotcom-reliability-kit/errors": "^3.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,33 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.7...log-error-v4.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
+    * @dotcom-reliability-kit/logger bumped from ^2.4.2 to ^3.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
+    * @dotcom-reliability-kit/serialize-request bumped from ^2.2.1 to ^3.0.0
+
 ## [3.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.6...log-error-v3.1.7) (2023-12-21)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "3.1.7",
+  "version": "4.0.0",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,10 +16,10 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/logger": "^2.4.2",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
-    "@dotcom-reliability-kit/serialize-request": "^2.2.1"
+    "@dotcom-reliability-kit/app-info": "^3.0.0",
+    "@dotcom-reliability-kit/logger": "^3.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.0",
+    "@dotcom-reliability-kit/serialize-request": "^3.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21"

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,39 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.2...logger-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* always log ISO datetime
+* drop support for Node.js 16 and npm 7
+
+### Bug Fixes
+
+* bump pino from 8.17.1 to 8.17.2 ([fa74a45](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fa74a450a0aa60d019ea32d8caba874a786c9c03))
+
+
+### Documentation Changes
+
+* add a missing table-of-contents link ([20fe3e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/20fe3e99db01132fdb40c57ad95785adb1e7a4a3))
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))
+
+
+### Miscellaneous
+
+* always log ISO datetime ([e12ab9a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e12ab9a22d078e58e17b934eca3edb20d302d7ae))
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
+
 ## [2.4.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.1...logger-v2.4.2) (2023-12-21)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+    "@dotcom-reliability-kit/app-info": "^3.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^8.17.2"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,30 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.9...middleware-log-errors-v4.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
+
 ## [3.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.8...middleware-log-errors-v3.0.9) (2023-12-21)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^3.1.7"
+    "@dotcom-reliability-kit/log-error": "^4.0.0"
   },
   "devDependencies": {
     "@financial-times/n-express": "^28.3.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,31 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.1.1...middleware-render-error-info-v5.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
+
 ## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.1.0...middleware-render-error-info-v4.1.1) (2023-12-21)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,9 +16,9 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^2.3.0",
-    "@dotcom-reliability-kit/log-error": "^3.1.7",
-    "@dotcom-reliability-kit/serialize-error": "^2.2.1",
+    "@dotcom-reliability-kit/app-info": "^3.0.0",
+    "@dotcom-reliability-kit/log-error": "^4.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.0",
     "entities": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.2.1...serialize-error-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
 ## [2.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.2.0...serialize-error-v2.2.1) (2023-12-21)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",

--- a/packages/serialize-request/CHANGELOG.md
+++ b/packages/serialize-request/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v2.2.1...serialize-request-v3.0.0) (2024-01-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 16 and npm 7
+
+### Documentation Changes
+
+* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
+
+
+### Miscellaneous
+
+* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
+
 ## [2.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v2.2.0...serialize-request-v2.2.1) (2023-10-10)
 
 

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-request",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v2.3.0...app-info-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
</details>

<details><summary>crash-handler: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.9...crash-handler-v4.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
</details>

<details><summary>errors: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v2.2.0...errors-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
</details>

<details><summary>eslint-config: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v2.0.1...eslint-config-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
</details>

<details><summary>fetch-error-handler: 0.2.0</summary>

## [0.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.1.2...fetch-error-handler-v0.2.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^2.2.0 to ^3.0.0
</details>

<details><summary>log-error: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.7...log-error-v4.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
    * @dotcom-reliability-kit/logger bumped from ^2.4.2 to ^3.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
    * @dotcom-reliability-kit/serialize-request bumped from ^2.2.1 to ^3.0.0
</details>

<details><summary>logger: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.2...logger-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* always log ISO datetime
* drop support for Node.js 16 and npm 7

### Bug Fixes

* bump pino from 8.17.1 to 8.17.2 ([fa74a45](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fa74a450a0aa60d019ea32d8caba874a786c9c03))


### Documentation Changes

* add a missing table-of-contents link ([20fe3e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/20fe3e99db01132fdb40c57ad95785adb1e7a4a3))
* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))


### Miscellaneous

* always log ISO datetime ([e12ab9a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e12ab9a22d078e58e17b934eca3edb20d302d7ae))
* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
</details>

<details><summary>middleware-log-errors: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.9...middleware-log-errors-v4.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))
* replace node 16 references with node 18 ([8196a95](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8196a954beebe89a720d3440041fd673e895c61b))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
</details>

<details><summary>middleware-render-error-info: 5.0.0</summary>

## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.1.1...middleware-render-error-info-v5.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^2.3.0 to ^3.0.0
    * @dotcom-reliability-kit/log-error bumped from ^3.1.7 to ^4.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^2.2.1 to ^3.0.0
</details>

<details><summary>serialize-error: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v2.2.1...serialize-error-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
</details>

<details><summary>serialize-request: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v2.2.1...serialize-request-v3.0.0) (2024-01-08)


### ⚠ BREAKING CHANGES

* drop support for Node.js 16 and npm 7

### Documentation Changes

* add migration guides for all packages ([f6233b8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6233b8ac802a32cad321e43b63420fe6fd979c0))


### Miscellaneous

* drop support for Node.js 16 and npm 7 ([016096e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/016096eab022fa426159ec649a4e32c24eedd568))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).