### PR TITLE
chore: remove unused development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2888,12 +2888,6 @@
         "svgo": "*"
       }
     },
-    "node_modules/@types/ungap__structured-clone": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.3.tgz",
-      "integrity": "sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==",
-      "dev": true
-    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -10323,8 +10317,7 @@
         "@financial-times/n-logger": "^10.3.0",
         "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.3",
-        "@types/lodash.clonedeep": "^4.5.9",
-        "@types/ungap__structured-clone": "^0.3.3"
+        "@types/lodash.clonedeep": "^4.5.9"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -11267,7 +11260,6 @@
         "@financial-times/n-mask-logger": "^7.2.0",
         "@types/events": "^3.0.3",
         "@types/lodash.clonedeep": "^4.5.9",
-        "@types/ungap__structured-clone": "^0.3.3",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^8.17.2"
       }
@@ -12585,12 +12577,6 @@
       "requires": {
         "svgo": "*"
       }
-    },
-    "@types/ungap__structured-clone": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.3.tgz",
-      "integrity": "sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==",
-      "dev": true
     },
     "@types/unist": {
       "version": "2.0.6",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -33,7 +33,6 @@
     "@financial-times/n-logger": "^10.3.0",
     "@financial-times/n-mask-logger": "^7.2.0",
     "@types/events": "^3.0.3",
-    "@types/lodash.clonedeep": "^4.5.9",
-    "@types/ungap__structured-clone": "^0.3.3"
+    "@types/lodash.clonedeep": "^4.5.9"
   }
 }


### PR DESCRIPTION
These are a hangover from the early logger experiments.