### PR TITLE
fix: add type declarations for serialize-error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ packages/logger/**/*.d.*
 packages/middleware-log-errors/**/*.d.*
 packages/middleware-render-error-info/**/*.d.*
 packages/opentelemetry/**/*.d.*
-packages/serialize-error/**/*.d.*
 coverage
 node_modules/
 resources/logos/dist

--- a/jsconfig.build.json
+++ b/jsconfig.build.json
@@ -16,7 +16,6 @@
 		"packages/logger/**/*.js",
 		"packages/middleware-log-errors/**/*.js",
 		"packages/middleware-render-error-info/**/*.js",
-		"packages/opentelemetry/**/*.js",
-		"packages/serialize-error/**/*.js"
+		"packages/opentelemetry/**/*.js"
 	]
 }

--- a/packages/serialize-error/.npmignore
+++ b/packages/serialize-error/.npmignore
@@ -1,5 +1,3 @@
-!*.d.ts
-!*.d.ts.map
 CHANGELOG.md
 docs
 test

--- a/packages/serialize-error/lib/index.js
+++ b/packages/serialize-error/lib/index.js
@@ -1,39 +1,10 @@
 const crypto = require('node:crypto');
 
 /**
- * @typedef {object} SerializedError
- * @property {string | null} fingerprint
- *     A hash of the first part of the error stack, used to help group errors that occurred in
- *     the same part of the codebase. The fingerprint is null if the error does not include a
- *     stack trace.
- * @property {string} name
- *     The name of the class that the error is an instance of.
- * @property {string} code
- *     A machine-readable error code which identifies the specific type of error.
- * @property {string} message
- *     A human readable message which describes the error.
- * @property {boolean} isOperational
- *     Whether the error is operational, as in it's an error we expect sometimes as part of running the application.
- * @property {string[]} relatesToSystems
- *     An array of FT system codes which are related to this error.
- * @property {(Error | null)} cause
- *     The root cause error instance.
- * @property {(string | null)} stack
- *     The full error stack.
- * @property {(number | null)} statusCode
- *     An HTTP status code to represent the error.
- * @property {{[key: string]: any}} data
- *     Any additional error information.
- */
-
-/**
  * Serialize an error object so that it can be consistently logged or output as JSON.
  *
- * @public
- * @param {(string | Error & Record<string, any>)} error
- *     The error object to serialize.
- * @returns {SerializedError}
- *     Returns the serialized error object.
+ * @param {import('@dotcom-reliability-kit/serialize-error').ErrorLike} error
+ * @returns {import('@dotcom-reliability-kit/serialize-error').SerializedError}
  */
 function serializeError(error) {
 	if (typeof error !== 'object' || Array.isArray(error) || error === null) {
@@ -105,11 +76,8 @@ function serializeError(error) {
 /**
  * Create a new serialized error object.
  *
- * @private
  * @param {Record<string, any>} properties
- *     The properties of the serialized error.
- * @returns {SerializedError}
- *     Returns the serialized error object.
+ * @returns {import('@dotcom-reliability-kit/serialize-error').SerializedError}
  */
 function createSerializedError(properties) {
 	return Object.assign(
@@ -131,6 +99,4 @@ function createSerializedError(properties) {
 }
 
 module.exports = serializeError;
-
-// @ts-ignore
 module.exports.default = module.exports;

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -14,5 +14,6 @@
     "node": "18.x || 20.x",
     "npm": "8.x || 9.x || 10.x"
   },
-  "main": "lib"
+  "main": "lib/index.js",
+  "types": "types/index.d.ts"
 }

--- a/packages/serialize-error/types/index.d.ts
+++ b/packages/serialize-error/types/index.d.ts
@@ -1,0 +1,22 @@
+declare module '@dotcom-reliability-kit/serialize-error' {
+	export type ErrorLike = string | (Error & Record<string, any>);
+
+	export type SerializedError = {
+		fingerprint: string | null;
+		name: string;
+		code: string;
+		message: string;
+		isOperational: boolean;
+		relatesToSystems: string[];
+		cause: Error | null;
+		stack: string | null;
+		statusCode: number | null;
+		data: {
+			[key: string]: any;
+		};
+	};
+
+	export default function serializeError(error: ErrorLike): SerializedError;
+
+	export = serializeError;
+}

--- a/scripts/clean-generated-types.sh
+++ b/scripts/clean-generated-types.sh
@@ -9,4 +9,3 @@ find ./packages/logger -name "*.d.ts*" | xargs -r rm
 find ./packages/middleware-log-errors -name "*.d.ts*" | xargs -r rm
 find ./packages/middleware-render-error-info -name "*.d.ts*" | xargs -r rm
 find ./packages/opentelemetry -name "*.d.ts*" | xargs -r rm
-find ./packages/serialize-error -name "*.d.ts*" | xargs -r rm


### PR DESCRIPTION
This adds manual type declarations for serialize-error which should make it work in most projects.

See-also: [CPREL-985](https://financialtimes.atlassian.net/browse/CPREL-985)

[CPREL-985]: https://financialtimes.atlassian.net/browse/CPREL-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ