### PR TITLE
fix: handle invalid URLs in the request filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12026,6 +12026,7 @@
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.1",
+        "@dotcom-reliability-kit/errors": "^3.0.1",
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/auto-instrumentations-node": "^0.41.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -17,6 +17,7 @@
 	"main": "lib",
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.0.1",
+		"@dotcom-reliability-kit/errors": "^3.0.1",
 		"@dotcom-reliability-kit/logger": "^3.0.3",
 		"@opentelemetry/api": "^1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.41.0",


### PR DESCRIPTION
Request URLs can still be invalid and make it all the way into our filter. One way you can cause this error to occur is by not setting a `host` header. We don't want errors to be logged for this so I'm now logging a warning with details about the URL that failed to be parsed.