### PR TITLE
DEMO Do not merge: add metric reader with oTel exporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@commitlint/cli": "^18.6.0",
         "@commitlint/config-conventional": "^18.6.0",
         "@financial-times/eslint-config-next": "^7.1.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
+        "@opentelemetry/sdk-metrics": "^1.22.0",
         "@types/jest": "^29.5.11",
         "eslint": "^8.56.0",
         "eslint-plugin-jsdoc": "^48.0.4",
@@ -2889,6 +2891,305 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-t/sWYqfcwn81SvYHIyYJDlJD2CjFz3/h2t4j+XCtdoHAfu+WVJQmwLsGYJPlCDp3UXQfFpMJMWvLlvtD2SL+rg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-xKI6aCRY+STxbF7PA+6YNNYWFf6IS065rZZeqlqvqQsp0HaFUqpPEzMJn0OmQMGuy40o7wWtmZ9/bSu4jlhfYw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
@@ -3804,6 +4105,22 @@
         "@opentelemetry/api": ">=1.3.0 <1.8.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
+      "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "dependencies": {
+        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/resources": "1.19.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
     "node_modules/@opentelemetry/propagation-utils": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.5.tgz",
@@ -3968,19 +4285,56 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
-      "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
@@ -4042,6 +4396,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
+      "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "dependencies": {
+        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/resources": "1.19.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
     "@financial-times/eslint-config-next": "^7.1.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
+    "@opentelemetry/sdk-metrics": "^1.22.0",
     "@types/jest": "^29.5.11",
     "eslint": "^8.56.0",
     "eslint-plugin-jsdoc": "^48.0.4",

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -14,6 +14,11 @@ const {
 } = require('@opentelemetry/exporter-trace-otlp-proto');
 const traceExporterPackageJson = require('@opentelemetry/exporter-trace-otlp-proto/package.json');
 const {
+	OTLPMetricExporter
+} = require('@opentelemetry/exporter-metrics-otlp-proto');
+const matricExporterPackageJson = require('@opentelemetry/exporter-metrics-otlp-proto/package.json');
+const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+const {
 	NoopSpanProcessor,
 	TraceIdRatioBasedSampler
 } = require('@opentelemetry/sdk-trace-base');
@@ -21,6 +26,7 @@ const logger = require('@dotcom-reliability-kit/logger');
 
 const USER_AGENT = `FTSystem/${appInfo.systemCode} (${packageJson.name}/${packageJson.version})`;
 const TRACING_USER_AGENT = `${USER_AGENT} (${traceExporterPackageJson.name}/${traceExporterPackageJson.version})`;
+const METRIC_USER_AGENT = `${USER_AGENT} (${matricExporterPackageJson.name}/${matricExporterPackageJson.version})`;
 
 const DEFAULT_SAMPLE_PERCENTAGE = 5;
 
@@ -32,6 +38,8 @@ const IGNORED_REQUEST_PATHS = ['/__gtg', '/__health', '/favicon.ico'];
  *      The HTTP `Authorization` header to send with OpenTelemetry requests.
  * @property {TracingOptions} [tracing]
  *      Configuration options for OpenTelemetry tracing.
+ * @property {MetricsOptions} [metrics]
+ *      Configuration options for OpenTelemetry metrics.
  */
 
 /**
@@ -43,12 +51,18 @@ const IGNORED_REQUEST_PATHS = ['/__gtg', '/__health', '/favicon.ico'];
  */
 
 /**
+ * @typedef {object} MetricsOptions
+ * @property {string} endpoint
+ *     The URL to send OpenTelemetry metrics segments to, for example http://localhost:4318/v1/metrics.
+ */
+
+/**
  * Set up OpenTelemetry tracing.
  *
  * @param {Options} [options]
  *      OpenTelemetry configuration options.
  */
-function setupOpenTelemetry({ authorizationHeader, tracing } = {}) {
+function setupOpenTelemetry({ authorizationHeader, tracing, metrics } = {}) {
 	// We don't support using the built-in `OTEL_`-prefixed environment variables. We
 	// do want to know when these are used, though, so that we can easily spot when
 	// an app's use of these environment variables might be interfering.
@@ -148,6 +162,39 @@ function setupOpenTelemetry({ authorizationHeader, tracing } = {}) {
 			endpoint: null
 		});
 		openTelemetryConfig.spanProcessor = new NoopSpanProcessor();
+	}
+
+	if (metrics?.endpoint) {
+		const headers = {
+			'user-agent': METRIC_USER_AGENT
+		};
+		if (authorizationHeader) {
+			headers.authorization = authorizationHeader;
+		}
+		const exporter = new OTLPMetricExporter({
+			url: metrics?.endpoint,
+			headers
+		});
+		openTelemetryConfig.metricReader = new PeriodicExportingMetricReader({
+			exporter,
+			exportIntervalMillis: 1000 // Set as 1000ms for development and demostration, need to set it higher for prod
+		});
+
+		logger.info({
+			event: 'OTEL_METRIC_STATUS',
+			message: `OpenTelemetry metrics is enabled and exporting to endpoint ${metrics.endpoint}`,
+			enabled: true,
+			endpoint: metrics.endpoint
+		});
+	} else {
+		// Noop metrics reader will be used if no metric reader is set
+		logger.warn({
+			event: 'OTEL_METRIC_STATUS',
+			message:
+				'OpenTelemetry metrics is disabled because no metrics endpoint was set',
+			enabled: false,
+			endpoint: null
+		});
 	}
 
 	// Set up and start OpenTelemetry

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -10,8 +10,16 @@ if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 			: undefined
 	};
 }
+/** @type {setupOpenTelemetry.MetricsOptions | undefined} */
+let metrics = undefined;
+if (process.env.OPENTELEMETRY_METRICS_ENDPOINT) {
+	metrics = {
+		endpoint: process.env.OPENTELEMETRY_METRICS_ENDPOINT
+	};
+}
 
 setupOpenTelemetry({
 	authorizationHeader: process.env.OPENTELEMETRY_AUTHORIZATION_HEADER,
-	tracing
+	tracing,
+	metrics
 });


### PR DESCRIPTION
## DEMO: DO NOT MERGE

## Description

This PR is a part of the SPIKE ticket to investigate the filtering and aggregation of Otel traces and metrics. It is for demonstration purpose only.

## Changes

When a metric endpoint (e.g. http://localhost:4318/v1/metrics) is provided in `OPENTELEMETRY_METRICS_ENDPOINT`, it adds a metric reader with oTel exporter to the oTel SDK, so the app can send metrics to the endpoint.

## Note

Although it is planned that Amazon Managed Service for Prometheus will be used as the backend of metric storage, it would be better to output the metrics in oTel format and convert the format to Prometheus in oTel collector, rather than directly using Prometheus exporter in the metric reader.