### PR TITLE
feat!: add the ability to sample traces

### DIFF
--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -14,6 +14,7 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
     * [`options.authorizationHeader`](#optionsauthorizationheader)
     * [`options.tracing`](#optionstracing)
     * [`options.tracing.endpoint`](#optionstracingendpoint)
+    * [`options.tracing.samplePercentage`](#optionstracingsamplepercentage)
     * [`OTEL_` environment variables](#otel_-environment-variables)
 * [Contributing](#contributing)
 * [License](#license)
@@ -169,6 +170,13 @@ A URL to send OpenTelemetry traces to. E.g. `http://localhost:4318/v1/traces`. D
 
 **Environment variable:** `OPENTELEMETRY_TRACING_ENDPOINT`<br/>
 **Option:** `tracing.endpoint` (`String`)
+
+#### `options.tracing.samplePercentage`
+
+The percentage of traces to send to the exporter. Defaults to `5` which means that 5% of traces will be exported.
+
+**Environment variable:** `OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE`<br/>
+**Option:** `tracing.samplePercentage` (`Number`)
 
 #### `OTEL_` environment variables
 

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -4,7 +4,10 @@ const setupOpenTelemetry = require('./lib/index.js');
 let tracing = undefined;
 if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 	tracing = {
-		endpoint: process.env.OPENTELEMETRY_TRACING_ENDPOINT
+		endpoint: process.env.OPENTELEMETRY_TRACING_ENDPOINT,
+		samplePercentage: process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE
+			? Number(process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE)
+			: undefined
 	};
 }
 

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -21,6 +21,38 @@ describe('setupOpenTelemetry', () => {
 		});
 	});
 
+	describe('when a sample rate is specified', () => {
+		it('calls OpenTelemetry with the given sample percentage as a number', () => {
+			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = '50';
+			require('../../setup.js');
+
+			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+				authorizationHeader: 'MOCK_AUTH_HEADER',
+				tracing: {
+					endpoint: 'MOCK_TRACING_ENDPOINT',
+					samplePercentage: 50
+				}
+			});
+		});
+	});
+
+	describe('when a non-numeric sample rate is specified', () => {
+		it('calls OpenTelemetry with NaN as a percentage', () => {
+			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = 'nope';
+			require('../../setup.js');
+
+			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+				authorizationHeader: 'MOCK_AUTH_HEADER',
+				tracing: {
+					endpoint: 'MOCK_TRACING_ENDPOINT',
+					samplePercentage: NaN
+				}
+			});
+		});
+	});
+
 	describe('when no traces endpoint is specified', () => {
 		it('should not include tracing configuration', () => {
 			delete process.env.OPENTELEMETRY_TRACING_ENDPOINT;


### PR DESCRIPTION
This is a breaking change because an app that updates will no longer see 100% of their traces in their backend.

I decided that working in percentages was better than working in ratios because I think there's less change for confusion.