### PR TITLE
docs: replace node 16 references with node 18

### DIFF
--- a/packages/log-error/README.md
+++ b/packages/log-error/README.md
@@ -60,7 +60,7 @@ This will automatically [serialize error objects](https://github.com/Financial-T
     app: {
         commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        nodeVersion: '16.16.0',
+        nodeVersion: '18.17.0',
         region: 'EU',
         releaseDate: '2022-07-25T01:37:00Z'
     }
@@ -94,7 +94,7 @@ The information logged looks like this:
     app: {
         commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        nodeVersion: '16.16.0',
+        nodeVersion: '18.17.0',
         region: 'EU',
         releaseDate: '2022-07-25T01:37:00Z'
     }
@@ -128,7 +128,7 @@ The information logged looks like this:
     app: {
         commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        nodeVersion: '16.16.0',
+        nodeVersion: '18.17.0',
         region: 'EU',
         releaseDate: '2022-07-25T01:37:00Z'
     }
@@ -252,7 +252,7 @@ When this option is defined, the logged data looks includes request data:
     app: {
         commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        nodeVersion: '16.16.0',
+        nodeVersion: '18.17.0',
         region: 'EU',
         releaseDate: '2022-07-25T01:37:00Z'
     }

--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -787,7 +787,7 @@ module.exports = [
 					message: 'Express application example started',
 					app: 'example',
 					port: 1234,
-					nodeVersion: 'v16.17.0'
+					nodeVersion: 'v18.17.0'
 				}
 			]
 		},
@@ -798,7 +798,7 @@ module.exports = [
 				message: 'Express application example started',
 				app: 'example',
 				port: 1234,
-				nodeVersion: 'v16.17.0'
+				nodeVersion: 'v18.17.0'
 			},
 			reliabilityKit: {
 				level: 'warn',
@@ -806,7 +806,7 @@ module.exports = [
 				message: 'Express application example started',
 				app: 'example',
 				port: 1234,
-				nodeVersion: 'v16.17.0'
+				nodeVersion: 'v18.17.0'
 			}
 		}
 	},

--- a/packages/middleware-log-errors/README.md
+++ b/packages/middleware-log-errors/README.md
@@ -68,7 +68,7 @@ This will automatically [serialize error objects](https://github.com/Financial-T
     app: {
         commit: '137da65185397a7d699ed54c3052d10d83e82137',
         name: 'example-app',
-        nodeVersion: '16.16.0',
+        nodeVersion: '18.17.0',
         region: 'EU',
         releaseDate: '2022-07-25T01:37:00Z'
     }


### PR DESCRIPTION
To avoid confusion, removed references to Node 16 in docs, now that node16 support bas been dropped by Dotcom-Reliability-kit-> #840 