### PR TITLE
feat!: move tracing config into a separate object

### DIFF
--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -12,7 +12,8 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
   * [Manual setup](#manual-setup)
   * [Configuration options](#configuration-options)
     * [`options.authorizationHeader`](#optionsauthorizationheader)
-    * [`options.tracesEndpoint`](#optionstracesendpoint)
+    * [`options.tracing`](#optionstracing)
+    * [`options.tracing.endpoint`](#optionstracingendpoint)
     * [`OTEL_` environment variables](#otel_-environment-variables)
 * [Contributing](#contributing)
 * [License](#license)
@@ -153,17 +154,21 @@ setupOpenTelemetry({
 
 #### `options.authorizationHeader`
 
-Set the [`Authorization` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) in requests to the OpenTelemetry collector. Defaults to `null`.
+Set the [`Authorization` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) in requests to the OpenTelemetry collector. Defaults to `undefined`.
 
 **Environment variable:** `OPENTELEMETRY_AUTHORIZATION_HEADER`<br/>
 **Option:** `authorizationHeader` (`String`)
 
-#### `options.tracesEndpoint`
+#### `options.tracing`
 
-A URL to send OpenTelemetry traces to. E.g. `http://localhost:4318/v1/traces`. Defaults to `null` which means that OpenTelemetry traces will not be sent.
+An object containing other tracing-specific configurations. Defaults to `undefined` which means that OpenTelemetry traces will not be sent.
 
-**Environment variable:** `OPENTELEMETRY_TRACES_ENDPOINT`<br/>
-**Option:** `tracesEndpoint` (`String`)
+#### `options.tracing.endpoint`
+
+A URL to send OpenTelemetry traces to. E.g. `http://localhost:4318/v1/traces`. Defaults to `undefined` which means that OpenTelemetry traces will not be sent.
+
+**Environment variable:** `OPENTELEMETRY_TRACING_ENDPOINT`<br/>
+**Option:** `tracing.endpoint` (`String`)
 
 #### `OTEL_` environment variables
 

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -1,6 +1,14 @@
 const setupOpenTelemetry = require('./lib/index.js');
 
+/** @type {setupOpenTelemetry.TracingOptions | undefined} */
+let tracing = undefined;
+if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
+	tracing = {
+		endpoint: process.env.OPENTELEMETRY_TRACING_ENDPOINT
+	};
+}
+
 setupOpenTelemetry({
 	authorizationHeader: process.env.OPENTELEMETRY_AUTHORIZATION_HEADER,
-	tracesEndpoint: process.env.OPENTELEMETRY_TRACES_ENDPOINT
+	tracing
 });

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -1,17 +1,35 @@
-jest.mock('../../lib/index.js', () => jest.fn());
-
-const mockSetupOpenTelemetry = require('../../lib/index.js');
-
 describe('setupOpenTelemetry', () => {
+	let setupOpenTelemetry;
+
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('../../lib/index.js', () => jest.fn());
+		setupOpenTelemetry = require('../../lib/index.js');
+	});
+
 	it('should call setupOpenTelemetry with the correct parameters', () => {
-		process.env.OPENTELEMETRY_TRACES_ENDPOINT = 'MOCK_TRACES_ENDPOINT';
+		process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
 		process.env.OPENTELEMETRY_AUTHORIZATION_HEADER = 'MOCK_AUTH_HEADER';
 		require('../../setup.js');
 
-		expect(mockSetupOpenTelemetry).toHaveBeenCalledWith({
+		expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+		expect(setupOpenTelemetry).toHaveBeenCalledWith({
 			authorizationHeader: 'MOCK_AUTH_HEADER',
-			tracesEndpoint: 'MOCK_TRACES_ENDPOINT'
+			tracing: {
+				endpoint: 'MOCK_TRACING_ENDPOINT'
+			}
 		});
-		expect(mockSetupOpenTelemetry).toHaveBeenCalledTimes(1);
+	});
+
+	describe('when no traces endpoint is specified', () => {
+		it('should not include tracing configuration', () => {
+			delete process.env.OPENTELEMETRY_TRACING_ENDPOINT;
+			require('../../setup.js');
+
+			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+				authorizationHeader: 'MOCK_AUTH_HEADER'
+			});
+		});
 	});
 });


### PR DESCRIPTION
This tidies up tracing config and paves the way to us having more configurations that are specific to tracing. It will make it easier to add metrics later as well.

This is a breaking change because:
1. Environment variable names have changed
2. The JavaScript API has changed

See-also: https://financialtimes.atlassian.net/browse/CPREL-951