### PR TITLE
feat: log OpenTelemetry success as info

### DIFF
--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -114,7 +114,7 @@ function setupOpenTelemetry({ authorizationHeader, tracing } = {}) {
 		const sampleRatio = samplePercentage / 100;
 		openTelemetryConfig.sampler = new TraceIdRatioBasedSampler(sampleRatio);
 
-		logger.debug({
+		logger.info({
 			event: 'OTEL_TRACE_STATUS',
 			message: `OpenTelemetry tracing is enabled and exporting to endpoint ${tracing.endpoint}`,
 			enabled: true,

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -126,7 +126,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		});
 
 		it('logs that tracing is enabled', () => {
-			expect(logger.debug).toHaveBeenCalledWith({
+			expect(logger.info).toHaveBeenCalledWith({
 				enabled: true,
 				endpoint: 'MOCK_TRACING_ENDPOINT',
 				event: 'OTEL_TRACE_STATUS',


### PR DESCRIPTION
This ensures that we can see that OpenTelemetry is running in more apps.