### PR TITLE
docs: add migration guides for all packages

### DIFF
--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -14,6 +14,7 @@ A utility to get application information (e.g. the system code) in a consistent 
     * [`appInfo.cloudProvider`](#appinfocloudprovider)
     * [`appInfo.herokuAppId`](#appinfoherokuappId)
     * [`appInfo.herokuDynoId`](#appinfoherokudynoId)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -97,6 +98,12 @@ This is derived from the dyno metadata
 Get the `process.env.HEROKU_DYNO_ID` which is the dyno identifier
 
 This is derived from the dyno metadata
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
+
 
 ## Contributing
 

--- a/packages/app-info/docs/migration.md
+++ b/packages/app-info/docs/migration.md
@@ -1,0 +1,28 @@
+
+# Migration guide for @dotcom-reliability-kit/app-info
+
+This document outlines how to migrate to the latest version of the Reliability Kit app-info package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/crash-handler/README.md
+++ b/packages/crash-handler/README.md
@@ -10,6 +10,7 @@ A method to bind an uncaught exception handler to ensure that fatal application 
     * [`options.process`](#optionsprocess)
 * [Compatibility](#compatibility)
   * [Migrating from Sentry](#migrating-from-sentry)
+* [Migrating](#migrating)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -81,6 +82,11 @@ registerCrashHandler({
 ### Migrating from Sentry
 
 The Reliability Kit crash handler is a replacement for Sentry's uncaught exception handling, which your app is likely to be using. You'll need to migrate away from Sentry in order to use this module. [We maintain a migration guide for this on Confluence](https://financialtimes.atlassian.net/l/cp/eeTWSAxe).
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/crash-handler/docs/migration.md
+++ b/packages/crash-handler/docs/migration.md
@@ -1,0 +1,57 @@
+
+# Migration guide for @dotcom-reliability-kit/crash-handler
+
+This document outlines how to migrate to the latest version of the Reliability Kit crash-handler package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Switch to Reliability Kit logger](#switch-to-reliability-kit-logger)
+  * [Remove Sentry workarounds](#remove-sentry-workarounds)
+* [Migrating from v3 to v4](#migrating-from-v3-to-v4)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Switch to Reliability Kit logger
+
+**:orange_circle: Possibly Breaking:** this version switches to use [Reliability Kit's logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger#readme) by default. This means that logs will not be sent directly to Splunk but will be sent to `stdout`. This may mean you lose some logs if you haven't configured your app to forward these logs somewhere more permanent.
+
+You may not need to change anything for this upgrade, for example, if your app uses Heroku log drains _or_ a Lambda log forwarder. [The logger migration guide has more information](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/packages/logger/docs/migration.md#n-logger-where-logs-get-sent).
+
+If you can't switch to Reliability Kit logger yet, then you can still use [n-logger](https://github.com/Financial-Times/n-logger) (the previous default logger) by manually passing it as an option when initialising Crash Handler:
+
+```js
+const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
+const nLogger = require('@financial-times/n-logger').default;
+
+registerCrashHandler({
+    logger: nLogger
+});
+```
+
+### Remove Sentry workarounds
+
+**:orange_circle: Possibly Breaking:** this only impacts apps that use [n-express](https://github.com/Financial-Times/n-express) v27 or older. Previously, this module contained code to disable the default [Sentry](https://sentry.io/) error handling which was enabled by n-express.
+
+You can safely migrate to this version of Crash Handler if your app is either _not_ using n-express or is using n-express v28 or above.
+
+
+## Migrating from v3 to v4
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -14,6 +14,7 @@ A suite of error classes which help you throw the most appropriate error in any 
     * [`UpstreamServiceError`](#upstreamserviceerror)
     * [`UserInputError`](#userinputerror)
     * [`BaseError`](#baseerror)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -219,6 +220,12 @@ throw new BaseError({
     cause: new TypeError('example cause')
 });
 ```
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
+
 
 ## Contributing
 

--- a/packages/errors/docs/migration.md
+++ b/packages/errors/docs/migration.md
@@ -1,0 +1,28 @@
+
+# Migration guide for @dotcom-reliability-kit/errors
+
+This document outlines how to migrate to the latest version of the Reliability Kit errors package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -4,6 +4,7 @@ A linting config, specifically focussed on enhancing code quality and proactivel
 
 - [Usage](#usage)
   - [Static Code Analysis](#static-code-analysis)
+- [Migrating](#migrating)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -34,6 +35,12 @@ Add the following command to the `scripts` object in your repository's package.j
 ```
 
 Run that command in your terminal to lint your files (either cd into the relevant directory or run from root). Any linting errors found by the config will be displayed in your terminal, with helpful suggestions on how to resolve them.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
+
 
 ## Contributing
 

--- a/packages/eslint-config/docs/migration.md
+++ b/packages/eslint-config/docs/migration.md
@@ -1,0 +1,36 @@
+
+# Migration guide for @dotcom-reliability-kit/eslint-config
+
+This document outlines how to migrate to the latest version of the Reliability Kit eslint-config package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Additional default ESLint rules added (v2)](#additional-default-eslint-rules-added-v2)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Additional default ESLint rules added (v2)
+
+**:orange_circle: Possibly Breaking:** this version adds a few new ESLint rules to the default configuration, the following rules now error:
+
+* [eqeqeq](https://eslint.org/docs/latest/rules/eqeqeq)
+* [no-extend-native](https://eslint.org/docs/latest/rules/no-extend-native)
+* [no-irregular-whitespace](https://eslint.org/docs/latest/rules/no-irregular-whitespace)
+* [no-undef](https://eslint.org/docs/latest/rules/no-undef)
+* [no-unused-vars](https://eslint.org/docs/latest/rules/no-unused-vars)
+
+You may need to make changes to your code if these linting errors are found.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -12,6 +12,7 @@ A method to consistently log error object with optional request information. Thi
     * [`options.includeHeaders`](#optionsincludeheaders)
     * [`options.logger`](#optionslogger)
     * [`options.request`](#optionsrequest)
+* [Migrating](#migrating)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -257,6 +258,11 @@ When this option is defined, the logged data looks includes request data:
     }
 }
 ```
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/log-error/docs/migration.md
+++ b/packages/log-error/docs/migration.md
@@ -1,0 +1,56 @@
+
+# Migration guide for @dotcom-reliability-kit/log-error
+
+This document outlines how to migrate to the latest version of the Reliability Kit log-error package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Switch to Reliability Kit logger](#switch-to-reliability-kit-logger)
+  * [Unhandled errors now have a level of fatal](#unhandled-errors-now-have-a-level-of-fatal)
+* [Migrating from v3 to v4](#migrating-from-v3-to-v4)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Switch to Reliability Kit logger
+
+**:orange_circle: Possibly Breaking:** this version switches to use [Reliability Kit's logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger#readme) by default. This means that logs will not be sent directly to Splunk but will be sent to `stdout`. This may mean you lose some logs if you haven't configured your app to forward these logs somewhere more permanent.
+
+You may not need to change anything for this upgrade, for example, if your app uses Heroku log drains _or_ a Lambda log forwarder. [The logger migration guide has more information](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/packages/logger/docs/migration.md#n-logger-where-logs-get-sent).
+
+If you can't switch to Reliability Kit logger yet, then you can still use [n-logger](https://github.com/Financial-Times/n-logger) (the previous default logger) by manually passing it as an option when logging errors:
+
+```js
+const { logHandledError } = require('@dotcom-reliability-kit/log-error');
+const nLogger = require('@financial-times/n-logger').default;
+
+logHandledError({
+    error: new Error('Something went wrong'),
+    logger: nLogger
+});
+```
+
+### Unhandled errors now have a level of fatal
+
+**:orange_circle: Possibly Breaking:** errors logged with `logUnhandledError` will now have a `level` property of `fatal` rather than `error`. This shouldn't require code changes but you may need to update your saved Splunk searches or dashboards.
+
+
+## Migrating from v3 to v4
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -30,9 +30,7 @@ A simple and fast logger based on [Pino](https://getpino.io/), with FT preferenc
     * [Production usage](#production-usage)
     * [Testing](#testing)
     * [Compatibility](#compatibility)
-      * [Migrating from n-logger](./docs/migration.md#migrating-from-n-logger)
-      * [Migrating from n-mask-logger](./docs/migration.md#migrating-from-n-mask-logger)
-      * [Migrating from n-serverless-logger](./docs/migration.md#migrating-from-n-serverless-logger)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -571,6 +569,11 @@ jest.mock('@dotcom-reliability-kit/logger', () => ({
 ### Compatibility
 
 `@dotcom-reliability-kit/logger` is compatible with most use cases of [n-logger](https://github.com/Financial-Times/n-logger), [n-mask-logger](https://github.com/Financial-Times/n-mask-logger), and [n-serverless-logger](https://github.com/Financial-Times/n-serverless-logger). We tried hard to make migration as easy as possible from these libraries. The full list of differences are available in the [Migration Guide](./docs/migration.md) as well as tips on migrating.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/logger/docs/migration.md
+++ b/packages/logger/docs/migration.md
@@ -5,11 +5,9 @@ This document outlines how to migrate to the latest version of the Reliability K
 
 Emoji           | Label             | Meaning
 ----------------|:------------------|:-------
-:red_circle:    | Breaking          | A breaking change which will definitely require code changes to resolve
-:orange_circle: | Possibly Breaking | A breaking change to the output of the library which may require extra steps
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
 :yellow_circle: | Deprecation       | A deprecated feature which will require code changes in the future
-
-## Table of contents
 
   * [Migrating from n-logger](#migrating-from-n-logger)
     * [Where logs get sent](#n-logger-where-logs-get-sent)
@@ -31,6 +29,11 @@ Emoji           | Label             | Meaning
     * [Logger property changes](#n-serverless-logger-property-changes)
     * [Logger method changes](#n-serverless-logger-method-changes)
     * [Environment variable changes](#n-serverless-logger-environment-variable-changes)
+  * [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+    * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+  * [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+    * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
 
 ## Migrating from n-logger
 
@@ -265,3 +268,27 @@ logger.info('Hello');
 The following environment variables have been deprecated.
 
   * **`SPLUNK_LOG_LEVEL`:** This environment variable will be used if a `LOG_LEVEL` environment variable is not present, however it may be removed in a later version of the Reliability Kit logger. It's best to migrate to `LOG_LEVEL` early.
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.
+
+### Log times are now ISO 8601 timestamps
+
+**:orange_circle: Possibly Breaking:** The `time` property of all logs is now an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) representation of the time that the log was sent rather than a timestamp. There are two ways this could be a breaking change in your app:
+
+  1. If you have saved searches or dashboards that rely on the `time` property being a number.
+
+  2. If you're using the `withTimestamps` or `useIsoTimeFormat` options with TypeScript, because these options have now been removed from the code and the type definitions.
+
+If neither of the above is true, this should be a safe update with no code changes.

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -9,6 +9,7 @@ Express middleware to consistently log errors. This module is part of [FT.com Re
     * [`options.filter`](#optionsfilter)
     * [`options.includeHeaders`](#optionsincludeheaders)
     * [`options.logger`](#optionslogger)
+* [Migrating](#migrating)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -165,6 +166,11 @@ type LogMethod = (...logData: any) => any;
 ```
 
 This is passed directly onto the relevant log-error method, [see the documentation for that package for more details](../log-error/README.md#optionslogger).
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/middleware-log-errors/docs/migration.md
+++ b/packages/middleware-log-errors/docs/migration.md
@@ -1,0 +1,59 @@
+
+# Migration guide for @dotcom-reliability-kit/middleware-log-errors
+
+This document outlines how to migrate to the latest version of the Reliability Kit middleware-log-errors package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Switch to Reliability Kit logger](#switch-to-reliability-kit-logger)
+  * [Remove Sentry workarounds](#remove-sentry-workarounds)
+* [Migrating from v3 to v4](#migrating-from-v3-to-v4)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Switch to Reliability Kit logger
+
+**:orange_circle: Possibly Breaking:** this version switches to use [Reliability Kit's logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger#readme) by default. This means that logs will not be sent directly to Splunk but will be sent to `stdout`. This may mean you lose some logs if you haven't configured your app to forward these logs somewhere more permanent.
+
+You may not need to change anything for this upgrade, for example, if your app uses Heroku log drains _or_ a Lambda log forwarder. [The logger migration guide has more information](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/packages/logger/docs/migration.md#n-logger-where-logs-get-sent).
+
+If you can't switch to Reliability Kit logger yet, then you can still use [n-logger](https://github.com/Financial-Times/n-logger) (the previous default logger) by manually passing it as an option when initialising the middleware:
+
+```js
+const createErrorLogger = require('@dotcom-reliability-kit/middleware-log-errors');
+const nLogger = require('@financial-times/n-logger').default;
+
+// ...
+
+app.use(createErrorLogger({
+    logger: nLogger
+}));
+```
+
+### Remove Sentry workarounds
+
+**:orange_circle: Possibly Breaking:** this only impacts apps that use [n-express](https://github.com/Financial-Times/n-express) v27 or older. Previously, this module contained code to disable the default [Sentry](https://sentry.io/) error handling which was enabled by n-express.
+
+You can safely migrate to this version of the error logging middleware if your app is either _not_ using n-express or is using n-express v28 or above.
+
+
+## Migrating from v3 to v4
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/middleware-render-error-info/README.md
+++ b/packages/middleware-render-error-info/README.md
@@ -5,6 +5,7 @@ Express middleware to render error information in a browser in a way that makes 
 
   * [Usage](#usage)
     * [`renderErrorInfoPage`](#rendererrorinfopage)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -50,6 +51,11 @@ Once you've mounted the middleware, if you're working locally you should now see
 #### Debug headers
 
 As well as rendering an error page, the middleware also sends an `error-fingerprint` HTTP header in the response. This contains the [error fingerprint](../serialize-error/README.md#serializederrorfingerprint) and is available in development and production. Inspecting this header on a generic error page can help identify the root cause of an issue.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/middleware-render-error-info/docs/migration.md
+++ b/packages/middleware-render-error-info/docs/migration.md
@@ -1,0 +1,55 @@
+
+# Migration guide for @dotcom-reliability-kit/middleware-render-error-info
+
+This document outlines how to migrate to the latest version of the Reliability Kit middleware-render-error-info package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Switch to Reliability Kit logger](#switch-to-reliability-kit-logger)
+  * [Remove Sentry workarounds](#remove-sentry-workarounds)
+* [Migrating from v3 to v4](#migrating-from-v3-to-v4)
+  * [Errors are now rendered in production](#errors-are-now-rendered-in-production)
+* [Migrating from v4 to v5](#migrating-from-v4-to-v5)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Switch to Reliability Kit logger
+
+**:orange_circle: Possibly Breaking:** this version switches to use [Reliability Kit's logger](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/logger#readme) by default. This means that logs will not be sent directly to Splunk but will be sent to `stdout`. This may mean you lose some logs if you haven't configured your app to forward these logs somewhere more permanent.
+
+You may not need to change anything for this upgrade, for example, if your app uses Heroku log drains _or_ a Lambda log forwarder. [The logger migration guide has more information](https://github.com/Financial-Times/dotcom-reliability-kit/blob/main/packages/logger/docs/migration.md#n-logger-where-logs-get-sent).
+
+### Remove Sentry workarounds
+
+**:orange_circle: Possibly Breaking:** this only impacts apps that use [n-express](https://github.com/Financial-Times/n-express) v27 or older. Previously, this module contained code to disable the default [Sentry](https://sentry.io/) error handling which was enabled by n-express.
+
+You can safely migrate to this version of the error logging middleware if your app is either _not_ using n-express or is using n-express v28 or above.
+
+
+## Migrating from v3 to v4
+
+### Errors are now rendered in production
+
+**:orange_circle: Possibly Breaking:** the error rendering middleware now also takes responsibility for outputting an error page in production environments. If you have any custom production error handling (e.g. outputting errors in an API as JSON) then this will be a breaking change. If you don't have any custom error handling and are just relying on express or n-express, then it's safe to upgrade.
+
+
+## Migrating from v4 to v5
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/serialize-error/README.md
+++ b/packages/serialize-error/README.md
@@ -16,6 +16,7 @@ A utility function to serialize an error object in a way that's friendly to logg
       * [`SerializedError.stack`](#serializederrorstack)
       * [`SerializedError.statusCode`](#serializederrorstatuscode)
       * [`SerializedError.data`](#serializederrordata)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -110,6 +111,11 @@ This is extracted from the `error.statusCode` property first, then the `error.st
 #### `SerializedError.data`
 
 This is extracted from the `error.data` property. If this property is not a plain object, then it will default to an empty object: `{}`.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/serialize-error/docs/migration.md
+++ b/packages/serialize-error/docs/migration.md
@@ -1,0 +1,28 @@
+
+# Migration guide for @dotcom-reliability-kit/serialize-error
+
+This document outlines how to migrate to the latest version of the Reliability Kit serialize-error package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.

--- a/packages/serialize-request/README.md
+++ b/packages/serialize-request/README.md
@@ -13,6 +13,7 @@ A utility function to serialize a request object ([Express](https://expressjs.co
       * [`SerializedRequest.url`](#serializedrequesturl)
       * [`SerializedRequest.headers`](#serializedrequestheaders)
       * [`SerializedRequest.route`](#serializedrequestroute)
+  * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
 
@@ -138,6 +139,11 @@ This is extracted from the `request.headers` property and is filtered to only in
 #### `SerializedRequest.route`
 
 This is an object extracted from `request.route.path` (string) and `request.params` (object) if they are present and conform to the same properties on an [Express Request object](https://expressjs.com/en/4x/api.html#req). It defaults to `undefined`.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/serialize-request/docs/migration.md
+++ b/packages/serialize-request/docs/migration.md
@@ -1,0 +1,28 @@
+
+# Migration guide for @dotcom-reliability-kit/serialize-request
+
+This document outlines how to migrate to the latest version of the Reliability Kit serialize-request package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [Node.js 14 is no longer supported](#nodejs-14-is-no-longer-supported)
+* [Migrating from v2 to v3](#migrating-from-v2-to-v3)
+  * [Node.js 16 is no longer supported](#nodejs-16-is-no-longer-supported)
+
+
+## Migrating from v1 to v2
+
+### Node.js 14 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v14. If your app is already using Node.js v16 or above then you can migrate with no code changes.
+
+
+## Migrating from v2 to v3
+
+### Node.js 16 is no longer supported
+
+**:red_circle: Breaking:** this version drops support for Node.js v16. If your app is already using Node.js v18 or above then you can migrate with no code changes.


### PR DESCRIPTION
There's a small maintenance overhead to adding these but I think they're far more clear than a changelog for major breaking versions. We need to include a lot of extra context and information and I think these guides will reduce questions from other teams.