### PR TITLE
feat: send a custom user-agent with otel requests

### DIFF
--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -1,3 +1,4 @@
+const packageJson = require('../package.json');
 const { diag, DiagLogLevel } = require('@opentelemetry/api');
 const {
 	getNodeAutoInstrumentations
@@ -11,8 +12,12 @@ const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
 	OTLPTraceExporter
 } = require('@opentelemetry/exporter-trace-otlp-proto');
+const traceExporterPackageJson = require('@opentelemetry/exporter-trace-otlp-proto/package.json');
 const { NoopSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const logger = require('@dotcom-reliability-kit/logger');
+
+const USER_AGENT = `FTSystem/${appInfo.systemCode} (${packageJson.name}/${packageJson.version})`;
+const TRACING_USER_AGENT = `${USER_AGENT} (${traceExporterPackageJson.name}/${traceExporterPackageJson.version})`;
 
 /**
  * @typedef {object} Options
@@ -71,7 +76,9 @@ function setupOpenTelemetry({ authorizationHeader, tracesEndpoint } = {}) {
 			enabled: true,
 			tracesEndpoint: tracesEndpoint
 		});
-		const headers = {};
+		const headers = {
+			'user-agent': TRACING_USER_AGENT
+		};
 		if (authorizationHeader) {
 			headers.authorization = authorizationHeader;
 		}

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -1,5 +1,13 @@
+jest.mock('../../../package.json', () => ({
+	name: 'mock-package',
+	version: '1.2.3'
+}));
 jest.mock('@opentelemetry/auto-instrumentations-node');
 jest.mock('@opentelemetry/exporter-trace-otlp-proto');
+jest.mock('@opentelemetry/exporter-trace-otlp-proto/package.json', () => ({
+	name: 'mock-otel-tracing-package',
+	version: '3.4.5'
+}));
 jest.mock('@opentelemetry/sdk-trace-base');
 jest.mock('@opentelemetry/resources');
 jest.mock('@opentelemetry/sdk-node');
@@ -96,7 +104,10 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 			expect(OTLPTraceExporter).toHaveBeenCalledTimes(1);
 			expect(OTLPTraceExporter).toHaveBeenCalledWith({
 				url: 'MOCK_TRACES_ENDPOINT',
-				headers: {}
+				headers: {
+					'user-agent':
+						'FTSystem/MOCK_SYSTEM_CODE (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
+				}
 			});
 			expect(
 				opentelemetrySDK.NodeSDK.mock.calls[0][0].traceExporter
@@ -122,7 +133,9 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 			expect(OTLPTraceExporter).toHaveBeenCalledWith({
 				url: 'MOCK_TRACES_ENDPOINT',
 				headers: {
-					authorization: 'mock-authorization-header'
+					authorization: 'mock-authorization-header',
+					'user-agent':
+						'FTSystem/MOCK_SYSTEM_CODE (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
 				}
 			});
 		});


### PR DESCRIPTION
This helps identify our OpenTelemetry client and the system that's making the requests, useful for debugging.