### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.0.1",
-  "packages/crash-handler": "4.0.1",
+  "packages/crash-handler": "4.0.2",
   "packages/errors": "3.0.1",
   "packages/eslint-config": "3.0.1",
   "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.1",
-  "packages/logger": "3.0.1",
-  "packages/middleware-log-errors": "4.0.1",
-  "packages/middleware-render-error-info": "5.0.1",
+  "packages/log-error": "4.0.2",
+  "packages/logger": "3.0.2",
+  "packages/middleware-log-errors": "4.0.2",
+  "packages/middleware-render-error-info": "5.0.2",
   "packages/serialize-error": "3.0.1",
   "packages/serialize-request": "3.0.1",
-  "packages/opentelemetry": "0.0.0"
+  "packages/opentelemetry": "0.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12308,10 +12308,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.1"
+        "@dotcom-reliability-kit/log-error": "^4.0.2"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -12363,11 +12363,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.1",
+        "@dotcom-reliability-kit/logger": "^3.0.2",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "@dotcom-reliability-kit/serialize-request": "^3.0.1"
       },
@@ -12381,7 +12381,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
@@ -12405,10 +12405,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.1"
+        "@dotcom-reliability-kit/log-error": "^4.0.2"
       },
       "devDependencies": {
         "@financial-times/n-express": "^28.3.0",
@@ -12422,11 +12422,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/log-error": "^4.0.1",
+        "@dotcom-reliability-kit/log-error": "^4.0.2",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "entities": "^4.5.0"
       },
@@ -12440,11 +12440,11 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.1",
+        "@dotcom-reliability-kit/logger": "^3.0.2",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/auto-instrumentations-node": "^0.40.2",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.1...crash-handler-v4.0.2) (2024-01-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
+
 ## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.0...crash-handler-v4.0.1) (2024-01-09)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.1"
+    "@dotcom-reliability-kit/log-error": "^4.0.2"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,15 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.1...log-error-v4.0.2) (2024-01-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.1 to ^3.0.2
+
 ## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.0...log-error-v4.0.1) (2024-01-09)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/logger": "^3.0.1",
+    "@dotcom-reliability-kit/logger": "^3.0.2",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "@dotcom-reliability-kit/serialize-request": "^3.0.1"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,13 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.1...logger-v3.0.2) (2024-01-16)
+
+
+### Bug Fixes
+
+* switch back to using a pino-pretty transport ([3a90c1e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3a90c1efec01f4d8e7df7b934ce692785de241bd))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.0...logger-v3.0.1) (2024-01-09)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.1...middleware-log-errors-v4.0.2) (2024-01-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
+
 ## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.0...middleware-log-errors-v4.0.1) (2024-01-09)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.1"
+    "@dotcom-reliability-kit/log-error": "^4.0.2"
   },
   "devDependencies": {
     "@financial-times/n-express": "^28.3.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.1...middleware-render-error-info-v5.0.2) (2024-01-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
+
 ## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.0...middleware-render-error-info-v5.0.1) (2024-01-09)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/log-error": "^4.0.1",
+    "@dotcom-reliability-kit/log-error": "^4.0.2",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 0.1.0 (2024-01-16)
+
+
+### Features
+
+* allow setting an authorization header ([6e89e7e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6e89e7ec40dd611fbe0120b9bed4e53ef5b0113b))
+* created new opentelemetry package with tracing functionality ([0871914](https://github.com/Financial-Times/dotcom-reliability-kit/commit/08719146f487d4040949556faf3985c7f461e952))
+* expose the type for OpenTelemetry options ([6d1bbde](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6d1bbdeecb17462a61a0322a1e1769069a783242))
+
+
+### Bug Fixes
+
+* bump @dotcom-reliability-kit/app-info in /packages/opentelemetry ([eb87cce](https://github.com/Financial-Times/dotcom-reliability-kit/commit/eb87ccefdde6c7dcd1074097821d1c378e1344e1))
+* bump @dotcom-reliability-kit/logger in /packages/opentelemetry ([062095a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/062095a08a0818b9b499752fb55126066cf56ec1))
+* bump @opentelemetry/exporter-trace-otlp-proto ([8b2dd87](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8b2dd87d5fbdd97fe361ba1917a3984070b54e11))
+* bump @opentelemetry/sdk-node in /packages/opentelemetry ([e29fc79](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e29fc79fb8f1cf1d528d2841ac58eea6ac1efe71))
+* bump @opentelemetry/semantic-conventions from 1.19.0 to 1.20.0 ([2aabf59](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2aabf59b84f9d521c19cd0eaaba880702dea3848))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.1 to ^3.0.2

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,7 +17,7 @@
 	"main": "lib",
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.1",
+		"@dotcom-reliability-kit/logger": "^3.0.2",
 		"@opentelemetry/api": "^1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.40.2",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.0.2</summary>

## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.1...crash-handler-v4.0.2) (2024-01-16)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
</details>

<details><summary>log-error: 4.0.2</summary>

## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.1...log-error-v4.0.2) (2024-01-16)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.1 to ^3.0.2
</details>

<details><summary>logger: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.1...logger-v3.0.2) (2024-01-16)


### Bug Fixes

* switch back to using a pino-pretty transport ([3a90c1e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3a90c1efec01f4d8e7df7b934ce692785de241bd))
</details>

<details><summary>middleware-log-errors: 4.0.2</summary>

## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.1...middleware-log-errors-v4.0.2) (2024-01-16)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
</details>

<details><summary>middleware-render-error-info: 5.0.2</summary>

## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.1...middleware-render-error-info-v5.0.2) (2024-01-16)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.1 to ^4.0.2
</details>

<details><summary>opentelemetry: 0.1.0</summary>

## 0.1.0 (2024-01-16)


### Features

* allow setting an authorization header ([6e89e7e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6e89e7ec40dd611fbe0120b9bed4e53ef5b0113b))
* created new opentelemetry package with tracing functionality ([0871914](https://github.com/Financial-Times/dotcom-reliability-kit/commit/08719146f487d4040949556faf3985c7f461e952))
* expose the type for OpenTelemetry options ([6d1bbde](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6d1bbdeecb17462a61a0322a1e1769069a783242))


### Bug Fixes

* bump @dotcom-reliability-kit/app-info in /packages/opentelemetry ([eb87cce](https://github.com/Financial-Times/dotcom-reliability-kit/commit/eb87ccefdde6c7dcd1074097821d1c378e1344e1))
* bump @dotcom-reliability-kit/logger in /packages/opentelemetry ([062095a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/062095a08a0818b9b499752fb55126066cf56ec1))
* bump @opentelemetry/exporter-trace-otlp-proto ([8b2dd87](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8b2dd87d5fbdd97fe361ba1917a3984070b54e11))
* bump @opentelemetry/sdk-node in /packages/opentelemetry ([e29fc79](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e29fc79fb8f1cf1d528d2841ac58eea6ac1efe71))
* bump @opentelemetry/semantic-conventions from 1.19.0 to 1.20.0 ([2aabf59](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2aabf59b84f9d521c19cd0eaaba880702dea3848))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.1 to ^3.0.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).