### PR TITLE
chore: remove unnecessary npmignore entries

### DIFF
--- a/packages/app-info/.npmignore
+++ b/packages/app-info/.npmignore
@@ -1,5 +1,3 @@
-!*.d.ts
-!*.d.ts.map
 CHANGELOG.md
 docs
 test


### PR DESCRIPTION
Now that we're using manual type declarations in app-info we don't need to unignore the files - they're no longer ignored in the root-level gitignore file.