### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.0.2",
-  "packages/crash-handler": "4.0.4",
+  "packages/crash-handler": "4.0.5",
   "packages/errors": "3.0.1",
-  "packages/eslint-config": "3.0.1",
+  "packages/eslint-config": "3.0.2",
   "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.4",
-  "packages/logger": "3.0.4",
-  "packages/middleware-log-errors": "4.0.4",
-  "packages/middleware-render-error-info": "5.0.4",
-  "packages/serialize-error": "3.0.1",
-  "packages/serialize-request": "3.0.1",
-  "packages/opentelemetry": "1.0.1"
+  "packages/log-error": "4.0.5",
+  "packages/logger": "3.0.5",
+  "packages/middleware-log-errors": "4.0.5",
+  "packages/middleware-render-error-info": "5.0.5",
+  "packages/serialize-error": "3.0.2",
+  "packages/serialize-request": "3.0.2",
+  "packages/opentelemetry": "1.0.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12780,10 +12780,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.4"
+        "@dotcom-reliability-kit/log-error": "^4.0.5"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -12801,7 +12801,7 @@
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^8.56.6"
@@ -12835,13 +12835,13 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/logger": "^3.0.4",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.1",
-        "@dotcom-reliability-kit/serialize-request": "^3.0.1"
+        "@dotcom-reliability-kit/logger": "^3.0.5",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+        "@dotcom-reliability-kit/serialize-request": "^3.0.2"
       },
       "devDependencies": {
         "@types/express": "^4.17.21"
@@ -12853,11 +12853,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.1",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^8.19.0"
       },
@@ -12877,10 +12877,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.4"
+        "@dotcom-reliability-kit/log-error": "^4.0.5"
       },
       "devDependencies": {
         "@financial-times/n-express": "^30.2.0",
@@ -12894,12 +12894,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/log-error": "^4.0.4",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.1",
+        "@dotcom-reliability-kit/log-error": "^4.0.5",
+        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
         "entities": "^4.5.0"
       },
       "devDependencies": {
@@ -12912,12 +12912,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
         "@dotcom-reliability-kit/errors": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.4",
+        "@dotcom-reliability-kit/logger": "^3.0.5",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.43.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.49.1",
@@ -12933,7 +12933,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x",
@@ -12942,7 +12942,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.21"

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -102,6 +102,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.4...crash-handler-v4.0.5) (2024-03-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
+
 ## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.3...crash-handler-v4.0.4) (2024-02-19)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.4"
+    "@dotcom-reliability-kit/log-error": "^4.0.5"
   }
 }

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.1...eslint-config-v3.0.2) (2024-03-22)
+
+
+### Bug Fixes
+
+* add type declarations for eslint-config ([dc7bedc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dc7bedca4a17d444d59363fdf8b813e1320b78e4))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.0...eslint-config-v3.0.1) (2024-01-09)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/eslint-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production",
   "repository": {
     "type": "git",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -87,6 +87,17 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
 
+## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.4...log-error-v4.0.5) (2024-03-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.4 to ^3.0.5
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
+    * @dotcom-reliability-kit/serialize-request bumped from ^3.0.1 to ^3.0.2
+
 ## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.3...log-error-v4.0.4) (2024-02-19)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,9 +17,9 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/logger": "^3.0.4",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.1",
-    "@dotcom-reliability-kit/serialize-request": "^3.0.1"
+    "@dotcom-reliability-kit/logger": "^3.0.5",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+    "@dotcom-reliability-kit/serialize-request": "^3.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21"

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -18,6 +18,15 @@
   * dependencies
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
 
+## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.4...logger-v3.0.5) (2024-03-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
+
 ## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.3...logger-v3.0.4) (2024-02-19)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.1",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^8.19.0"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -114,6 +114,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.4...middleware-log-errors-v4.0.5) (2024-03-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
+
 ## [4.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.3...middleware-log-errors-v4.0.4) (2024-02-19)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.4"
+    "@dotcom-reliability-kit/log-error": "^4.0.5"
   },
   "devDependencies": {
     "@financial-times/n-express": "^30.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -106,6 +106,16 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
 
+## [5.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.4...middleware-render-error-info-v5.0.5) (2024-03-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
+
 ## [5.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.3...middleware-render-error-info-v5.0.4) (2024-02-19)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/log-error": "^4.0.4",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.1",
+    "@dotcom-reliability-kit/log-error": "^4.0.5",
+    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
     "entities": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.1...opentelemetry-v1.0.2) (2024-03-22)
+
+
+### Bug Fixes
+
+* bump all OpenTelemetry packages ([92ee099](https://github.com/Financial-Times/dotcom-reliability-kit/commit/92ee099e130f64e648a49475cac9d54f99c108ab))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.4 to ^3.0.5
+
 ## [1.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.0...opentelemetry-v1.0.1) (2024-02-19)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.0.2",
 		"@dotcom-reliability-kit/errors": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.4",
+		"@dotcom-reliability-kit/logger": "^3.0.5",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.43.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.49.1",

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.1...serialize-error-v3.0.2) (2024-03-22)
+
+
+### Bug Fixes
+
+* add type declarations for serialize-error ([8909075](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8909075fe882f9e2e594aca5c071bc82b2edabaa))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.0...serialize-error-v3.0.1) (2024-01-09)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",

--- a/packages/serialize-request/CHANGELOG.md
+++ b/packages/serialize-request/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.1...serialize-request-v3.0.2) (2024-03-22)
+
+
+### Bug Fixes
+
+* add type declarations for serialize-request ([b45d3e4](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b45d3e42cda481d898eadebf4aadab0e9b2db823))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.0...serialize-request-v3.0.1) (2024-01-09)
 
 

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-request",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.0.5</summary>

## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.4...crash-handler-v4.0.5) (2024-03-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
</details>

<details><summary>eslint-config: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.1...eslint-config-v3.0.2) (2024-03-22)


### Bug Fixes

* add type declarations for eslint-config ([dc7bedc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dc7bedca4a17d444d59363fdf8b813e1320b78e4))
</details>

<details><summary>log-error: 4.0.5</summary>

## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.4...log-error-v4.0.5) (2024-03-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.4 to ^3.0.5
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
    * @dotcom-reliability-kit/serialize-request bumped from ^3.0.1 to ^3.0.2
</details>

<details><summary>logger: 3.0.5</summary>

## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.4...logger-v3.0.5) (2024-03-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
</details>

<details><summary>middleware-log-errors: 4.0.5</summary>

## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.4...middleware-log-errors-v4.0.5) (2024-03-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
</details>

<details><summary>middleware-render-error-info: 5.0.5</summary>

## [5.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.4...middleware-render-error-info-v5.0.5) (2024-03-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.4 to ^4.0.5
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.1 to ^3.0.2
</details>

<details><summary>opentelemetry: 1.0.2</summary>

## [1.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.1...opentelemetry-v1.0.2) (2024-03-22)


### Bug Fixes

* bump all OpenTelemetry packages ([92ee099](https://github.com/Financial-Times/dotcom-reliability-kit/commit/92ee099e130f64e648a49475cac9d54f99c108ab))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.4 to ^3.0.5
</details>

<details><summary>serialize-error: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.1...serialize-error-v3.0.2) (2024-03-22)


### Bug Fixes

* add type declarations for serialize-error ([8909075](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8909075fe882f9e2e594aca5c071bc82b2edabaa))
</details>

<details><summary>serialize-request: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.1...serialize-request-v3.0.2) (2024-03-22)


### Bug Fixes

* add type declarations for serialize-request ([b45d3e4](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b45d3e42cda481d898eadebf4aadab0e9b2db823))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).