### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.0.2",
   "packages/serialize-error": "3.0.1",
   "packages/serialize-request": "3.0.1",
-  "packages/opentelemetry": "0.2.0"
+  "packages/opentelemetry": "0.2.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12440,7 +12440,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.0...opentelemetry-v0.2.1) (2024-01-19)
+
+
+### Features
+
+* log OpenTelemetry success as info ([af5fce9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/af5fce92fb26bc4f52d8421fe5b93c0ffd758770))
+
 ## [0.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.1.1...opentelemetry-v0.2.0) (2024-01-18)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 0.2.1</summary>

## [0.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.0...opentelemetry-v0.2.1) (2024-01-19)


### Features

* log OpenTelemetry success as info ([af5fce9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/af5fce92fb26bc4f52d8421fe5b93c0ffd758770))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).