### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.0.1",
-  "packages/crash-handler": "4.0.2",
+  "packages/crash-handler": "4.0.3",
   "packages/errors": "3.0.1",
   "packages/eslint-config": "3.0.1",
   "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.2",
-  "packages/logger": "3.0.2",
-  "packages/middleware-log-errors": "4.0.2",
-  "packages/middleware-render-error-info": "5.0.2",
+  "packages/log-error": "4.0.3",
+  "packages/logger": "3.0.3",
+  "packages/middleware-log-errors": "4.0.3",
+  "packages/middleware-render-error-info": "5.0.3",
   "packages/serialize-error": "3.0.1",
   "packages/serialize-request": "3.0.1",
-  "packages/opentelemetry": "0.2.1"
+  "packages/opentelemetry": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12268,10 +12268,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.2"
+        "@dotcom-reliability-kit/log-error": "^4.0.3"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -12323,11 +12323,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.2",
+        "@dotcom-reliability-kit/logger": "^3.0.3",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "@dotcom-reliability-kit/serialize-request": "^3.0.1"
       },
@@ -12341,7 +12341,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
@@ -12365,10 +12365,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.2"
+        "@dotcom-reliability-kit/log-error": "^4.0.3"
       },
       "devDependencies": {
         "@financial-times/n-express": "^28.4.0",
@@ -12382,11 +12382,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/log-error": "^4.0.2",
+        "@dotcom-reliability-kit/log-error": "^4.0.3",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "entities": "^4.5.0"
       },
@@ -12400,11 +12400,11 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "0.2.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.2",
+        "@dotcom-reliability-kit/logger": "^3.0.3",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/auto-instrumentations-node": "^0.40.2",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.2...crash-handler-v4.0.3) (2024-01-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
+
 ## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.1...crash-handler-v4.0.2) (2024-01-16)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.2"
+    "@dotcom-reliability-kit/log-error": "^4.0.3"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,15 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.2...log-error-v4.0.3) (2024-01-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.2 to ^3.0.3
+
 ## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.1...log-error-v4.0.2) (2024-01-16)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/logger": "^3.0.2",
+    "@dotcom-reliability-kit/logger": "^3.0.3",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "@dotcom-reliability-kit/serialize-request": "^3.0.1"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,13 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.2...logger-v3.0.3) (2024-01-22)
+
+
+### Documentation Changes
+
+* fix typo in Tranform -&gt; Transform ([dab3539](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dab3539a13504b29600318c29119653485df66eb))
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.1...logger-v3.0.2) (2024-01-16)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.2...middleware-log-errors-v4.0.3) (2024-01-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
+
 ## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.1...middleware-log-errors-v4.0.2) (2024-01-16)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.2"
+    "@dotcom-reliability-kit/log-error": "^4.0.3"
   },
   "devDependencies": {
     "@financial-times/n-express": "^28.4.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.2...middleware-render-error-info-v5.0.3) (2024-01-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
+
 ## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.1...middleware-render-error-info-v5.0.2) (2024-01-16)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/log-error": "^4.0.2",
+    "@dotcom-reliability-kit/log-error": "^4.0.3",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.1...opentelemetry-v1.0.0) (2024-01-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* mark as stable
+
+### Features
+
+* ignore commonly polled URLs ([c207c37](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c207c378869d41a9f8d73f411a4784041d689253))
+
+
+### Documentation Changes
+
+* add a full local development example ([0dd33c6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0dd33c6d5fef6f31bafa71c0e02becb86bc5588e))
+* add running instructions ([e936cee](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e936cee7b1f1cfcae7e2e0b7a559056eb84c5ece))
+* mark as stable ([4f8c924](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4f8c92425d53035d4b80a6b8539d8181bf4e0e44))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.2 to ^3.0.3
+
 ## [0.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.0...opentelemetry-v0.2.1) (2024-01-19)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "0.2.1",
+	"version": "1.0.0",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,7 +17,7 @@
 	"main": "lib",
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.2",
+		"@dotcom-reliability-kit/logger": "^3.0.3",
 		"@opentelemetry/api": "^1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.40.2",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.0.3</summary>

## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.2...crash-handler-v4.0.3) (2024-01-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
</details>

<details><summary>log-error: 4.0.3</summary>

## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.2...log-error-v4.0.3) (2024-01-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.2 to ^3.0.3
</details>

<details><summary>logger: 3.0.3</summary>

## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.2...logger-v3.0.3) (2024-01-22)


### Documentation Changes

* fix typo in Tranform -&gt; Transform ([dab3539](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dab3539a13504b29600318c29119653485df66eb))
</details>

<details><summary>middleware-log-errors: 4.0.3</summary>

## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.2...middleware-log-errors-v4.0.3) (2024-01-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
</details>

<details><summary>middleware-render-error-info: 5.0.3</summary>

## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.2...middleware-render-error-info-v5.0.3) (2024-01-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.2 to ^4.0.3
</details>

<details><summary>opentelemetry: 1.0.0</summary>

## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.1...opentelemetry-v1.0.0) (2024-01-22)


### ⚠ BREAKING CHANGES

* mark as stable

### Features

* ignore commonly polled URLs ([c207c37](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c207c378869d41a9f8d73f411a4784041d689253))


### Documentation Changes

* add a full local development example ([0dd33c6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0dd33c6d5fef6f31bafa71c0e02becb86bc5588e))
* add running instructions ([e936cee](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e936cee7b1f1cfcae7e2e0b7a559056eb84c5ece))
* mark as stable ([4f8c924](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4f8c92425d53035d4b80a6b8539d8181bf4e0e44))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.2 to ^3.0.3
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).