### PR TITLE
fix: switch back to using a pino-pretty transport

### DIFF
--- a/packages/logger/test/unit/lib/logger.spec.js
+++ b/packages/logger/test/unit/lib/logger.spec.js
@@ -42,7 +42,6 @@ let Logger = require('../../../lib/logger');
 
 describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 	let mockPinoLogger;
-	let pinoPretty;
 
 	beforeEach(() => {
 		mockPinoLogger = createMockPinoLogger();
@@ -760,10 +759,7 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 
 		describe('when pino-pretty is installed and the environment is not "production" - e.g. "development', () => {
 			beforeEach(() => {
-				jest.mock('pino-pretty', () => {
-					return { default: jest.fn().mockReturnValue('mock pino pretty') };
-				});
-				pinoPretty = require('pino-pretty').default;
+				jest.mock('pino-pretty', () => 'mock pino pretty');
 				appInfo.environment = 'development';
 
 				// We have to reset all modules because the checks for pino-pretty are done
@@ -782,21 +778,22 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 			});
 
 			it('configures the created Pino logger with prettification', () => {
-				const pinoStream = pino.mock.calls[0][1];
-				expect(pinoPretty).toHaveBeenCalledWith({
-					colorize: true,
-					messageKey: 'message'
+				const pinoOptions = pino.mock.calls[0][0];
+				expect(typeof pinoOptions.transport).toStrictEqual('object');
+				expect(pinoOptions.transport).toEqual({
+					target: 'pino-pretty',
+					worker: { execArgv: [] },
+					options: {
+						colorize: true,
+						messageKey: 'message'
+					}
 				});
-				expect(pinoStream).toStrictEqual('mock pino pretty');
 			});
 		});
 
 		describe('when pino-pretty is installed and the environment is not "production" - e.g. "test', () => {
 			beforeEach(() => {
-				jest.mock('pino-pretty', () => {
-					return { default: jest.fn().mockReturnValue('mock pino pretty') };
-				});
-				pinoPretty = require('pino-pretty').default;
+				jest.mock('pino-pretty', () => 'mock pino pretty');
 				appInfo.environment = 'test';
 
 				// We have to reset all modules because the checks for pino-pretty are done
@@ -815,21 +812,22 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 			});
 
 			it('configures the created Pino logger with prettification', () => {
-				const pinoStream = pino.mock.calls[0][1];
-				expect(pinoPretty).toHaveBeenCalledWith({
-					colorize: true,
-					messageKey: 'message'
+				const pinoOptions = pino.mock.calls[0][0];
+				expect(typeof pinoOptions.transport).toStrictEqual('object');
+				expect(pinoOptions.transport).toEqual({
+					target: 'pino-pretty',
+					worker: { execArgv: [] },
+					options: {
+						colorize: true,
+						messageKey: 'message'
+					}
 				});
-				expect(pinoStream).toStrictEqual('mock pino pretty');
 			});
 		});
 
 		describe('when pino-pretty is installed and the `withPrettifier` option is set to `false`', () => {
 			beforeEach(() => {
-				jest.mock('pino-pretty', () => {
-					return { default: jest.fn().mockReturnValue('mock pino pretty') };
-				});
-				pinoPretty = require('pino-pretty').default;
+				jest.mock('pino-pretty', () => 'mock pino pretty');
 				appInfo.environment = 'development';
 
 				// We have to reset all modules because the checks for pino-pretty are done
@@ -855,10 +853,7 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 
 		describe('when pino-pretty is installed and the `LOG_DISABLE_PRETTIFIER` environment variable is set', () => {
 			beforeEach(() => {
-				jest.mock('pino-pretty', () => {
-					return { default: jest.fn().mockReturnValue('mock pino pretty') };
-				});
-				pinoPretty = require('pino-pretty').default;
+				jest.mock('pino-pretty', () => 'mock pino pretty');
 				appInfo.environment = 'development';
 				process.env.LOG_DISABLE_PRETTIFIER = 'true';
 
@@ -885,10 +880,7 @@ describe('@dotcom-reliability-kit/logger/lib/logger', () => {
 
 		describe('when pino-pretty is installed and the environment is "production"', () => {
 			beforeEach(() => {
-				jest.mock('pino-pretty', () => {
-					return { default: jest.fn().mockReturnValue('mock pino pretty') };
-				});
-				pinoPretty = require('pino-pretty').default;
+				jest.mock('pino-pretty', () => 'mock pino pretty');
 				appInfo.environment = 'production';
 
 				// We have to reset all modules because the checks for pino-pretty are done


### PR DESCRIPTION
Back in #802 we fixed an issue where we were doubling up logs due to pino-pretty being installed. We switched to streaming logs into pino-pretty instead of configuring it as a transport.

This turned out to be a configuration issue ([see issue comment on Pino](https://github.com/pinojs/pino/issues/1852#issuecomment-1883376351)) which allows us to switch back to configuring pino-pretty as a transport rather than creating a stream. I prefer this approach as it's easier to test and I think results in more readable code.

This is largely a revert of 7abae5a92a012b835a009e4df983bc401223e134, but some related code has changed since this commit so I had to manually switch back to the old way of doing things.