### PR TITLE
Fix the changelogs

### DIFF
--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,107 +1,5 @@
 # Changelog
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.11 to ^1.4.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.2 to ^3.1.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
-
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.4...crash-handler-v4.0.5) (2024-03-22)
 
 
@@ -190,6 +88,78 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
 
+## [3.0.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.7...crash-handler-v3.0.8) (2023-12-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
+
+## [3.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.6...crash-handler-v3.0.7) (2023-11-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
+
+## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.5...crash-handler-v3.0.6) (2023-11-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
+
+## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.4...crash-handler-v3.0.5) (2023-11-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.2 to ^3.1.3
+
+## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.3...crash-handler-v3.0.4) (2023-11-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
+
+## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.2...crash-handler-v3.0.3) (2023-10-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
+
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.1...crash-handler-v3.0.2) (2023-09-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
+
+## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v3.0.0...crash-handler-v3.0.1) (2023-08-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v2.1.2...crash-handler-v3.0.0) (2023-08-07)
 
 
@@ -220,6 +190,15 @@
 ### Bug Fixes
 
 * avoid double-registering Crash Handler ([e18c8b3](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e18c8b34adefa0ff3dfe38db9c4261ca77ae86de))
+
+## [2.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v2.1.0...crash-handler-v2.1.1) (2023-06-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
 
 ## [2.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v2.0.1...crash-handler-v2.1.0) (2023-05-02)
 
@@ -267,6 +246,42 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^1.5.4 to ^2.0.0
 
+## [1.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v1.1.3...crash-handler-v1.1.4) (2023-04-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
+
+## [1.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v1.1.2...crash-handler-v1.1.3) (2023-04-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
+
+## [1.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v1.1.1...crash-handler-v1.1.2) (2023-03-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
+
+## [1.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v1.1.0...crash-handler-v1.1.1) (2022-12-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
+
 ## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v1.0.0...crash-handler-v1.1.0) (2022-11-22)
 
 
@@ -286,7 +301,50 @@
 
 ### Features
 
+* add an uncaught exception handler ([a2bf68e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/a2bf68ed4fd31c2e7856b4fbe130afcf6ca7289c))
 * indicate that the crash handler is stable ([63c694c](https://github.com/Financial-Times/dotcom-reliability-kit/commit/63c694c14d261f545efa91edbcf1454658e355fa))
+
+
+### Documentation Changes
+
+* clarify where you register crash handlers ([459d68e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/459d68e10000fc93366b5ca9458d21f3ba2a87be))
+* fix a typo ([10daf21](https://github.com/Financial-Times/dotcom-reliability-kit/commit/10daf21e48706e623a7b14d79864df7ea87c7055))
+
+## [0.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v0.1.3...crash-handler-v0.1.4) (2022-11-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.11 to ^1.4.0
+
+## [0.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v0.1.2...crash-handler-v0.1.3) (2022-11-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
+
+## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v0.1.1...crash-handler-v0.1.2) (2022-10-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
+
+## [0.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v0.1.0...crash-handler-v0.1.1) (2022-10-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
 
 ## 0.1.0 (2022-10-21)
 

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,92 +1,5 @@
 # Changelog
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-error bumped from ^1.0.0 to ^1.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-error bumped from ^1.1.0 to ^1.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-request bumped from ^1.0.3 to ^1.0.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-request bumped from ^1.1.0 to ^1.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.1.0 to ^1.2.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.2.0 to ^1.2.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-request bumped from ^2.1.0 to ^2.2.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/serialize-request bumped from ^2.2.0 to ^2.2.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
-    * @dotcom-reliability-kit/logger bumped from ^2.2.9 to ^2.2.10
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/logger bumped from ^2.2.10 to ^2.3.0
-    * @dotcom-reliability-kit/serialize-error bumped from ^2.1.0 to ^2.2.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/logger bumped from ^2.3.0 to ^2.3.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/logger bumped from ^2.3.1 to ^2.4.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
-    * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
-
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.4...log-error-v4.0.5) (2024-03-22)
 
 
@@ -185,6 +98,63 @@
     * @dotcom-reliability-kit/logger bumped from ^2.4.1 to ^2.4.2
     * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
 
+## [3.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.5...log-error-v3.1.6) (2023-12-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
+    * @dotcom-reliability-kit/logger bumped from ^2.4.0 to ^2.4.1
+
+## [3.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.4...log-error-v3.1.5) (2023-11-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^2.3.1 to ^2.4.0
+
+## [3.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.3...log-error-v3.1.4) (2023-11-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^2.3.0 to ^2.3.1
+
+## [3.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.2...log-error-v3.1.3) (2023-11-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^2.2.10 to ^2.3.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^2.1.0 to ^2.2.0
+
+## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.1...log-error-v3.1.2) (2023-11-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
+    * @dotcom-reliability-kit/logger bumped from ^2.2.9 to ^2.2.10
+
+## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.1.0...log-error-v3.1.1) (2023-10-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-request bumped from ^2.2.0 to ^2.2.1
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v3.0.1...log-error-v3.1.0) (2023-09-19)
 
 
@@ -232,6 +202,15 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/logger bumped from ^2.2.6 to ^2.2.7
+
+## [2.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v2.1.0...log-error-v2.1.1) (2023-06-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-request bumped from ^2.1.0 to ^2.2.0
 
 ## [2.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v2.0.1...log-error-v2.1.0) (2023-05-02)
 
@@ -285,6 +264,42 @@
     * @dotcom-reliability-kit/serialize-error bumped from ^1.1.4 to ^2.0.0
     * @dotcom-reliability-kit/serialize-request bumped from ^1.1.1 to ^2.0.0
 
+## [1.5.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.5.3...log-error-v1.5.4) (2023-04-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.2.0 to ^1.2.1
+
+## [1.5.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.5.2...log-error-v1.5.3) (2023-04-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.1.0 to ^1.2.0
+
+## [1.5.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.5.1...log-error-v1.5.2) (2023-03-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-request bumped from ^1.1.0 to ^1.1.1
+
+## [1.5.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.5.0...log-error-v1.5.1) (2022-12-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
+
 ## [1.5.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.4.0...log-error-v1.5.0) (2022-11-22)
 
 
@@ -313,6 +328,15 @@
 ### Bug Fixes
 
 * correct ESM exports ([9964686](https://github.com/Financial-Times/dotcom-reliability-kit/commit/996468686dfc62db95e7bea4b2028a28dfb28621))
+
+## [1.3.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.3.9...log-error-v1.3.10) (2022-10-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-request bumped from ^1.0.3 to ^1.0.4
 
 ## [1.3.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.3.8...log-error-v1.3.9) (2022-10-25)
 
@@ -403,6 +427,24 @@
 
 * clarify that x-request-id is auto-logged ([4fb32cc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4fb32cc7cd0df2347464b5a6194819395fdf2fbb))
 
+## [1.3.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.3.1...log-error-v1.3.2) (2022-08-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-error bumped from ^1.1.0 to ^1.1.1
+
+## [1.3.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.3.0...log-error-v1.3.1) (2022-08-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-error bumped from ^1.0.0 to ^1.1.0
+
 ## [1.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v1.2.0...log-error-v1.3.0) (2022-08-01)
 
 
@@ -435,7 +477,6 @@
 ### Features
 
 * require n-logger v10.2.0 ([c0c0da1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/c0c0da19aa81bdbecf8727085d85dc610265fb05))
-
 
 ## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v0.1.0...log-error-v1.0.0) (2022-07-05)
 

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,23 +1,5 @@
 # Changelog
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
-
 ## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.4...logger-v3.0.5) (2024-03-22)
 
 
@@ -123,6 +105,15 @@
   * dependencies
     * @dotcom-reliability-kit/serialize-error bumped from ^2.2.0 to ^2.2.1
 
+## [2.4.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.4.0...logger-v2.4.1) (2023-12-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
+
 ## [2.4.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.3.1...logger-v2.4.0) (2023-11-23)
 
 
@@ -151,6 +142,15 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/serialize-error bumped from ^2.1.0 to ^2.2.0
+
+## [2.2.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.2.9...logger-v2.2.10) (2023-11-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
 
 ## [2.2.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v2.2.8...logger-v2.2.9) (2023-09-19)
 
@@ -373,6 +373,15 @@
 ### Features
 
 * mark the logger package as stable ([57c5f65](https://github.com/Financial-Times/dotcom-reliability-kit/commit/57c5f65272692bf416c7f1777b240f2276e02e9d))
+
+## [0.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v0.1.4...logger-v0.1.5) (2022-12-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
 
 ## [0.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v0.1.3...logger-v0.1.4) (2022-12-16)
 

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,119 +1,5 @@
 # Changelog
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.0 to ^1.3.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.1 to ^1.3.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.3 to ^1.3.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.2 to ^3.1.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
-
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.4...middleware-log-errors-v4.0.5) (2024-03-22)
 
 
@@ -203,6 +89,78 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^3.1.6 to ^3.1.7
 
+## [3.0.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.7...middleware-log-errors-v3.0.8) (2023-12-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
+
+## [3.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.6...middleware-log-errors-v3.0.7) (2023-11-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
+
+## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.5...middleware-log-errors-v3.0.6) (2023-11-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
+
+## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.4...middleware-log-errors-v3.0.5) (2023-11-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.2 to ^3.1.3
+
+## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.3...middleware-log-errors-v3.0.4) (2023-11-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
+
+## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.2...middleware-log-errors-v3.0.3) (2023-10-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
+
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.1...middleware-log-errors-v3.0.2) (2023-09-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
+
+## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v3.0.0...middleware-log-errors-v3.0.1) (2023-08-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v2.1.1...middleware-log-errors-v3.0.0) (2023-08-07)
 
 
@@ -226,6 +184,15 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^2.1.1 to ^3.0.0
+
+## [2.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v2.1.0...middleware-log-errors-v2.1.1) (2023-06-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
 
 ## [2.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v2.0.1...middleware-log-errors-v2.1.0) (2023-05-02)
 
@@ -273,6 +240,33 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^1.5.4 to ^2.0.0
 
+## [1.5.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.5.3...middleware-log-errors-v1.5.4) (2023-04-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
+
+## [1.5.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.5.2...middleware-log-errors-v1.5.3) (2023-04-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
+
+## [1.5.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.5.1...middleware-log-errors-v1.5.2) (2023-03-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
+
 ## [1.5.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.5.0...middleware-log-errors-v1.5.1) (2023-03-14)
 
 
@@ -286,6 +280,15 @@
 ### Features
 
 * add filter option to the logging middleware ([5a64b13](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5a64b1376dfe037f7eb721b2be7ff1d1525fc806))
+
+## [1.4.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.4.0...middleware-log-errors-v1.4.1) (2022-12-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
 
 ## [1.4.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.3.0...middleware-log-errors-v1.4.0) (2022-11-22)
 
@@ -320,6 +323,33 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^1.3.11 to ^1.4.0
+
+## [1.2.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.11...middleware-log-errors-v1.2.12) (2022-11-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
+
+## [1.2.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.10...middleware-log-errors-v1.2.11) (2022-10-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
+
+## [1.2.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.9...middleware-log-errors-v1.2.10) (2022-10-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
 
 ## [1.2.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.8...middleware-log-errors-v1.2.9) (2022-10-12)
 
@@ -382,6 +412,15 @@
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^1.3.4 to ^1.3.5
 
+## [1.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.4...middleware-log-errors-v1.2.5) (2022-08-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.3 to ^1.3.4
+
 ## [1.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.3...middleware-log-errors-v1.2.4) (2022-08-19)
 
 
@@ -402,6 +441,24 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^1.3.2 to ^1.3.3
+
+## [1.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.1...middleware-log-errors-v1.2.2) (2022-08-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.1 to ^1.3.2
+
+## [1.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.2.0...middleware-log-errors-v1.2.1) (2022-08-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.0 to ^1.3.1
 
 ## [1.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v1.1.0...middleware-log-errors-v1.2.0) (2022-08-01)
 

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,111 +1,5 @@
 # Changelog
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.1 to ^1.3.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.3.11 to ^1.4.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.4.0 to ^1.5.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.1.0 to ^1.2.0
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^1.2.0 to ^1.2.1
-    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
-
 ## [5.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.4...middleware-render-error-info-v5.0.5) (2024-03-22)
 
 
@@ -216,6 +110,24 @@
     * @dotcom-reliability-kit/app-info bumped from ^2.2.0 to ^2.3.0
     * @dotcom-reliability-kit/log-error bumped from ^3.1.5 to ^3.1.6
 
+## [4.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.0.1...middleware-render-error-info-v4.0.2) (2023-11-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.4 to ^3.1.5
+
+## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v4.0.0...middleware-render-error-info-v4.0.1) (2023-11-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.3 to ^3.1.4
+
 ## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v3.1.0...middleware-render-error-info-v4.0.0) (2023-11-20)
 
 
@@ -253,6 +165,43 @@
     * @dotcom-reliability-kit/log-error bumped from ^3.1.2 to ^3.1.3
     * @dotcom-reliability-kit/serialize-error bumped from ^2.1.0 to ^2.2.0
 
+## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v3.0.3...middleware-render-error-info-v3.0.4) (2023-11-07)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^2.1.0 to ^2.2.0
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.1 to ^3.1.2
+
+## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v3.0.2...middleware-render-error-info-v3.0.3) (2023-10-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.1.0 to ^3.1.1
+
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v3.0.1...middleware-render-error-info-v3.0.2) (2023-09-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.1 to ^3.1.0
+
+## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v3.0.0...middleware-render-error-info-v3.0.1) (2023-08-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^3.0.0 to ^3.0.1
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v2.1.1...middleware-render-error-info-v3.0.0) (2023-08-07)
 
 
@@ -276,6 +225,15 @@
 * The following workspace dependencies were updated
   * dependencies
     * @dotcom-reliability-kit/log-error bumped from ^2.1.1 to ^3.0.0
+
+## [2.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v2.1.0...middleware-render-error-info-v2.1.1) (2023-06-23)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^2.1.0 to ^2.1.1
 
 ## [2.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v2.0.1...middleware-render-error-info-v2.1.0) (2023-05-02)
 
@@ -336,12 +294,96 @@
 
 * bump entities from 4.4.0 to 4.5.0 ([f6ca40d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6ca40de6ab72794774b22a1458cc3cf481b518f))
 
+## [1.1.17](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.16...middleware-render-error-info-v1.1.17) (2023-04-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.2.0 to ^1.2.1
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.3 to ^1.5.4
+
+## [1.1.16](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.15...middleware-render-error-info-v1.1.16) (2023-04-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.1.0 to ^1.2.0
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.2 to ^1.5.3
+
+## [1.1.15](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.14...middleware-render-error-info-v1.1.15) (2023-03-21)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.1 to ^1.5.2
+
 ## [1.1.14](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.13...middleware-render-error-info-v1.1.14) (2023-01-25)
 
 
 ### Bug Fixes
 
 * use fake timers in middleware rendering snapshot test ([6fabcce](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6fabcce57d19102a8dfa78442a83cb60f7cb323f))
+
+## [1.1.13](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.12...middleware-render-error-info-v1.1.13) (2022-12-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^1.0.3 to ^1.1.0
+    * @dotcom-reliability-kit/log-error bumped from ^1.5.0 to ^1.5.1
+
+## [1.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.11...middleware-render-error-info-v1.1.12) (2022-11-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.4.0 to ^1.5.0
+
+## [1.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.10...middleware-render-error-info-v1.1.11) (2022-11-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.11 to ^1.4.0
+
+## [1.1.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.9...middleware-render-error-info-v1.1.10) (2022-11-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.10 to ^1.3.11
+
+## [1.1.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.8...middleware-render-error-info-v1.1.9) (2022-10-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.9 to ^1.3.10
+
+## [1.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.7...middleware-render-error-info-v1.1.8) (2022-10-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.8 to ^1.3.9
 
 ## [1.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.6...middleware-render-error-info-v1.1.7) (2022-10-12)
 
@@ -431,6 +473,15 @@
 ### Bug Fixes
 
 * return named functions in middleware ([00e7ddd](https://github.com/Financial-Times/dotcom-reliability-kit/commit/00e7ddd77d18681dea8c504c40e4879c04207748))
+
+## [1.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.1.0...middleware-render-error-info-v1.1.1) (2022-08-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^1.3.1 to ^1.3.3
 
 ## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v1.0.0...middleware-render-error-info-v1.1.0) (2022-08-12)
 


### PR DESCRIPTION
I've been wanting to do this for ages and Release Please have finally fixed the issue their end. When dependencies were updated _within_ the monorepo the changelogs didn't get updated correctly with a version heading. I've regenerated all the impacted changelog files based on the GitHub release data.

The bulk of the work was done with a quick script I wrote after pulling the release JSON. I double checked myself and think everything is correct 👍