### PR TITLE
chore: group OpenTelemetry updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,3 +116,10 @@ updates:
     commit-message:
       prefix: "fix:"
       prefix-development: "chore:"
+    groups:
+      opentelemetry:
+        patterns:
+          - "@opentelemetry/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
We should group OpenTelemetry updates because they're likely to be more frequent than our other dependency bumps. E.g. right now there are 5 different PRs relating to it that we'll otherwise need to merge separately.