### PR TITLE
docs!: mark as stable

### DIFF
--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -6,9 +6,6 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
 > [!TIP]<br />
 > OpenTelemetry is an open source observability framework that supports sending metrics, traces, and logs to a large variety of backends via a shared protocol. We try to abstract some of these concepts away with this module, but [understanding OpenTelemetry will help you get it set up](https://opentelemetry.io/docs/what-is-opentelemetry/).
 
-> [!WARNING]<br />
-> This package is in beta and hasn't been tested extensively in production yet. Feel free to use, and any feedback is greatly appreciated.
-
 * [Usage](#usage)
   * [Setup](#setup)
     * [Automated setup with `--require`](#automated-setup-with---require)


### PR DESCRIPTION
We've tested out this beta package in next-preflight, dotcom-debug-user, and also reliability-dashboards, and feel happy to mark it as stable for other systems to install now in production. This completes CPREL-956

Release-as: 1.0.0