### PR TITLE
fix: update all OpenTelemetry packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1442,9 +1442,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
+      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -2789,9 +2789,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
-      "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.48.0.tgz",
+      "integrity": "sha512-1/aMiU4Eqo3Zzpfwu51uXssp5pzvHFObk8S9pKAiXb1ne8pvg1qxBQitYL1XUiAMEXFzgjaidYG2V6624DRhhw==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -2800,54 +2800,54 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.40.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.40.3.tgz",
-      "integrity": "sha512-MgBCzpFU4FBQEsXPgt5driYzxErf2JGntQ8Amtc94sqrnvq+FKdEBa6vxOpZlPM+c4Xr6tPpAT1ecTBV8U87hw==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.41.0.tgz",
+      "integrity": "sha512-CmVVzphp1eb6Aenrr4B6TDsCNuDvut8NQbosTSdJFfnEX4+3szVQuaJquaicGI5tLvVxrgVbZAv52C7bJgMHkg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.33.5",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.37.4",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.37.2",
-        "@opentelemetry/instrumentation-bunyan": "^0.34.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.34.2",
-        "@opentelemetry/instrumentation-connect": "^0.32.4",
-        "@opentelemetry/instrumentation-cucumber": "^0.2.1",
-        "@opentelemetry/instrumentation-dataloader": "^0.5.4",
-        "@opentelemetry/instrumentation-dns": "^0.32.5",
-        "@opentelemetry/instrumentation-express": "^0.34.1",
-        "@opentelemetry/instrumentation-fastify": "^0.32.6",
-        "@opentelemetry/instrumentation-fs": "^0.8.4",
-        "@opentelemetry/instrumentation-generic-pool": "^0.32.5",
-        "@opentelemetry/instrumentation-graphql": "^0.36.1",
-        "@opentelemetry/instrumentation-grpc": "^0.46.0",
-        "@opentelemetry/instrumentation-hapi": "^0.33.3",
-        "@opentelemetry/instrumentation-http": "^0.46.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.36.1",
-        "@opentelemetry/instrumentation-knex": "^0.32.4",
-        "@opentelemetry/instrumentation-koa": "^0.36.4",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.33.5",
-        "@opentelemetry/instrumentation-memcached": "^0.32.5",
-        "@opentelemetry/instrumentation-mongodb": "^0.38.1",
-        "@opentelemetry/instrumentation-mongoose": "^0.34.0",
-        "@opentelemetry/instrumentation-mysql": "^0.34.5",
-        "@opentelemetry/instrumentation-mysql2": "^0.34.5",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.33.4",
-        "@opentelemetry/instrumentation-net": "^0.32.5",
-        "@opentelemetry/instrumentation-pg": "^0.37.2",
-        "@opentelemetry/instrumentation-pino": "^0.34.5",
-        "@opentelemetry/instrumentation-redis": "^0.35.5",
-        "@opentelemetry/instrumentation-redis-4": "^0.35.6",
-        "@opentelemetry/instrumentation-restify": "^0.34.3",
-        "@opentelemetry/instrumentation-router": "^0.33.4",
-        "@opentelemetry/instrumentation-socket.io": "^0.35.0",
-        "@opentelemetry/instrumentation-tedious": "^0.6.5",
-        "@opentelemetry/instrumentation-winston": "^0.33.1",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.5",
-        "@opentelemetry/resource-detector-aws": "^1.3.5",
-        "@opentelemetry/resource-detector-container": "^0.3.5",
-        "@opentelemetry/resource-detector-gcp": "^0.29.5",
+        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.34.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.38.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.38.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.35.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.35.0",
+        "@opentelemetry/instrumentation-connect": "^0.33.0",
+        "@opentelemetry/instrumentation-cucumber": "^0.3.0",
+        "@opentelemetry/instrumentation-dataloader": "^0.6.0",
+        "@opentelemetry/instrumentation-dns": "^0.33.0",
+        "@opentelemetry/instrumentation-express": "^0.35.0",
+        "@opentelemetry/instrumentation-fastify": "^0.33.0",
+        "@opentelemetry/instrumentation-fs": "^0.9.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.33.0",
+        "@opentelemetry/instrumentation-graphql": "^0.37.0",
+        "@opentelemetry/instrumentation-grpc": "^0.48.0",
+        "@opentelemetry/instrumentation-hapi": "^0.34.0",
+        "@opentelemetry/instrumentation-http": "^0.48.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.37.0",
+        "@opentelemetry/instrumentation-knex": "^0.33.0",
+        "@opentelemetry/instrumentation-koa": "^0.37.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.34.0",
+        "@opentelemetry/instrumentation-memcached": "^0.33.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.39.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.35.0",
+        "@opentelemetry/instrumentation-mysql": "^0.35.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.35.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.34.0",
+        "@opentelemetry/instrumentation-net": "^0.33.0",
+        "@opentelemetry/instrumentation-pg": "^0.38.0",
+        "@opentelemetry/instrumentation-pino": "^0.35.0",
+        "@opentelemetry/instrumentation-redis": "^0.36.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.36.0",
+        "@opentelemetry/instrumentation-restify": "^0.35.0",
+        "@opentelemetry/instrumentation-router": "^0.34.0",
+        "@opentelemetry/instrumentation-socket.io": "^0.36.0",
+        "@opentelemetry/instrumentation-tedious": "^0.7.0",
+        "@opentelemetry/instrumentation-winston": "^0.34.0",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.6",
+        "@opentelemetry/resource-detector-aws": "^1.3.6",
+        "@opentelemetry/resource-detector-container": "^0.3.6",
+        "@opentelemetry/resource-detector-gcp": "^0.29.6",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.46.0"
+        "@opentelemetry/sdk-node": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -2857,9 +2857,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.19.0.tgz",
-      "integrity": "sha512-0i1ECOc9daKK3rjUgDDXf0GDD5XfCou5lXnt2DALIc2qKoruPPcesobNKE54laSVUWnC3jX26RzuOa31g0V32A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.21.0.tgz",
+      "integrity": "sha512-t0iulGPiMjG/NrSjinPQoIf8ST/o9V0dGOJthfrFporJlNdlKIQPfC7lkrV+5s2dyBThfmSbJlp/4hO1eOcDXA==",
       "engines": {
         "node": ">=14"
       },
@@ -2868,11 +2868,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.19.0.tgz",
-      "integrity": "sha512-w42AukJh3TP8R0IZZOVJVM/kMWu8g+lm4LzT70WtuKqhwq7KVhcDzZZuZinWZa6TtQCl7Smt2wolEYzpHabOgw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -2881,25 +2881,17 @@
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
-    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
-      "integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.48.0.tgz",
+      "integrity": "sha512-+qRQXUbdRW6aNRT5yWOG3G6My1VxxKeqgUyLkkdIjkT20lvymjiN2RpBfGMtAf/oqnuRknf9snFl9VSIO2gniw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -2909,15 +2901,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.46.0.tgz",
-      "integrity": "sha512-vZ2pYOB+qrQ+jnKPY6Gnd58y1k/Ti//Ny6/XsSX7/jED0X77crtSVgC6N5UA0JiGJOh6QB2KE9gaH99010XHzg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.48.0.tgz",
+      "integrity": "sha512-QEZKbfWqXrbKVpr2PHd4KyKI0XVOhUYC+p2RPV8s+2K5QzZBE3+F9WlxxrXDfkrvGmpQAZytBoHQQYA3AGOtpw==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -2927,154 +2919,33 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.47.0.tgz",
-      "integrity": "sha512-0gzOFQr//nh/BtlmYl2I5jhxsfvYkdHr7lluLS5I9M/dCxaZqZHeY7sZgop+g5WbTRAyK63q5BwrpyjbxdXnMg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.48.0.tgz",
+      "integrity": "sha512-hVXr/8DYlAKAzQYMsCf3ZsGweS6NTK3IHIEqmLokJZYcvJQBEEazeAdISfrL/utWnapg1Qnpw8u+W6SpxNzmTw==",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/api-logs": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
-      "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
-      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
-      "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
-      "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
-      "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
-      "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": ">=0.39.1"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
-      "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
-      "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.19.0.tgz",
-      "integrity": "sha512-TY1fy4JiOBN5a8T9fknqTMcz0DXIeFBr6sklaLCgwtj+G699a5R4CekNwpeM7DHSwC44UMX7gljO2I6dYsTS3A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.21.0.tgz",
+      "integrity": "sha512-J0ejrOx52s1PqvjNalIHvY/4v9ZxR2r7XS7WZbwK3qpVYZlGVq5V1+iCNweqsKnb/miUt/4TFvJBc9f5Q/kGcA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3083,18 +2954,10 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
-      "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
+      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
@@ -3110,12 +2973,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.5.tgz",
-      "integrity": "sha512-WQ/XPzNLOHL3fpsmgoQUkiKCkJ09hvPN8wGrGzzOHMiJ5/3LqvfvxsJ4Rcd6aWkA4il3hEfpl+V0VF0t/DP65A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.34.0.tgz",
+      "integrity": "sha512-lVGRkyGnjFJv9O8oO/+uT40nrNj4UO+UN0k8708guy/toVgxsVpv4PtdWJTjbtu89UDk9gUxq62jpHxqrVaNnw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3126,11 +2989,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.4.tgz",
-      "integrity": "sha512-/wdZwUalIWAbxeycvmE+25c1xCMhe5EUuj8bN0MWWN3L8N2SYvfv6DmiRgwrTIPXRgIyFugh2udNiF4MezZN4Q==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.38.0.tgz",
+      "integrity": "sha512-MIPvM8S4LqGKE+IAnYVCRUnEjaWbPsbqL4p2BnGcox08e6+JQe+0d16DI0cKVSFZOzV5T/or3ewQ/bB0lPm8yg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -3144,13 +3007,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.37.2.tgz",
-      "integrity": "sha512-eFHHOk0P9EFQ9Ho+2w7KH9R8cH7hut0/ePSsrk0nAM6Tiq2lBPeHn8ialCWESAA9jSjy+iuDelwmqAEXEe+jrg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.38.0.tgz",
+      "integrity": "sha512-q1R+evR1j8sqd5LG+I8fKqP5TAPJEEOmJTvtEDYCVCdtzukI0ABYN8SHEIgDgYZmGBDM0yvC6jH0GmoEwvYuMw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
-        "@opentelemetry/propagation-utils": "^0.30.5",
+        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/propagation-utils": "^0.30.6",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3161,12 +3024,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.34.1.tgz",
-      "integrity": "sha512-+eshbCFr2dkUYO2jCpbYGFC5hs94UCOsQRK1XqNOjeiNvQRtqvKYqk8ARwJBYBX+aW4J02jOliAHQUh/d7gYPg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.35.0.tgz",
+      "integrity": "sha512-bQ8OzV7nVTA+oGiTzLjUmRFAbnXi0U/Z4VJCpj+1DRsaAaMT17eRpAOh22LQR0JBnv2vBm8CvIQl4CcAnsB46g==",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.46.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/api-logs": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@types/bunyan": "1.8.9"
       },
       "engines": {
@@ -3177,11 +3040,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.34.2.tgz",
-      "integrity": "sha512-wuzq7QQ9o7PJnzseblNfBcURtM+9AwO6e1m644QYtAb/6YRR6qg6gAmAipVeQu01H5BuHBFC/92svaAkdIV2WQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.35.0.tgz",
+      "integrity": "sha512-NlJkEiP37/WQvtSyYe4zxaBcaoweO/2+UtDssldk9NFmFutLHyMT/P5q5fe8i73ylmkPOAZnN8P48oHOhZHM1g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3192,12 +3055,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.4.tgz",
-      "integrity": "sha512-oUGph9idncdnHlQMwdIs6m6mii7Kdp9PpHkM9roOZy71h+2vvf6+cVn45bs2unBbE2Vxho2i/049QQbaYKDYlw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.33.0.tgz",
+      "integrity": "sha512-EAMmUC2/KfeZl4qNgUsiVqT5Jti0jDl4GHi4TpDg41VBEJkRX/0+JcPBWgdFUgEfeiZr0GPVQud4i8jAwJ+ORw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.36"
       },
@@ -3209,11 +3072,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.2.1.tgz",
-      "integrity": "sha512-ydF0DpmE0D6wccAbxx1F+6kokzcSSRy3X78Bvgok/3fHUSSshGLErqNiQL1HV44OIcV6392P3tu/jtXtUq3UDQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.3.0.tgz",
+      "integrity": "sha512-nM9BL0t2Nxwbb41MXxNXTDL0zq7FXhOX9F3OiAqYUJHqb7BHyzV9KoQ+Ao1BjqJR91hUm1OFNgHAk3y8uiuq4w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3224,11 +3087,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.4.tgz",
-      "integrity": "sha512-l1qQvvygxZJw+S+4hgYgzvT4GArqBrar42wzB5LVsOy04+gmbDw/4y7IqxZYepFyXKuBownGS8pR4huRL/Tj/A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.6.0.tgz",
+      "integrity": "sha512-jkPdn83WV/TcnhQ5bOIoYcJGvMxXyYlCzbqfuB6HsMqf3CqpdgBQYlMuKi6qIfD4QWYt2R992yglNxPLuJ7xeg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0"
+        "@opentelemetry/instrumentation": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -3238,11 +3101,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.5.tgz",
-      "integrity": "sha512-fHJqrbezpZSipo4O9nF9yGq6R8oyr1W2gSlyk1foJNXBaqdCODTlzIa7BP50vGtLBN/m+qO8pMOWCJmYSBX35g==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.33.0.tgz",
+      "integrity": "sha512-QDJadJOQg9CLqMC79r4T5ugN4C4lb6eJYLmHgnLg3fh1JUGfyjQHtD3T7lH0P8251Mnt5m8zjDDbPKcqK2aGcw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.5.4"
       },
@@ -3254,12 +3117,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.34.1.tgz",
-      "integrity": "sha512-pQBQxXpkH6imvzwCdPcw2FKjB1cphoRpmWTiGi6vtBdKXCP0hpne613ycpwhGG7C17S+mbarVmukbJKR4rmh6Q==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.35.0.tgz",
+      "integrity": "sha512-ZmSB4WMd88sSecOL7DlghzdBl56/8ymb02n+xEJ/6zUgONuw/1uoTh1TAaNPKfEWdNLoLKXQm+Gd2zBrUVOX0w==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3270,12 +3133,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.6.tgz",
-      "integrity": "sha512-UkBu8rAqeVC034jsRMiEAmYhFQ03pvmE/MnoPKE9gAbgVtPILdekHYqAKM0MdqnEjW7pO45t4wWsbtIcN0eiBw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.33.0.tgz",
+      "integrity": "sha512-sl3q9Mt+yM6GlZJKhfLUIRrVEYqfmI0hqYLha5OFG5rLrgnZCCZVy8ra4+Pa40ecH1409cvwwBPf7k9AHEQBTw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3286,12 +3149,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.8.4.tgz",
-      "integrity": "sha512-g99963nK8TuisUM3KH+ee5hOCHdCHSKiAdmy0RMdiKT7ITh3rXUct7fghQibViQA7FVPkdwM9+uRKkigJSFS9w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.9.0.tgz",
+      "integrity": "sha512-Xp31lb2Sj50ppsJ393650HxSi5IJIgddXxrUeVljmsabdmECPUj0YAt/Wwb1oIHFn04iL9Tq4VkF/otlLaI9ww==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3302,11 +3165,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.5.tgz",
-      "integrity": "sha512-MNFloXa3SDg/rHh397JnWADr7iYQ6HHRwT7ZId5Vt0L1Xx+Qp3XSIILsXk5qTXVUIytEIVgn8iMT+kZILHzSqg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.33.0.tgz",
+      "integrity": "sha512-QMSSOfIqMJhXqFryLVbAMsgRktNHdhMEpsOgEiHurLfvAJhyEOBcTTUuo6Laqt50IIzIm3YuHL9ZtEl9fve2ag==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3317,11 +3180,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.36.1.tgz",
-      "integrity": "sha512-EOvaS+d2909TOJJjNTsb0vHaLg8WdTLoQS8bRKdy3lMgdd7I4OL9/LSC7dp4M8CvJKz9B464Ix9PnARvhMkNOw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.37.0.tgz",
+      "integrity": "sha512-WL5Qn1aRudJDxVN0Ao73/yzXBGBJAH1Fd2tteuGXku/Qw9hYQ936CgoO66GWmSiq2lyjsojAk1t5f+HF9j3NXw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0"
+        "@opentelemetry/instrumentation": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -3331,12 +3194,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.46.0.tgz",
-      "integrity": "sha512-KemIpB4jmywQv/+MbVoUIMVp3vr+rzra37TYbN7kTsbrn213YlzdXVamf6nq/yChI6q+9JlUnCdSZf86D6NO6g==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.48.0.tgz",
+      "integrity": "sha512-MmJHkbqaulqfECjotRtco9AXOq+D1HLq53wI7UFeE8bl8kISP9iMkt+A7PrtPFpRGCglwFvSa0djId6EWsP0DQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3345,21 +3208,13 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.3.tgz",
-      "integrity": "sha512-l14u1TFPXMUjfHqnrHtzuMyLq6V8BikwhYJO/hIgkbaPCxS38TloCtDLJvcs8S8AZlcQfkUqE/NFgXYETZRo+Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.34.0.tgz",
+      "integrity": "sha512-qUENVxwCYbRbJ8HBY54ZL1Z9q1guCEurW6tCFFJJKQFu/MKEw7GSFImy5DR2Mp8b5ggZO36lYFcx0QUxfy4GJg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.13"
       },
@@ -3371,13 +3226,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.46.0.tgz",
-      "integrity": "sha512-t5cxgqfV9AcxVP00/OL1ggkOSZM57VXDpvlWaOidYyyfLKcUJ9e2fGbNwoVsGFboRDeH0iFo7gLA3EEvX13wCA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.48.0.tgz",
+      "integrity": "sha512-uXqOsLhW9WC3ZlGm6+PSX0xjSDTCfy4CMjfYj6TPWusOO8dtdx040trOriF24y+sZmS3M+5UQc6/3/ZxBJh4Mw==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3387,20 +3242,12 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.36.1.tgz",
-      "integrity": "sha512-xxab7n4TD5igCFR5N0j5PJFYVeOXm54ZtCARVS32xavwGyGf+Sb6VtuVCLdl0re4JENCg18FO97Dyb1ql2EBUA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.37.0.tgz",
+      "integrity": "sha512-xBPfu03IIG8x1pmt1Dx+XrBO4ZB4UjEcrouGbp6eV3dLQ7eJPYZgfNXmsqkpsxgNQuVCi2a3WEAwZ5Wl2hk7Vw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
@@ -3413,11 +3260,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.4.tgz",
-      "integrity": "sha512-vqxK1wqhktQnBA7nGr6nqfhV5irSXK9v0R29hqlyTr/cB/86Hn3Z98zH58QvHo131FcE+d70QdiXu3P9S5vq4g==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.33.0.tgz",
+      "integrity": "sha512-7L3Q8Yy5vY4W4zpRrjKEc0OpVPYyERtDz5dAumKjkJsEVPANr7E8Cc+No6VjZGeN+HgFFwEo+jcQCTWJzdxvRw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3428,14 +3275,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.36.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.4.tgz",
-      "integrity": "sha512-Qt6IF0mo3FZZ+x4NQhv/pViDtPSw/h/QYDvyIqMCuqUibqta619WLUCwAcanKnZWvzMuYh6lT0TnZ8ktjXo6jQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.37.0.tgz",
+      "integrity": "sha512-EfuGv1RJCSZh77dDc3PtvZXGwcsTufn9tU6T9VOTFcxovpyJ6w0og73eD0D02syR8R+kzv6rg1TeS8+lj7pyrQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/koa": "2.13.9",
+        "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3"
       },
       "engines": {
@@ -3446,11 +3293,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.33.5.tgz",
-      "integrity": "sha512-vbm9QPEYD3FZNGSa+7xQ7uOkgbJtskIwp1KnsCpmdBBiulhBaqqgeNLFo7gd8UxMrI2Vu3LTlZil2D0dVt8g/A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.34.0.tgz",
+      "integrity": "sha512-m1kXrc11XNj7cC6sfcsYqd+kuCcN2wI9LXpB2l2BZCogqxHCgjuVoiXvT6K9LfO4tLefcvhoK0N8XuVJ8xyyOw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0"
+        "@opentelemetry/instrumentation": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -3460,11 +3307,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.5.tgz",
-      "integrity": "sha512-1MS9LfgZruAsWOHVDTI+/Wy9mFFivUlpGUwYC4D+ho1I4NUyE33XHwL1BKcjMupkuRnE0JmbhdBfTG9Ai1vFkw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.33.0.tgz",
+      "integrity": "sha512-TdGT5ytt8o7FTIsQvx010ykYbqu+IfGoOKA+IXLHdX1+l7vFWyv3ZOzQbRDmA4rxujJAAPf/n4/D7QECyedE/g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -3476,11 +3323,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.38.1.tgz",
-      "integrity": "sha512-X6YjE8dOCf8lG8FGmoAvczZq7LtgYaRzZcLGthZSUJQ2rfp1JJRlJixc+COvhrn1HJj5ab+AsSdUQgTpfQgEHQ==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.39.0.tgz",
+      "integrity": "sha512-m9dMj39pcCshzlfCEn2lGrlNo7eV5fb9pGBnPyl/Am9Crh7Or8vOqvByCNd26Dgf5J978zTdLGF+6tM8j1WOew==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3492,12 +3339,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.34.0.tgz",
-      "integrity": "sha512-/wGNK7qR/QXpcidXntKsnfACHETp8G/f2o/k8FPvJ2lukvdM9r7cHLys8QwkJkTN8Kt3qG1VIwarGKYtE/zOSw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.35.0.tgz",
+      "integrity": "sha512-gReBMWD2Oa/wBGRWyg6B2dbPHhgkpOqDio31gE3DbC4JaqCsMByyeix75rZSzZ71RQmVh3d4jRLsqUtNVBzcyg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3508,11 +3355,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.5.tgz",
-      "integrity": "sha512-cE8z1uJTeLcMj+R31t1pLkLqt3ryGMl1HApxsqqf8YCSHetrkVwGZOcyQ3phfgGSaNlC4/pdf3CQqfjhXbLWlA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.35.0.tgz",
+      "integrity": "sha512-QKRHd3aFA2vKOPzIZ9Q3UIxYeNPweB62HGlX2l3shOKrUhrtTg2/BzaKpHQBy2f2nO2mxTF/mOFeVEDeANnhig==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.22"
       },
@@ -3524,11 +3371,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.5.tgz",
-      "integrity": "sha512-Ai3+cJ83b11kLypIVEPLHuYCiIQjf828hHJPpllr78EhmHiq4S1yTW34aP3BzCBY+5Adr5PS5Nnv7NLBI/YfaQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.35.0.tgz",
+      "integrity": "sha512-DI9NXYJBbQ72rjz1KCKerQFQE+Z4xRDoyYek6JpITv5BlhPboA8zKkltxyQLL06Y2RTFYslw1gvg+x9CWlRzJw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0"
       },
@@ -3540,11 +3387,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.4.tgz",
-      "integrity": "sha512-AynD6TesE0bZg9UzS4ZLG//6TmU8GkRrjubhxs7jYZ3JRAlJAq1In0zSwM082JOIs7wr286nhs1FmqK91cG1cg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.34.0.tgz",
+      "integrity": "sha512-HvbcCVAMZEIFrJ0Si9AfjxOr14KcH5h/lq5zLQ8AjZJpW0WaeO/ox5UgFi3J73Br91WbZHRgbXxMeodNycJJuA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3555,11 +3402,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.5.tgz",
-      "integrity": "sha512-omBLTXyJeCtBy1MzVi+IzUcpXiup90k0z3AGhNKbzro4RhpsdMpN9O+3zZCXCIHMuyifhy7z8w99wmvvFO/FCQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.33.0.tgz",
+      "integrity": "sha512-x6awrqF0YfEhGGNE2JtEWvB+zEls7mFvLDii54DnWxpQU69+AqKCW/ZwC91EDefOMGSYBckL0uEn6XNOgkTTbw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3570,12 +3417,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.37.2.tgz",
-      "integrity": "sha512-MAiKqdtGItYjvD6rOCyGS27CdMaDnh2JuImIHXhrPjq/sb2JlBNm6m1e4BH4uik1VfcKt/I3pI3UkydSWIscCg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.38.0.tgz",
+      "integrity": "sha512-Q7V/OJ1OZwaWYNOP/E9S6sfS03Z+PNU1SAjdAoXTj5j4u4iJSMSieLRWXFaHwsbefIOMkYvA00EBKF9IgbgbLA==",
       "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
@@ -3589,11 +3435,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.5.tgz",
-      "integrity": "sha512-auYDSeFhkPFXayT/060mQRL7O88Bt5NKcV0qOfquNa9J5/qs5dlJYdTOraxPrjiGPM3tHaAJ+AvAhR0CPYgZew==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.35.0.tgz",
+      "integrity": "sha512-gMfJ5Qy793mbaAGnQE3yp1Cb0y4np74rBPu20Oy/v8TTgPQOEV5PyNI0GNGggmZQIJSkdtYa8Ndb3huH3iZE5g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0"
+        "@opentelemetry/instrumentation": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -3603,11 +3449,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.35.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.5.tgz",
-      "integrity": "sha512-UPYUncDlLqDPtyU11UhyZOUxAyPQS6yQGT0b96KjpqMhmuRb3b0WxzZh3SoIaAyprL5f9fxyeV2HfSulR0aWFQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.36.0.tgz",
+      "integrity": "sha512-rKFylIacEBwLxKFrPvxpVi8hHY9qXfQSybYnYNyF/VxUWMGYDPMpbCnTQkiVR5u+tIhwSvhSDG2YQEq6syHUIQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3619,11 +3465,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.35.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.6.tgz",
-      "integrity": "sha512-OVSUJZAuy6OX18X2TKPdPlpwM5t4FooJU9QXiUxezhdMvfIAu00Agchw+gRbszkM7nvQ9dkXFOZO3nTmJNcLcA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.36.0.tgz",
+      "integrity": "sha512-XO0EV2TxUsaRdcp79blyLGG5JWWl7NWVd/XNbU8vY7CuYUfRhWiTXYoM4PI+lwkAnUPvPtyiOzYs9px23GnibA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3635,12 +3481,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.3.tgz",
-      "integrity": "sha512-nUqf4RTcQyc/YTWMT0e/ZqvuQqhRH04MOoSwaH6ocmyrEhKdPDq9AbvSMerQ/AxNC9yju/PytgzFFWH45hh3KA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.35.0.tgz",
+      "integrity": "sha512-0ghtxsGJxHEwJfIzxDN3FCbNiTXqwv2jV6ip716jyjWN3f6MuRHm7NPWI/KNvu+IjqDj16KRGZG7nUAEB1ojog==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3651,11 +3497,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.4.tgz",
-      "integrity": "sha512-4140BgILsL0H8tA0BBN2tjzajgjxlDqd4xPatk2i5q9ofy8wlB0BlDJ4m36U7G1z0v+a+LshQSNqPP2VHZ9ORw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.34.0.tgz",
+      "integrity": "sha512-7LsonkdnQi35eF7CWl8394QDgyd811gCawJ6QuS8GbWNIvZ3S2f9j+Zy0fWSmFgO28ruW1pUG51ql8xdXWa8TA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3666,11 +3512,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-socket.io": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.35.0.tgz",
-      "integrity": "sha512-ED1/Wco05H9fepKqX7n2kONq9EXxkBZTKS29nUH9vVL7wSIT8sBIDqpHz94CnQ8xuicaQQ7c5h9TVuhjtzV43Q==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.36.0.tgz",
+      "integrity": "sha512-c9Zc6WKxTZtMaOj01kmJGLKabEj805YgTav4l9vgojHrf6MH1fTlw+SGvOKhfPfzmu2QhNORAfqPAB1poDwqEQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3681,11 +3527,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.5.tgz",
-      "integrity": "sha512-jjdrDegLUodz9np0yKCAa7sLxlAGTsxM7wU7l1mQ2NM6PHAGv4X3eSFClUk3fOipLx4+r5jTLnlsgu7g9CW+Qw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.7.0.tgz",
+      "integrity": "sha512-o/5my8ZOuxACPSzMaXdPnQiMpmOPIJoTj+DRcs4vEJxk+KwlVNucoafSMpWQEyTNNuq2JI87Ru6Di2mp5T20EQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.48.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.10"
       },
@@ -3697,11 +3543,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.33.1.tgz",
-      "integrity": "sha512-4tSORoAY9f+yzqNVGcGr/3GydPMfgSiKK1OESc+qBwVTz0bmz4cOrhCruCngGzoqDCmPYpwqwR/8j4wRKgcUpw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.34.0.tgz",
+      "integrity": "sha512-Ejssv6Uih7ipoNGYQLXd+cKZdEfTfTJ/vzpUSeYiJZ36mVYER1f8fs9Kb7jTKjHD55g2s6cUJj9lifbDFI4EEw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.46.0"
+        "@opentelemetry/instrumentation": "^0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -3711,11 +3557,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.46.0.tgz",
-      "integrity": "sha512-hfkh7cG17l77ZSLRAogz19SIJzr0KeC7xv5PDyTFbHFpwwoxV/bEViO49CqUFH6ckXB63NrltASP9R7po+ahTQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.48.0.tgz",
+      "integrity": "sha512-T4LJND+Ugl87GUONoyoQzuV9qCn4BFIPOnCH1biYqdGhc2JahjuLqVD9aefwLzGBW638iLAo88Lh68h2F1FLiA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3725,13 +3571,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
-      "integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.48.0.tgz",
+      "integrity": "sha512-Vdp56RK9OU+Oeoy3YQC/UMOWglKQ9qvgGr49FgF4r8vk5DlcTUgVS0m3KG8pykmRPA+5ZKaDuqwPw5aTvWmHFw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -3742,12 +3588,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.47.0.tgz",
-      "integrity": "sha512-SFVuzf3b7U9+5jfxqWrwsq/HlGF8CEKFe4avSFtEFpj8VOSRDOTYK6A641HEAHiQp/nTLlTHtV7djdp6ZyIUVw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.48.0.tgz",
+      "integrity": "sha512-14GSTvPZPfrWsB54fYMGb8v+Uge5xGXyz0r2rf4SzcRnO2hXCPHEuL3yyL50emaKPAY+fj29Dm0bweawe8UA6A==",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -3757,45 +3603,17 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
-      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
-      "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.46.0.tgz",
-      "integrity": "sha512-Fj9hZwr6xuqgsaERn667Uf6kuDG884puWhyrai2Jen2Fq+bGf4/5BzEJp/8xvty0VSU4EfXOto/ys3KpSz2UHg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.48.0.tgz",
+      "integrity": "sha512-yuoS4cUumaTK/hhxW3JUy3wl2U4keMo01cFDrUOmjloAdSSXvv1zyQ920IIH4lymp5Xd21Dj2/jq2LOro56TJg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3805,9 +3623,9 @@
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.5.tgz",
-      "integrity": "sha512-9ENyx6ptmjyYzL7le3FXk/lJc3cFFTrh9Y/ubO9velQZ64BdjpF9kOMJN3Z8KLJFVt66HYoWy9xlWoSIfS/ICg==",
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.6.tgz",
+      "integrity": "sha512-qvnYee5I/xrBY5XClUlOASIOdoTbnFGNI6+ViKqdoErF2xKmhysXcmxlJNzQFNDK0muTfjvJMZcFyEielARk7g==",
       "engines": {
         "node": ">=14"
       },
@@ -3830,11 +3648,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.19.0.tgz",
-      "integrity": "sha512-v7y5IBOKBm0vP3yf0DHzlw4L2gL6tZ0KeeMTaxfO5IuomMffDbrGWcvYFp0Dt4LdZctTSK523rVLBB9FBHBciQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.21.0.tgz",
+      "integrity": "sha512-3ZTobj2VDIOzLsIvvYCdpw6tunxUVElPxDvog9lS49YX4hohHeD84A8u9Ns/6UYUcaN5GSoEf891lzhcBFiOLA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3844,11 +3662,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.19.0.tgz",
-      "integrity": "sha512-dedkOoTzKg+nYoLWCMp0Im+wo+XkTRW6aXhi8VQRtMW/9SNJGOllCJSu8llToLxMDF0+6zu7OCrKkevAof2tew==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.21.0.tgz",
+      "integrity": "sha512-8TQSwXjBmaDx7JkxRD7hdmBmRK2RGRgzHX1ArJfJhIc5trzlVweyorzqQrXOvqVEdEg+zxUMHkL5qbGH/HDTPA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3866,9 +3684,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.5.tgz",
-      "integrity": "sha512-cobe2I0c5a66d98nCBprEB5erN5S0PTRrs49qSOnuTT2dC90nwSo2WDcSBfeDSKZH/7sB686P7FyKefWjQzhoA==",
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.6.tgz",
+      "integrity": "sha512-VuJXc+oDQ/SYRHBCQbEshl0WJtEMvgfSkTDBq+WSxj6y9sKe0HCt55Sxeb5nLmBdtCYWMQFniHe2K4GLSjDZVw==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -3881,9 +3699,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.5.tgz",
-      "integrity": "sha512-0GZJi8m6czksDJwpndSYJpnaPaFe83nEQVg4UnTTwB0cxKtrjpaarWDI46X0BuCX4bGp0M8pvI7f0rBt+LsIhA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.6.tgz",
+      "integrity": "sha512-hFJ19yFwChqGCv1uMkXtjZU9BG8GcChe8cRCAkGWg1RZADse5S2ausf3D8pYw1cR3ktJtuAmRrGZniT6TDUPDw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -3897,9 +3715,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.5.tgz",
-      "integrity": "sha512-yLGLueH63DE9/WmDrizleqtT0uCOsslNqW+AcwzMHW7t8c2MtoJ7msgIsmi7tz5kxJgG8o54CnvXxobcwBhLCQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.6.tgz",
+      "integrity": "sha512-psxtzQakVuZKFl/ukn+nPW4Ixn+KPHGsWJMYKndmXrsgdFri78X+MHR0wLOO41Zn79sc35DiSk+GdJ24cCylbg==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -3912,9 +3730,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.5.tgz",
-      "integrity": "sha512-cYckfRDDNX/nhiMF7fFooOCb/EObydNXWi0HwuPELHYa7heBCkWgTtNxs/PzuP46+FqDjuBcJL6beS2Ef7MyWg==",
+      "version": "0.29.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.6.tgz",
+      "integrity": "sha512-cx03fXPknmiVW0hpWAJr0Nr8xwkwRB8VNWPvNrmP7UzJ8eEztY9lHnVke4ZVFaVGvm/4EFxk2y5hPNggbIezoA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -3929,12 +3747,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.19.0.tgz",
-      "integrity": "sha512-RgxvKuuMOf7nctOeOvpDjt2BpZvZGr9Y0vf7eGtY5XYZPkh2p7e2qub1S2IArdBMf9kEbz0SfycqCviOu9isqg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
+      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3943,21 +3761,13 @@
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.46.0.tgz",
-      "integrity": "sha512-Knlyk4+G72uEzNh6GRN1Fhmrj+/rkATI5/lOrevN7zRDLgp4kfyZBGGoWk7w+qQjlYvwhIIdPVxlIcipivdZIg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.48.0.tgz",
+      "integrity": "sha512-lRcA5/qkSJuSh4ItWCddhdn/nNbVvnzM+cm9Fg1xpZUeTeozjJDBcHnmeKoOaWRnrGYBdz6UTY6bynZR9aBeAA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -3968,12 +3778,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
-      "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.21.0.tgz",
+      "integrity": "sha512-on1jTzIHc5DyWhRP+xpf+zrgrREXcHBH4EDAfaB5mIG7TWpKxNXooQ1JCylaPsswZUv4wGnVTinr4HrBdGARAQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
@@ -3984,23 +3794,23 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.46.0.tgz",
-      "integrity": "sha512-BQhzdCRZXchhKjZaFkgxlgoowjOt/QXekJ1CZgfvFO9Yg5GV15LyJFUEyQkDyD8XbshGo3Cnj0WZMBnDWtWY1A==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.48.0.tgz",
+      "integrity": "sha512-3o3GS6t+VLGVFCV5bqfGOcWIgOdkR/UE6Qz7hHksP5PXrVBeYsPqts7cPma5YXweaI3r3h26mydg9PqQIcqksg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -4009,57 +3819,14 @@
         "@opentelemetry/api": ">=1.3.0 <1.8.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.46.0.tgz",
-      "integrity": "sha512-A7PftDM57w1TLiirrhi8ceAnCpYkpUBObELdn239IyYF67zwngImGfBLf5Yo3TTAOA2Oj1TL76L8zWVL8W+Suw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.46.0.tgz",
-      "integrity": "sha512-rEJBA8U2AxfEzrdIUcyyjOweyVFkO6V1XAxwP161JkxpvNuVDdULHAfRVnGtoZhiVA1XsJKcpIIq2MEKAqq4cg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.19.0.tgz",
-      "integrity": "sha512-+IRvUm+huJn2KqfFW3yW/cjvRwJ8Q7FzYHoUNx5Fr0Lws0LxjMJG1uVB8HDpLwm7mg5XXH2M5MF+0jj5cM8BpQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
+      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -4068,24 +3835,16 @@
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.19.0.tgz",
-      "integrity": "sha512-TCiEq/cUjM15RFqBRwWomTVbOqzndWL4ILa7ZCu0zbjU1/XY6AgHkgrgAc7vGP6TjRqH4Xryuglol8tcIfbBUQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.21.0.tgz",
+      "integrity": "sha512-1pdm8jnqs+LuJ0Bvx6sNL28EhC8Rv7NYV8rnoXq3GIQo7uOHBDAFSj7makAfbakrla7ecO1FRfI8emnR4WvhYA==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/propagator-jaeger": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/propagator-jaeger": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -4096,9 +3855,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
-      "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
+      "integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
       "engines": {
         "node": ">=14"
       }
@@ -4184,9 +3943,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -4350,9 +4109,9 @@
       "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
     },
     "node_modules/@types/cookies": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.10.tgz",
-      "integrity": "sha512-hmUCjAk2fwZVPPkkPBcI7jGLIR5mg4OVoNMBwU6aVsMm/iNPY7z9/R+x2fSwLt/ZXoGua6C5Zy2k5xOo9jUyhQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
+      "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -4513,9 +4272,9 @@
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
     },
     "node_modules/@types/koa": {
-      "version": "2.13.9",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.9.tgz",
-      "integrity": "sha512-tPX3cN1dGrMn+sjCDEiQqXH2AqlPoPd594S/8zxwUm/ZbPsQXKqHPUypr2gjCPhHUc+nDJLduhh5lXI/1olnGQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.14.0.tgz",
+      "integrity": "sha512-DTDUyznHGNHAl+wd1n0z1jxNajduyTh8R53xoewuerdBzGo6Ogj6F2299BFtrexJw4NtgjsI5SMPCmV9gZwGXA==",
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -8461,13 +8220,13 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -10339,9 +10098,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12406,321 +12165,16 @@
         "@dotcom-reliability-kit/app-info": "^3.0.1",
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.40.2",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",
-        "@opentelemetry/resources": "^1.19.0",
-        "@opentelemetry/sdk-node": "^0.47.0",
-        "@opentelemetry/sdk-trace-base": "^1.19.0",
-        "@opentelemetry/semantic-conventions": "^1.20.0"
+        "@opentelemetry/auto-instrumentations-node": "^0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",
+        "@opentelemetry/resources": "^1.21.0",
+        "@opentelemetry/sdk-node": "^0.48.0",
+        "@opentelemetry/sdk-trace-base": "^1.21.0",
+        "@opentelemetry/semantic-conventions": "^1.21.0"
       },
       "engines": {
         "node": "18.x || 20.x",
         "npm": "8.x || 9.x || 10.x"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/api-logs": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
-      "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.20.0.tgz",
-      "integrity": "sha512-PNecg4zvRF5y5h3luK/hzUEmgZtZ8hbX19TMALj3SVShYS2MrDZG6uT27uLkAwACMfK9BP7/UyXXjND5lkaC2w==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
-      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.47.0.tgz",
-      "integrity": "sha512-cWy713Wb3WzuBDyhYiLONF2Ojmn6H2Agn/CiIerMypeMIFyhfO3fPm5cA1qSew+6s3115dwrXGw8kQLtfb/xlA==",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.47.0.tgz",
-      "integrity": "sha512-TUSlzSHswJSWVxPx89oF6tOqT9tn+s7/15ED3Hi4Qa17CBmZbJxQ3Bn1j7F5kpBpyPOWjGSdSooOPYCgGsF6Jw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.20.0.tgz",
-      "integrity": "sha512-CnbkOhvUebOzri1WyGkkdlWIj5AJAhEIRh/ubuT2V48NypXUUCnbrBKN1Aw4pj+wQAkPelYJ6cW42sBdBuOFPg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.47.0.tgz",
-      "integrity": "sha512-ZFhphFbowWwMahskn6BBJgMm8Z+TUx98IM+KpLIX3pwCK/zzgbCgwsJXRnjF9edDkc5jEhA7cEz/mP0CxfQkLA==",
-      "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "^1.7.2",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
-      "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.47.0.tgz",
-      "integrity": "sha512-iejk7A+82fWpIvGA+rxi9MYGJLvu4e6DGhfJeBiUfrqLnyQEUUFAjprWTN85JuEJHMoqB7/IUiitve01vuNZQQ==",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
-      "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.20.0.tgz",
-      "integrity": "sha512-rDLcZGhhe+VoKKY77U5o5IW5D+OMoXg44GYmCn68Jx3O5TBGMJ2oZBcCxLgHlAA/ZdqkdRgQD0E40s8bXq41JA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.20.0.tgz",
-      "integrity": "sha512-JqdKlyyrgIinR8ZhMoJrL54AAHMDEACLLXYLnabzFTHeoBEsC36ZoO98hVucrpUvkDCJMvdVHH/4cvvj+boUzg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/resources": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
-      "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
-      "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": ">=0.39.1"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
-      "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/sdk-node": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.47.0.tgz",
-      "integrity": "sha512-xUkVKcg/GzMgGlZPN43U5rCQLnWe/IQLPcUBptsDFD/JW1C9i3D8MepoSDjNunrOPHKZgpSNzx09Qlyzs9RgSQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
-      "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.20.0.tgz",
-      "integrity": "sha512-3RRl4O63Wr/QyWhjreB7xilFhj3cQHWuMqESPwWHb7eJogNmjj1JQsRda/i8xj1Td4Bk+2ojC7aA8mwbKbEfPQ==",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/propagator-jaeger": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "packages/opentelemetry/node_modules/import-in-the-middle": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
-      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
       }
     },
     "packages/serialize-error": {

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -187,6 +187,8 @@ Some details about how we're implementing OpenTelemetry. This is to help avoid a
 
   * We don't instrument file system operations because we don't find these useful. If you would like traces for file system operations then let us know and we can add a configuration.
 
+  * It's less of _our_ implementation detail and more a note on the [OpenTelemetry Node.js SDK](https://github.com/open-telemetry/opentelemetry-js). Native ES Modules cannot be auto-instrumented without the `--experimental-loader` Node.js option. [Documentation is here](https://www.npmjs.com/package/@opentelemetry/instrumentation?activeTab=readme#instrumentation-for-es-modules-in-nodejs-experimental).
+
 ### Configuration options
 
 Depending on the way you set up OpenTelemetry, you can either configure it via environment variables or options passed into an object.

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -19,11 +19,11 @@
 		"@dotcom-reliability-kit/app-info": "^3.0.1",
 		"@dotcom-reliability-kit/logger": "^3.0.3",
 		"@opentelemetry/api": "^1.7.0",
-		"@opentelemetry/auto-instrumentations-node": "^0.40.2",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",
-		"@opentelemetry/resources": "^1.19.0",
-		"@opentelemetry/sdk-node": "^0.47.0",
-		"@opentelemetry/sdk-trace-base": "^1.19.0",
-		"@opentelemetry/semantic-conventions": "^1.20.0"
+		"@opentelemetry/auto-instrumentations-node": "^0.41.0",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",
+		"@opentelemetry/resources": "^1.21.0",
+		"@opentelemetry/sdk-node": "^0.48.0",
+		"@opentelemetry/sdk-trace-base": "^1.21.0",
+		"@opentelemetry/semantic-conventions": "^1.21.0"
 	}
 }


### PR DESCRIPTION
I need to do this manually for now until we merge #912. There's a breaking change in 0.48 but it's only re-removing experimental support for ESM modules, not something we use. However I thought it'd be worth adding a note to the README about this gotcha.