### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.0.1",
-  "packages/crash-handler": "4.0.3",
+  "packages/app-info": "3.0.2",
+  "packages/crash-handler": "4.0.4",
   "packages/errors": "3.0.1",
   "packages/eslint-config": "3.0.1",
   "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.3",
-  "packages/logger": "3.0.3",
-  "packages/middleware-log-errors": "4.0.3",
-  "packages/middleware-render-error-info": "5.0.3",
+  "packages/log-error": "4.0.4",
+  "packages/logger": "3.0.4",
+  "packages/middleware-log-errors": "4.0.4",
+  "packages/middleware-render-error-info": "5.0.4",
   "packages/serialize-error": "3.0.1",
   "packages/serialize-request": "3.0.1",
-  "packages/opentelemetry": "1.0.0"
+  "packages/opentelemetry": "1.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12257,7 +12257,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x",
@@ -12266,10 +12266,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.3"
+        "@dotcom-reliability-kit/log-error": "^4.0.4"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -12321,11 +12321,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.3",
+        "@dotcom-reliability-kit/app-info": "^3.0.2",
+        "@dotcom-reliability-kit/logger": "^3.0.4",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "@dotcom-reliability-kit/serialize-request": "^3.0.1"
       },
@@ -12339,10 +12339,10 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.1",
+        "@dotcom-reliability-kit/app-info": "^3.0.2",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^8.19.0"
@@ -12363,10 +12363,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.3"
+        "@dotcom-reliability-kit/log-error": "^4.0.4"
       },
       "devDependencies": {
         "@financial-times/n-express": "^29.0.0",
@@ -12380,11 +12380,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.1",
-        "@dotcom-reliability-kit/log-error": "^4.0.3",
+        "@dotcom-reliability-kit/app-info": "^3.0.2",
+        "@dotcom-reliability-kit/log-error": "^4.0.4",
         "@dotcom-reliability-kit/serialize-error": "^3.0.1",
         "entities": "^4.5.0"
       },
@@ -12398,12 +12398,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.1",
+        "@dotcom-reliability-kit/app-info": "^3.0.2",
         "@dotcom-reliability-kit/errors": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.3",
+        "@dotcom-reliability-kit/logger": "^3.0.4",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/auto-instrumentations-node": "^0.41.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.1...app-info-v3.0.2) (2024-02-19)
+
+
+### Bug Fixes
+
+* add manual types for app-info ([e36bb9e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e36bb9ee20e7a75c5301bfcceb15018242caaaf4))
+* correct the types for the app-info package ([86cd542](https://github.com/Financial-Times/dotcom-reliability-kit/commit/86cd54280fdfa3482a1ca81a5474301714031f63))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.0...app-info-v3.0.1) (2024-01-09)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.3...crash-handler-v4.0.4) (2024-02-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
+
 ## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.2...crash-handler-v4.0.3) (2024-01-22)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.3"
+    "@dotcom-reliability-kit/log-error": "^4.0.4"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,16 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.3...log-error-v4.0.4) (2024-02-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
+    * @dotcom-reliability-kit/logger bumped from ^3.0.3 to ^3.0.4
+
 ## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.2...log-error-v4.0.3) (2024-01-22)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/logger": "^3.0.3",
+    "@dotcom-reliability-kit/app-info": "^3.0.2",
+    "@dotcom-reliability-kit/logger": "^3.0.4",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "@dotcom-reliability-kit/serialize-request": "^3.0.1"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,21 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.3...logger-v3.0.4) (2024-02-19)
+
+
+### Bug Fixes
+
+* bump pino from 8.17.2 to 8.19.0 ([9c80a44](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9c80a447b1a5c3e6820c03afb48ef68e2d1c728b))
+* get the types working with most modules ([0323c02](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0323c0236edabe72ef31c5e91dbb0dc76fce396a))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
+
 ## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.2...logger-v3.0.3) (2024-01-22)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.1",
+    "@dotcom-reliability-kit/app-info": "^3.0.2",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^8.19.0"

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.3...middleware-log-errors-v4.0.4) (2024-02-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
+
 ## [4.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.2...middleware-log-errors-v4.0.3) (2024-01-22)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.3"
+    "@dotcom-reliability-kit/log-error": "^4.0.4"
   },
   "devDependencies": {
     "@financial-times/n-express": "^29.0.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,16 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [5.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.3...middleware-render-error-info-v5.0.4) (2024-02-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
+
 ## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.2...middleware-render-error-info-v5.0.3) (2024-01-22)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.1",
-    "@dotcom-reliability-kit/log-error": "^4.0.3",
+    "@dotcom-reliability-kit/app-info": "^3.0.2",
+    "@dotcom-reliability-kit/log-error": "^4.0.4",
     "@dotcom-reliability-kit/serialize-error": "^3.0.1",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.0...opentelemetry-v1.0.1) (2024-02-19)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([48418fa](https://github.com/Financial-Times/dotcom-reliability-kit/commit/48418faa415ce9242a0664ab9ec682a224d501d4))
+* handle invalid URLs in the request filter ([ade80ff](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ade80ff8c9ab622d6eb911891870d85923a0c6d9))
+* update all OpenTelemetry packages ([bf460e5](https://github.com/Financial-Times/dotcom-reliability-kit/commit/bf460e5d69804decffc7bc3b650a1acd79581a25))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
+    * @dotcom-reliability-kit/logger bumped from ^3.0.3 to ^3.0.4
+
 ## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v0.2.1...opentelemetry-v1.0.0) (2024-01-22)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -16,9 +16,9 @@
 	},
 	"main": "lib",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.0.1",
+		"@dotcom-reliability-kit/app-info": "^3.0.2",
 		"@dotcom-reliability-kit/errors": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.3",
+		"@dotcom-reliability-kit/logger": "^3.0.4",
 		"@opentelemetry/api": "^1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.41.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.1...app-info-v3.0.2) (2024-02-19)


### Bug Fixes

* add manual types for app-info ([e36bb9e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e36bb9ee20e7a75c5301bfcceb15018242caaaf4))
* correct the types for the app-info package ([86cd542](https://github.com/Financial-Times/dotcom-reliability-kit/commit/86cd54280fdfa3482a1ca81a5474301714031f63))
</details>

<details><summary>crash-handler: 4.0.4</summary>

## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.3...crash-handler-v4.0.4) (2024-02-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
</details>

<details><summary>log-error: 4.0.4</summary>

## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.3...log-error-v4.0.4) (2024-02-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
    * @dotcom-reliability-kit/logger bumped from ^3.0.3 to ^3.0.4
</details>

<details><summary>logger: 3.0.4</summary>

## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.3...logger-v3.0.4) (2024-02-19)


### Bug Fixes

* bump pino from 8.17.2 to 8.19.0 ([9c80a44](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9c80a447b1a5c3e6820c03afb48ef68e2d1c728b))
* get the types working with most modules ([0323c02](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0323c0236edabe72ef31c5e91dbb0dc76fce396a))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
</details>

<details><summary>middleware-log-errors: 4.0.4</summary>

## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.3...middleware-log-errors-v4.0.4) (2024-02-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
</details>

<details><summary>middleware-render-error-info: 5.0.4</summary>

## [5.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.3...middleware-render-error-info-v5.0.4) (2024-02-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
    * @dotcom-reliability-kit/log-error bumped from ^4.0.3 to ^4.0.4
</details>

<details><summary>opentelemetry: 1.0.1</summary>

## [1.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.0...opentelemetry-v1.0.1) (2024-02-19)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([48418fa](https://github.com/Financial-Times/dotcom-reliability-kit/commit/48418faa415ce9242a0664ab9ec682a224d501d4))
* handle invalid URLs in the request filter ([ade80ff](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ade80ff8c9ab622d6eb911891870d85923a0c6d9))
* update all OpenTelemetry packages ([bf460e5](https://github.com/Financial-Times/dotcom-reliability-kit/commit/bf460e5d69804decffc7bc3b650a1acd79581a25))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.1 to ^3.0.2
    * @dotcom-reliability-kit/logger bumped from ^3.0.3 to ^3.0.4
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).