### PR TITLE
fix: bump all OpenTelemetry packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,15 +1796,15 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
-      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.3.tgz",
+      "integrity": "sha512-qiO9MNgYnwbvZ8MK0YLWbnGrNX3zTcj6/Ef7UHu5ZofER3e2nF3Y35GaPo9qNJJ/UJQKa4KL+z/F4Q8Q+uCdUQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -2955,6 +2955,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3220,17 +3229,17 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
-      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.48.0.tgz",
-      "integrity": "sha512-1/aMiU4Eqo3Zzpfwu51uXssp5pzvHFObk8S9pKAiXb1ne8pvg1qxBQitYL1XUiAMEXFzgjaidYG2V6624DRhhw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -3239,54 +3248,54 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.41.1.tgz",
-      "integrity": "sha512-gQG0mHlPVBQveuemqNYkrL4IB3T6v2e5sMiDI6FQzFWeLzzFrC04R4fY6AE1YmkhOyteCDpHL/U6CULP2mkt8w==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.43.0.tgz",
+      "integrity": "sha512-2WvHUSi/QVeVG8ObPD0Ls6WevfIbQjspxIQRuHaQFWXhmEwy/MsEcoQUjbNKXwO5516aS04GTydKEoRKsMwhdA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.34.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.38.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.38.1",
-        "@opentelemetry/instrumentation-bunyan": "^0.35.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.35.0",
-        "@opentelemetry/instrumentation-connect": "^0.33.0",
-        "@opentelemetry/instrumentation-cucumber": "^0.3.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.6.0",
-        "@opentelemetry/instrumentation-dns": "^0.33.0",
-        "@opentelemetry/instrumentation-express": "^0.35.0",
-        "@opentelemetry/instrumentation-fastify": "^0.33.0",
-        "@opentelemetry/instrumentation-fs": "^0.9.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.33.0",
-        "@opentelemetry/instrumentation-graphql": "^0.37.0",
-        "@opentelemetry/instrumentation-grpc": "^0.48.0",
-        "@opentelemetry/instrumentation-hapi": "^0.34.0",
-        "@opentelemetry/instrumentation-http": "^0.48.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.37.0",
-        "@opentelemetry/instrumentation-knex": "^0.33.0",
-        "@opentelemetry/instrumentation-koa": "^0.37.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.34.0",
-        "@opentelemetry/instrumentation-memcached": "^0.33.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.39.0",
-        "@opentelemetry/instrumentation-mongoose": "^0.35.0",
-        "@opentelemetry/instrumentation-mysql": "^0.35.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.35.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.34.0",
-        "@opentelemetry/instrumentation-net": "^0.33.0",
-        "@opentelemetry/instrumentation-pg": "^0.38.0",
-        "@opentelemetry/instrumentation-pino": "^0.35.0",
-        "@opentelemetry/instrumentation-redis": "^0.36.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.36.0",
-        "@opentelemetry/instrumentation-restify": "^0.35.0",
-        "@opentelemetry/instrumentation-router": "^0.34.0",
-        "@opentelemetry/instrumentation-socket.io": "^0.36.0",
-        "@opentelemetry/instrumentation-tedious": "^0.7.0",
-        "@opentelemetry/instrumentation-winston": "^0.34.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.6",
-        "@opentelemetry/resource-detector-aws": "^1.3.6",
-        "@opentelemetry/resource-detector-container": "^0.3.6",
-        "@opentelemetry/resource-detector-gcp": "^0.29.6",
+        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation-amqplib": "^0.35.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.39.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.39.1",
+        "@opentelemetry/instrumentation-bunyan": "^0.36.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.36.0",
+        "@opentelemetry/instrumentation-connect": "^0.34.0",
+        "@opentelemetry/instrumentation-cucumber": "^0.4.0",
+        "@opentelemetry/instrumentation-dataloader": "^0.7.0",
+        "@opentelemetry/instrumentation-dns": "^0.34.0",
+        "@opentelemetry/instrumentation-express": "^0.36.1",
+        "@opentelemetry/instrumentation-fastify": "^0.34.0",
+        "@opentelemetry/instrumentation-fs": "^0.10.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.34.0",
+        "@opentelemetry/instrumentation-graphql": "^0.38.1",
+        "@opentelemetry/instrumentation-grpc": "^0.49.1",
+        "@opentelemetry/instrumentation-hapi": "^0.35.0",
+        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation-ioredis": "^0.38.0",
+        "@opentelemetry/instrumentation-knex": "^0.34.0",
+        "@opentelemetry/instrumentation-koa": "^0.38.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.35.0",
+        "@opentelemetry/instrumentation-memcached": "^0.34.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.41.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.36.0",
+        "@opentelemetry/instrumentation-mysql": "^0.36.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.36.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.35.0",
+        "@opentelemetry/instrumentation-net": "^0.34.0",
+        "@opentelemetry/instrumentation-pg": "^0.39.1",
+        "@opentelemetry/instrumentation-pino": "^0.36.0",
+        "@opentelemetry/instrumentation-redis": "^0.37.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.37.0",
+        "@opentelemetry/instrumentation-restify": "^0.36.0",
+        "@opentelemetry/instrumentation-router": "^0.35.0",
+        "@opentelemetry/instrumentation-socket.io": "^0.37.0",
+        "@opentelemetry/instrumentation-tedious": "^0.8.0",
+        "@opentelemetry/instrumentation-winston": "^0.35.0",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.7",
+        "@opentelemetry/resource-detector-aws": "^1.4.0",
+        "@opentelemetry/resource-detector-container": "^0.3.7",
+        "@opentelemetry/resource-detector-gcp": "^0.29.7",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.48.0"
+        "@opentelemetry/sdk-node": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3296,41 +3305,41 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.21.0.tgz",
-      "integrity": "sha512-t0iulGPiMjG/NrSjinPQoIf8ST/o9V0dGOJthfrFporJlNdlKIQPfC7lkrV+5s2dyBThfmSbJlp/4hO1eOcDXA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
+      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.48.0.tgz",
-      "integrity": "sha512-+qRQXUbdRW6aNRT5yWOG3G6My1VxxKeqgUyLkkdIjkT20lvymjiN2RpBfGMtAf/oqnuRknf9snFl9VSIO2gniw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
+      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3340,15 +3349,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.48.0.tgz",
-      "integrity": "sha512-QEZKbfWqXrbKVpr2PHd4KyKI0XVOhUYC+p2RPV8s+2K5QzZBE3+F9WlxxrXDfkrvGmpQAZytBoHQQYA3AGOtpw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3358,16 +3367,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.48.0.tgz",
-      "integrity": "sha512-hVXr/8DYlAKAzQYMsCf3ZsGweS6NTK3IHIEqmLokJZYcvJQBEEazeAdISfrL/utWnapg1Qnpw8u+W6SpxNzmTw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3377,14 +3386,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.21.0.tgz",
-      "integrity": "sha512-J0ejrOx52s1PqvjNalIHvY/4v9ZxR2r7XS7WZbwK3qpVYZlGVq5V1+iCNweqsKnb/miUt/4TFvJBc9f5Q/kGcA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
+      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3394,10 +3403,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
-      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
+      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
       "dependencies": {
+        "@opentelemetry/api-logs": "0.49.1",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -3412,12 +3422,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.34.0.tgz",
-      "integrity": "sha512-lVGRkyGnjFJv9O8oO/+uT40nrNj4UO+UN0k8708guy/toVgxsVpv4PtdWJTjbtu89UDk9gUxq62jpHxqrVaNnw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.35.0.tgz",
+      "integrity": "sha512-rb3hIWA7f0HXpXpfElnGC6CukRxy58/OJ6XYlTzpZJtNJPao7BuobZjkQEscaRYhUzgi7X7R1aKkIUOTV5JFrg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3428,11 +3438,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.38.0.tgz",
-      "integrity": "sha512-MIPvM8S4LqGKE+IAnYVCRUnEjaWbPsbqL4p2BnGcox08e6+JQe+0d16DI0cKVSFZOzV5T/or3ewQ/bB0lPm8yg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.39.0.tgz",
+      "integrity": "sha512-D+oG/hIBDdwCNq7Y6BEuddjcwDVD0C8NhBE7A85mRZ9RLG0bKoWrhIdVvbpqEoa0U5AWe9Y98RX4itNg7WTy4w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -3446,13 +3456,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.38.1.tgz",
-      "integrity": "sha512-/Tupb4UfVVkmcopq2H2nr2D/pHLF0riVw2biQQUJ/jGIkfrOgUMMKbShi2RQE4Zy8NFv3xaDn4/pNxzodLBy3w==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.39.1.tgz",
+      "integrity": "sha512-QnvIMVpzRYqQHSXydGUksbhBjPbMyHSUBwi6ocN7gEXoI711+tIY3R1cfRutl0u3M67A/fAvPI3IgACfJaFORg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
-        "@opentelemetry/propagation-utils": "^0.30.6",
+        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/propagation-utils": "^0.30.7",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3463,12 +3473,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.35.0.tgz",
-      "integrity": "sha512-bQ8OzV7nVTA+oGiTzLjUmRFAbnXi0U/Z4VJCpj+1DRsaAaMT17eRpAOh22LQR0JBnv2vBm8CvIQl4CcAnsB46g==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.36.0.tgz",
+      "integrity": "sha512-sHD5BSiqSrgWow7VmugEFzV8vGdsz5m+w1v9tK6YwRzuAD7vbo57chluq+UBzIqStoCH+0yOzRzSALH7hrfffg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.48.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@types/bunyan": "1.8.9"
       },
       "engines": {
@@ -3479,11 +3489,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.35.0.tgz",
-      "integrity": "sha512-NlJkEiP37/WQvtSyYe4zxaBcaoweO/2+UtDssldk9NFmFutLHyMT/P5q5fe8i73ylmkPOAZnN8P48oHOhZHM1g==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.36.0.tgz",
+      "integrity": "sha512-gMfxzryOIP/mvSLXBJp/QxSr2NvS+cC1dkIXn+aSOzYoU1U3apeF3nAyuikmY9dRCQDV7wHPslqbi+pCmd4pAQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3494,12 +3504,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.33.0.tgz",
-      "integrity": "sha512-EAMmUC2/KfeZl4qNgUsiVqT5Jti0jDl4GHi4TpDg41VBEJkRX/0+JcPBWgdFUgEfeiZr0GPVQud4i8jAwJ+ORw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.34.0.tgz",
+      "integrity": "sha512-PJO99nfyUp3JSoBMhwZsOQDm/XKfkb/QQ8YTsNX4ZJ28phoRcNLqe36mqIMp80DKmKAX4xkxCAyrSYtW8QqZxA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.36"
       },
@@ -3511,11 +3521,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.3.0.tgz",
-      "integrity": "sha512-nM9BL0t2Nxwbb41MXxNXTDL0zq7FXhOX9F3OiAqYUJHqb7BHyzV9KoQ+Ao1BjqJR91hUm1OFNgHAk3y8uiuq4w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.4.0.tgz",
+      "integrity": "sha512-n53QvozzgMS9imEclow2nBYJ/jtZlZqiKIqDUi2/g0nDi08F555JhDS03d/Z+4NJxbu7bDLAg12giCV9KZN/Jw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3526,11 +3536,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.6.0.tgz",
-      "integrity": "sha512-jkPdn83WV/TcnhQ5bOIoYcJGvMxXyYlCzbqfuB6HsMqf3CqpdgBQYlMuKi6qIfD4QWYt2R992yglNxPLuJ7xeg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.7.0.tgz",
+      "integrity": "sha512-sIaevxATJV5YaZzBTTcTaDEnI+/1vxYs+lVk1honnvrEAaP0FA9C/cFrQEN0kP2BDHkHRE/t6y5lGUqusi/h3A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0"
+        "@opentelemetry/instrumentation": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3540,11 +3550,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.33.0.tgz",
-      "integrity": "sha512-QDJadJOQg9CLqMC79r4T5ugN4C4lb6eJYLmHgnLg3fh1JUGfyjQHtD3T7lH0P8251Mnt5m8zjDDbPKcqK2aGcw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.34.0.tgz",
+      "integrity": "sha512-3tmXdvrzHQ7S3v82Cm36PTYLtgg2+hVm00K1xB3uzP08GEo9w/F8DW4me9z6rDroVGiLIg621RZ6dzjBcmmFCg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.5.4"
       },
@@ -3556,12 +3566,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.35.0.tgz",
-      "integrity": "sha512-ZmSB4WMd88sSecOL7DlghzdBl56/8ymb02n+xEJ/6zUgONuw/1uoTh1TAaNPKfEWdNLoLKXQm+Gd2zBrUVOX0w==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.36.1.tgz",
+      "integrity": "sha512-ltIE4kIMa+83QjW/p7oe7XCESF29w3FQ9/T1VgShdX7fzm56K2a0xfEX1vF8lnHRGERYxIWX9D086C6gJOjVGA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3572,12 +3582,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.33.0.tgz",
-      "integrity": "sha512-sl3q9Mt+yM6GlZJKhfLUIRrVEYqfmI0hqYLha5OFG5rLrgnZCCZVy8ra4+Pa40ecH1409cvwwBPf7k9AHEQBTw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.34.0.tgz",
+      "integrity": "sha512-2Qu66XBkfJ8tr6H+RHBTyw/EX73N9U7pvNa49aonDnT9/mK58k7AKOscpRnKXOvHqc2YIdEPRcBIWxhksPFZVA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3588,12 +3598,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.9.0.tgz",
-      "integrity": "sha512-Xp31lb2Sj50ppsJ393650HxSi5IJIgddXxrUeVljmsabdmECPUj0YAt/Wwb1oIHFn04iL9Tq4VkF/otlLaI9ww==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.10.0.tgz",
+      "integrity": "sha512-XtMoNINVsIQTQHjtxe7A0Lng96wxA5DSD5CYVVvpquG6HJRdZ4xNe9DTU03YtoEFqlN9qTfvGb/6ILzhKhiG8g==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3604,11 +3614,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.33.0.tgz",
-      "integrity": "sha512-QMSSOfIqMJhXqFryLVbAMsgRktNHdhMEpsOgEiHurLfvAJhyEOBcTTUuo6Laqt50IIzIm3YuHL9ZtEl9fve2ag==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.34.0.tgz",
+      "integrity": "sha512-jdI7tfVVwZJuTu4j2kAvJtx4wlEQKIXSZnZG4RdqRHc56KqQQDuVTBLvUgmDXvnSVclH9ayf4oaAV08R9fICtw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3619,11 +3629,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.37.0.tgz",
-      "integrity": "sha512-WL5Qn1aRudJDxVN0Ao73/yzXBGBJAH1Fd2tteuGXku/Qw9hYQ936CgoO66GWmSiq2lyjsojAk1t5f+HF9j3NXw==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.38.1.tgz",
+      "integrity": "sha512-mSt4ztn3EVlLtZJ+tDEqq5GUEYdY8cbTT9SeVJFmXSfdSQkPZn0ovo/dRe6dUcplM60gg4w+llw8SZuQN0iZfQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0"
+        "@opentelemetry/instrumentation": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3633,12 +3643,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.48.0.tgz",
-      "integrity": "sha512-MmJHkbqaulqfECjotRtco9AXOq+D1HLq53wI7UFeE8bl8kISP9iMkt+A7PrtPFpRGCglwFvSa0djId6EWsP0DQ==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.49.1.tgz",
+      "integrity": "sha512-f8mQjFi5/PiP4SK3VDU1/3sUUgs6exMtBgcnNycgCKgN40htiPT+MuDRwdRnRMNI/4vNQ7p1/5r4Q5oN0GuRBw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3648,12 +3658,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.34.0.tgz",
-      "integrity": "sha512-qUENVxwCYbRbJ8HBY54ZL1Z9q1guCEurW6tCFFJJKQFu/MKEw7GSFImy5DR2Mp8b5ggZO36lYFcx0QUxfy4GJg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.35.0.tgz",
+      "integrity": "sha512-j7q99aTLHfjNKW94qJnEaDatgz+q2psTKs7lxZO4QHRnoDltDk39a44/+AkI1qBJNw5xyLjrApqkglfbWJ2abg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.13"
       },
@@ -3665,13 +3675,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.48.0.tgz",
-      "integrity": "sha512-uXqOsLhW9WC3ZlGm6+PSX0xjSDTCfy4CMjfYj6TPWusOO8dtdx040trOriF24y+sZmS3M+5UQc6/3/ZxBJh4Mw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.49.1.tgz",
+      "integrity": "sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3682,11 +3692,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.37.0.tgz",
-      "integrity": "sha512-xBPfu03IIG8x1pmt1Dx+XrBO4ZB4UjEcrouGbp6eV3dLQ7eJPYZgfNXmsqkpsxgNQuVCi2a3WEAwZ5Wl2hk7Vw==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.38.0.tgz",
+      "integrity": "sha512-c9nQFhRjFAtpInTks7z5v9CiOCiR8U9GbIhIv0TLEJ/r0wqdKNLfLZzCrr9XQ9WasxeOmziLlPFhpRBAd9Q4oA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
@@ -3699,11 +3709,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.33.0.tgz",
-      "integrity": "sha512-7L3Q8Yy5vY4W4zpRrjKEc0OpVPYyERtDz5dAumKjkJsEVPANr7E8Cc+No6VjZGeN+HgFFwEo+jcQCTWJzdxvRw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.34.0.tgz",
+      "integrity": "sha512-6kZOEvNJOylTQunU5zSSi4iTuCkwIL9nwFnZg7719p61u3d6Qj3X4xi9su46VE3M0dH7vEoxUW+nb/0ilm+aZg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3714,12 +3724,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.37.0.tgz",
-      "integrity": "sha512-EfuGv1RJCSZh77dDc3PtvZXGwcsTufn9tU6T9VOTFcxovpyJ6w0og73eD0D02syR8R+kzv6rg1TeS8+lj7pyrQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.38.0.tgz",
+      "integrity": "sha512-lQujF4I3wdcrOF14miCV2pC72H+OJKb2LrrmTvTDAhELQDN/95v0doWgT9aHybUGkaAeB3QG4d09sved548TlA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3"
@@ -3732,11 +3742,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.34.0.tgz",
-      "integrity": "sha512-m1kXrc11XNj7cC6sfcsYqd+kuCcN2wI9LXpB2l2BZCogqxHCgjuVoiXvT6K9LfO4tLefcvhoK0N8XuVJ8xyyOw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.35.0.tgz",
+      "integrity": "sha512-wCXe+iCF7JweMgY3blLM2Y1G0GSwLEeSA61z/y1UwzvBLEEXt7vL6qOl2mkNcUL9ZbLDS+EABatBH+vFO6DV5Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0"
+        "@opentelemetry/instrumentation": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3746,11 +3756,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.33.0.tgz",
-      "integrity": "sha512-TdGT5ytt8o7FTIsQvx010ykYbqu+IfGoOKA+IXLHdX1+l7vFWyv3ZOzQbRDmA4rxujJAAPf/n4/D7QECyedE/g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.34.0.tgz",
+      "integrity": "sha512-RleFfaag3Evg4pTzHwDBwo1KiFgnCtiT4V6MQRRHadytNGdpcL+Ynz32ydDdiOXeadt7xpRI7HSvBy0quGTXSw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -3762,11 +3772,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.39.0.tgz",
-      "integrity": "sha512-m9dMj39pcCshzlfCEn2lGrlNo7eV5fb9pGBnPyl/Am9Crh7Or8vOqvByCNd26Dgf5J978zTdLGF+6tM8j1WOew==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.41.0.tgz",
+      "integrity": "sha512-DlSH0oyEuTW5gprCUppb0Qe3pK3cpUUFW5eTmayWNyICI1LFunwtcrULTNv6UiThD/V5ykAf/GGGEa7KFAmkog==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3778,12 +3788,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.35.0.tgz",
-      "integrity": "sha512-gReBMWD2Oa/wBGRWyg6B2dbPHhgkpOqDio31gE3DbC4JaqCsMByyeix75rZSzZ71RQmVh3d4jRLsqUtNVBzcyg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.36.0.tgz",
+      "integrity": "sha512-UelQ8dLQRLTdck3tPJdZ17b+Hk9usLf1cY2ou5THAaZpulUdpg62Q9Hx2RHRU71Rp2/YMDk25og7GJhuWScfEA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3794,11 +3804,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.35.0.tgz",
-      "integrity": "sha512-QKRHd3aFA2vKOPzIZ9Q3UIxYeNPweB62HGlX2l3shOKrUhrtTg2/BzaKpHQBy2f2nO2mxTF/mOFeVEDeANnhig==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.36.0.tgz",
+      "integrity": "sha512-2mt/032SLkiuddzMrq3YwM0bHksXRep69EzGRnBfF+bCbwYvKLpqmSFqJZ9T3yY/mBWj+tvdvc1+klXGrh2QnQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.22"
       },
@@ -3810,11 +3820,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.35.0.tgz",
-      "integrity": "sha512-DI9NXYJBbQ72rjz1KCKerQFQE+Z4xRDoyYek6JpITv5BlhPboA8zKkltxyQLL06Y2RTFYslw1gvg+x9CWlRzJw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.36.0.tgz",
+      "integrity": "sha512-F63lKcl/R+if2j5Vz66c2/SLXQEtLlFkWTmYb8NQSgmcCaEKjML4RRRjZISIT4IBwdpanJ2qmNuXVM6MYqhBXw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0"
       },
@@ -3826,11 +3836,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.34.0.tgz",
-      "integrity": "sha512-HvbcCVAMZEIFrJ0Si9AfjxOr14KcH5h/lq5zLQ8AjZJpW0WaeO/ox5UgFi3J73Br91WbZHRgbXxMeodNycJJuA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.35.0.tgz",
+      "integrity": "sha512-INKA7CIOteTSRVxP7SQaFby11AYU3uezI93xDaDRGY4TloXNVoyw5n6UmcVJU4yDn6xY2r7zZ2SVHvblUc21/g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3841,11 +3851,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.33.0.tgz",
-      "integrity": "sha512-x6awrqF0YfEhGGNE2JtEWvB+zEls7mFvLDii54DnWxpQU69+AqKCW/ZwC91EDefOMGSYBckL0uEn6XNOgkTTbw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.34.0.tgz",
+      "integrity": "sha512-gjybNOQQqbXmD1qVHNO2qBJI4V6p3QQ7xKg3pnC/x7wRdxn+siLQj7QIVxW85C3mymngoJJdRs6BwI3qPUfsPQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3856,11 +3866,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.38.0.tgz",
-      "integrity": "sha512-Q7V/OJ1OZwaWYNOP/E9S6sfS03Z+PNU1SAjdAoXTj5j4u4iJSMSieLRWXFaHwsbefIOMkYvA00EBKF9IgbgbLA==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.39.1.tgz",
+      "integrity": "sha512-pX5ujDOyGpPcrZlzaD3LJzmyaSMMMKAP+ffTHJp9vasvZJr+LifCk53TMPVUafcXKV/xX/IIkvADO+67M1Z25g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
@@ -3874,11 +3884,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.35.0.tgz",
-      "integrity": "sha512-gMfJ5Qy793mbaAGnQE3yp1Cb0y4np74rBPu20Oy/v8TTgPQOEV5PyNI0GNGggmZQIJSkdtYa8Ndb3huH3iZE5g==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.36.0.tgz",
+      "integrity": "sha512-oEz+BJEYRBMAUu7MVJFJhhlsBuwLaUGjbJciKZRIeGX+fUtgcbQGV+a2Ris9jR3yFzWZrYg0aNBSCbGqvPCtMQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0"
+        "@opentelemetry/instrumentation": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3888,11 +3898,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.36.0.tgz",
-      "integrity": "sha512-rKFylIacEBwLxKFrPvxpVi8hHY9qXfQSybYnYNyF/VxUWMGYDPMpbCnTQkiVR5u+tIhwSvhSDG2YQEq6syHUIQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.37.0.tgz",
+      "integrity": "sha512-9G0T74kheu37k+UvyBnAcieB5iowxska3z2rhUcSTL8Cl0y/CvMn7sZ7txkUbXt0rdX6qeEUdMLmbsY2fPUM7Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3904,11 +3914,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.36.0.tgz",
-      "integrity": "sha512-XO0EV2TxUsaRdcp79blyLGG5JWWl7NWVd/XNbU8vY7CuYUfRhWiTXYoM4PI+lwkAnUPvPtyiOzYs9px23GnibA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.37.0.tgz",
+      "integrity": "sha512-WNO+HALvPPvjbh7UEEIuay0Z0d2mIfSCkBZbPRwZttDGX6LYGc2WnRgJh3TnYqjp7/y9IryWIbajAFIebj1OBA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -3920,12 +3930,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.35.0.tgz",
-      "integrity": "sha512-0ghtxsGJxHEwJfIzxDN3FCbNiTXqwv2jV6ip716jyjWN3f6MuRHm7NPWI/KNvu+IjqDj16KRGZG7nUAEB1ojog==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.36.0.tgz",
+      "integrity": "sha512-QbOh8HpnnRn4xxFXX77Gdww6M78yx7dRiIKR6+H3j5LH5u6sYckTXw3TGPSsXsaM4DQHy0fOw15sAcJoWkC+aQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3936,11 +3946,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.34.0.tgz",
-      "integrity": "sha512-7LsonkdnQi35eF7CWl8394QDgyd811gCawJ6QuS8GbWNIvZ3S2f9j+Zy0fWSmFgO28ruW1pUG51ql8xdXWa8TA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.35.0.tgz",
+      "integrity": "sha512-MdxGJuNTIy/2qDI8yow6cRBQ87m6O//VuHIlawe8v0x1NsTOSwS72xm+BzTuY9D0iMqiJUiTlE3dBs8DA91MTw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3951,11 +3961,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-socket.io": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.36.0.tgz",
-      "integrity": "sha512-c9Zc6WKxTZtMaOj01kmJGLKabEj805YgTav4l9vgojHrf6MH1fTlw+SGvOKhfPfzmu2QhNORAfqPAB1poDwqEQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.37.0.tgz",
+      "integrity": "sha512-aIztxmx/yis/goEndnoITrZvDDr1GdCtlsWo9ex7MhUIjqq5nJbTuyigf3GmU86XFFhSThxfQuJ9DpJyPxfBfA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -3966,11 +3976,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.7.0.tgz",
-      "integrity": "sha512-o/5my8ZOuxACPSzMaXdPnQiMpmOPIJoTj+DRcs4vEJxk+KwlVNucoafSMpWQEyTNNuq2JI87Ru6Di2mp5T20EQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.8.0.tgz",
+      "integrity": "sha512-BBRW8+Qm2PLNkVMynr3Q7L4xCAOCOs0J9BJIJ8ZGoatW42b2H4qhMhq35jfPDvEL5u5azxHDapmUVYrDJDjAfA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.10"
       },
@@ -3982,11 +3992,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.34.0.tgz",
-      "integrity": "sha512-Ejssv6Uih7ipoNGYQLXd+cKZdEfTfTJ/vzpUSeYiJZ36mVYER1f8fs9Kb7jTKjHD55g2s6cUJj9lifbDFI4EEw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.35.0.tgz",
+      "integrity": "sha512-ymcuA3S2flnLmH1GS0105H91iDLap8cizOCaLMCp7Xz7r4L+wFf1zfix9M+iSkxcPFshHRt8LFA/ELXw51nk0g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0"
+        "@opentelemetry/instrumentation": "^0.49.1"
       },
       "engines": {
         "node": ">=14"
@@ -3996,11 +4006,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.48.0.tgz",
-      "integrity": "sha512-T4LJND+Ugl87GUONoyoQzuV9qCn4BFIPOnCH1biYqdGhc2JahjuLqVD9aefwLzGBW638iLAo88Lh68h2F1FLiA==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -4010,13 +4020,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.48.0.tgz",
-      "integrity": "sha512-Vdp56RK9OU+Oeoy3YQC/UMOWglKQ9qvgGr49FgF4r8vk5DlcTUgVS0m3KG8pykmRPA+5ZKaDuqwPw5aTvWmHFw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -4027,12 +4037,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.48.0.tgz",
-      "integrity": "sha512-14GSTvPZPfrWsB54fYMGb8v+Uge5xGXyz0r2rf4SzcRnO2hXCPHEuL3yyL50emaKPAY+fj29Dm0bweawe8UA6A==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -4043,28 +4053,28 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.48.0.tgz",
-      "integrity": "sha512-yuoS4cUumaTK/hhxW3JUy3wl2U4keMo01cFDrUOmjloAdSSXvv1zyQ920IIH4lymp5Xd21Dj2/jq2LOro56TJg==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.6.tgz",
-      "integrity": "sha512-qvnYee5I/xrBY5XClUlOASIOdoTbnFGNI6+ViKqdoErF2xKmhysXcmxlJNzQFNDK0muTfjvJMZcFyEielARk7g==",
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.7.tgz",
+      "integrity": "sha512-QkxOkuCQdq8YgJstEMF4ntSyr0ivCrcQc49uvO2pyccrniu2DwA+JD071aM4BXfNVSCeOuhIyW/3QPiZYl4zdA==",
       "engines": {
         "node": ">=14"
       },
@@ -4087,31 +4097,31 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.21.0.tgz",
-      "integrity": "sha512-3ZTobj2VDIOzLsIvvYCdpw6tunxUVElPxDvog9lS49YX4hohHeD84A8u9Ns/6UYUcaN5GSoEf891lzhcBFiOLA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
+      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.21.0.tgz",
-      "integrity": "sha512-8TQSwXjBmaDx7JkxRD7hdmBmRK2RGRgzHX1ArJfJhIc5trzlVweyorzqQrXOvqVEdEg+zxUMHkL5qbGH/HDTPA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
+      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -4123,9 +4133,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.6.tgz",
-      "integrity": "sha512-VuJXc+oDQ/SYRHBCQbEshl0WJtEMvgfSkTDBq+WSxj6y9sKe0HCt55Sxeb5nLmBdtCYWMQFniHe2K4GLSjDZVw==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.7.tgz",
+      "integrity": "sha512-7o/waBJ08JrKED4blHGyBPIN1HMM1KEvhbO1HmdA+tsUqsGwZdTjsdMKFW7hc1TvAu4AQEnuvMy/Q5OByVr95A==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -4138,9 +4148,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.6.tgz",
-      "integrity": "sha512-hFJ19yFwChqGCv1uMkXtjZU9BG8GcChe8cRCAkGWg1RZADse5S2ausf3D8pYw1cR3ktJtuAmRrGZniT6TDUPDw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.4.0.tgz",
+      "integrity": "sha512-Cn8eQ/heLqrNrPuHGG7xUkk//VQt4hzVIPurmLlCI0wrDV6HR+yykBvRkJBuSdLzbjeQ/qNbGel9OvTmA6PBQA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -4154,9 +4164,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.6.tgz",
-      "integrity": "sha512-psxtzQakVuZKFl/ukn+nPW4Ixn+KPHGsWJMYKndmXrsgdFri78X+MHR0wLOO41Zn79sc35DiSk+GdJ24cCylbg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.7.tgz",
+      "integrity": "sha512-AYqwffGVuGLuzzVOQMLNHTztwyvsep9noxN9HTQ/grwmJSWZ6851kNx+W735K7v6GZEDmXeLpBn+J3TeqKQUJA==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -4169,9 +4179,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.6",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.6.tgz",
-      "integrity": "sha512-cx03fXPknmiVW0hpWAJr0Nr8xwkwRB8VNWPvNrmP7UzJ8eEztY9lHnVke4ZVFaVGvm/4EFxk2y5hPNggbIezoA==",
+      "version": "0.29.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.7.tgz",
+      "integrity": "sha512-uUHKfoOgBCZCEPCU6FWnRrbYuz1miaeIfos0Xe38YuR06vQvddhqZ0tewYunJpfECfKEcjSjY0eDe2QIRLMkXw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -4186,117 +4196,117 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
-      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.48.0.tgz",
-      "integrity": "sha512-lRcA5/qkSJuSh4ItWCddhdn/nNbVvnzM+cm9Fg1xpZUeTeozjJDBcHnmeKoOaWRnrGYBdz6UTY6bynZR9aBeAA==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.21.0.tgz",
-      "integrity": "sha512-on1jTzIHc5DyWhRP+xpf+zrgrREXcHBH4EDAfaB5mIG7TWpKxNXooQ1JCylaPsswZUv4wGnVTinr4HrBdGARAQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.48.0.tgz",
-      "integrity": "sha512-3o3GS6t+VLGVFCV5bqfGOcWIgOdkR/UE6Qz7hHksP5PXrVBeYsPqts7cPma5YXweaI3r3h26mydg9PqQIcqksg==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
+      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
-      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.21.0.tgz",
-      "integrity": "sha512-1pdm8jnqs+LuJ0Bvx6sNL28EhC8Rv7NYV8rnoXq3GIQo7uOHBDAFSj7makAfbakrla7ecO1FRfI8emnR4WvhYA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
+      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
-      "integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
       "engines": {
         "node": ">=14"
       }
@@ -7257,9 +7267,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
-      "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.3.0.tgz",
+      "integrity": "sha512-p+ggrQw3fBwH2F5N/PAI4k/G/y1art5OxKpb2J2chwNNHM4hHuAOtivjPuirMF4KNKwTTUal/lPfL2+7h2mEcg==",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -8741,9 +8751,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.12.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
-      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
+      "version": "17.12.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.2.tgz",
+      "integrity": "sha512-RonXAIzCiHLc8ss3Ibuz45u28GOsWE1UpfDXLbN/9NKbL4tCJf8TWYVKsoYuuh+sAUt7fsSNpA+r2+TBA6Wjmw==",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -11003,9 +11013,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.1.tgz",
+      "integrity": "sha512-u5XngygsJ+XV2dBV/Pl4SrcNpUXQfmYmXtuFeHDXfzk4i4NnGnret6xKWkkJHjMHS/16yMV9pEAlAunqmjllkA==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -12798,13 +12808,13 @@
         "@dotcom-reliability-kit/app-info": "^3.0.2",
         "@dotcom-reliability-kit/errors": "^3.0.1",
         "@dotcom-reliability-kit/logger": "^3.0.4",
-        "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.41.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",
-        "@opentelemetry/resources": "^1.21.0",
-        "@opentelemetry/sdk-node": "^0.48.0",
-        "@opentelemetry/sdk-trace-base": "^1.21.0",
-        "@opentelemetry/semantic-conventions": "^1.21.0"
+        "@opentelemetry/api": "^1.8.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.43.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.49.1",
+        "@opentelemetry/resources": "^1.22.0",
+        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-trace-base": "^1.22.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": "18.x || 20.x",

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -6,7 +6,11 @@ const {
 const { Resource } = require('@opentelemetry/resources');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
 const {
-	SemanticResourceAttributes
+	SEMRESATTRS_CLOUD_PROVIDER,
+	SEMRESATTRS_CLOUD_REGION,
+	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+	SEMRESATTRS_SERVICE_NAME,
+	SEMRESATTRS_SERVICE_VERSION
 } = require('@opentelemetry/semantic-conventions');
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
@@ -78,13 +82,12 @@ function setupOpenTelemetry({ authorizationHeader, tracing } = {}) {
 	const openTelemetryConfig = {};
 
 	// Set OpenTelemetry resource attributes based on app data
-	// @ts-ignore
 	openTelemetryConfig.resource = new Resource({
-		[SemanticResourceAttributes.SERVICE_NAME]: appInfo.systemCode,
-		[SemanticResourceAttributes.SERVICE_VERSION]: appInfo.releaseVersion,
-		[SemanticResourceAttributes.CLOUD_PROVIDER]: appInfo.cloudProvider,
-		[SemanticResourceAttributes.CLOUD_REGION]: appInfo.region,
-		[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: appInfo.environment
+		[SEMRESATTRS_SERVICE_NAME]: appInfo.systemCode || undefined,
+		[SEMRESATTRS_SERVICE_VERSION]: appInfo.releaseVersion || undefined,
+		[SEMRESATTRS_CLOUD_PROVIDER]: appInfo.cloudProvider || undefined,
+		[SEMRESATTRS_CLOUD_REGION]: appInfo.region || undefined,
+		[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: appInfo.environment || undefined
 	});
 
 	// Auto-instrument common and built-in Node.js modules

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -19,12 +19,12 @@
 		"@dotcom-reliability-kit/app-info": "^3.0.2",
 		"@dotcom-reliability-kit/errors": "^3.0.1",
 		"@dotcom-reliability-kit/logger": "^3.0.4",
-		"@opentelemetry/api": "^1.7.0",
-		"@opentelemetry/auto-instrumentations-node": "^0.41.1",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.48.0",
-		"@opentelemetry/resources": "^1.21.0",
-		"@opentelemetry/sdk-node": "^0.48.0",
-		"@opentelemetry/sdk-trace-base": "^1.21.0",
-		"@opentelemetry/semantic-conventions": "^1.21.0"
+		"@opentelemetry/api": "^1.8.0",
+		"@opentelemetry/auto-instrumentations-node": "^0.43.0",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.49.1",
+		"@opentelemetry/resources": "^1.22.0",
+		"@opentelemetry/sdk-node": "^0.49.1",
+		"@opentelemetry/sdk-trace-base": "^1.22.0",
+		"@opentelemetry/semantic-conventions": "^1.22.0"
 	}
 }

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -28,7 +28,11 @@ const { UserInputError } = require('@dotcom-reliability-kit/errors');
 const { Resource } = require('@opentelemetry/resources');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
 const {
-	SemanticResourceAttributes
+	SEMRESATTRS_CLOUD_PROVIDER,
+	SEMRESATTRS_CLOUD_REGION,
+	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+	SEMRESATTRS_SERVICE_NAME,
+	SEMRESATTRS_SERVICE_VERSION
 } = require('@opentelemetry/semantic-conventions');
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
@@ -84,11 +88,11 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		it('sets OpenTelemetry resource attributes based on app data', () => {
 			expect(Resource).toHaveBeenCalledTimes(1);
 			expect(Resource).toHaveBeenCalledWith({
-				[SemanticResourceAttributes.SERVICE_NAME]: 'MOCK_SYSTEM_CODE',
-				[SemanticResourceAttributes.SERVICE_VERSION]: 'MOCK_RELEASE_VERSION',
-				[SemanticResourceAttributes.CLOUD_PROVIDER]: 'MOCK_CLOUD_PROVIDER',
-				[SemanticResourceAttributes.CLOUD_REGION]: 'MOCK_CLOUD_REGION',
-				[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: 'MOCK_ENVIRONMENT'
+				[SEMRESATTRS_SERVICE_NAME]: 'MOCK_SYSTEM_CODE',
+				[SEMRESATTRS_SERVICE_VERSION]: 'MOCK_RELEASE_VERSION',
+				[SEMRESATTRS_CLOUD_PROVIDER]: 'MOCK_CLOUD_PROVIDER',
+				[SEMRESATTRS_CLOUD_REGION]: 'MOCK_CLOUD_REGION',
+				[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: 'MOCK_ENVIRONMENT'
 			});
 			expect(opentelemetrySDK.NodeSDK.mock.calls[0][0].resource).toBeInstanceOf(
 				Resource
@@ -314,6 +318,31 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 				event: 'OTEL_ENVIRONMENT_VARIABLES_DEFINED',
 				message:
 					'OTEL-prefixed environment variables are defined, this use-case is not supported by Reliability Kit. You may encounter issues'
+			});
+		});
+	});
+
+	describe('when app data is not available', () => {
+		beforeAll(() => {
+			Resource.mockReset();
+			appInfo.systemCode = null;
+			appInfo.releaseVersion = null;
+			appInfo.cloudProvider = null;
+			appInfo.region = null;
+			appInfo.environment = null;
+			openTelemetryTracing({
+				tracing: { endpoint: 'MOCK_TRACING_ENDPOINT' }
+			});
+		});
+
+		it('sets OpenTelemetry resource attributes to undefined', () => {
+			expect(Resource).toHaveBeenCalledTimes(1);
+			expect(Resource).toHaveBeenCalledWith({
+				[SEMRESATTRS_SERVICE_NAME]: undefined,
+				[SEMRESATTRS_SERVICE_VERSION]: undefined,
+				[SEMRESATTRS_CLOUD_PROVIDER]: undefined,
+				[SEMRESATTRS_CLOUD_REGION]: undefined,
+				[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: undefined
 			});
 		});
 	});


### PR DESCRIPTION
None of the individual dependency PRs pass the tests because they're not compatible with the other versions. This bumps everything at once.

There was also a deprecation in semantic resource attributes which was causing some type errors. I've fixed these.