### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.0.2",
-  "packages/crash-handler": "4.0.5",
+  "packages/crash-handler": "4.0.6",
   "packages/errors": "3.0.1",
   "packages/eslint-config": "3.0.2",
   "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.5",
-  "packages/logger": "3.0.5",
-  "packages/middleware-log-errors": "4.0.5",
-  "packages/middleware-render-error-info": "5.0.5",
+  "packages/log-error": "4.0.6",
+  "packages/logger": "3.0.6",
+  "packages/middleware-log-errors": "4.0.6",
+  "packages/middleware-render-error-info": "5.0.6",
   "packages/serialize-error": "3.0.2",
   "packages/serialize-request": "3.0.2",
-  "packages/opentelemetry": "1.0.2"
+  "packages/opentelemetry": "1.0.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12793,10 +12793,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.5"
+        "@dotcom-reliability-kit/log-error": "^4.0.6"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -12848,11 +12848,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/logger": "^3.0.5",
+        "@dotcom-reliability-kit/logger": "^3.0.6",
         "@dotcom-reliability-kit/serialize-error": "^3.0.2",
         "@dotcom-reliability-kit/serialize-request": "^3.0.2"
       },
@@ -12866,7 +12866,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
@@ -12890,10 +12890,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.5"
+        "@dotcom-reliability-kit/log-error": "^4.0.6"
       },
       "devDependencies": {
         "@financial-times/n-express": "^30.2.0",
@@ -12907,11 +12907,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/log-error": "^4.0.5",
+        "@dotcom-reliability-kit/log-error": "^4.0.6",
         "@dotcom-reliability-kit/serialize-error": "^3.0.2",
         "entities": "^4.5.0"
       },
@@ -12925,12 +12925,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.0.2",
         "@dotcom-reliability-kit/errors": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.5",
+        "@dotcom-reliability-kit/logger": "^3.0.6",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.44.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.5...crash-handler-v4.0.6) (2024-04-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
+
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.4...crash-handler-v4.0.5) (2024-03-22)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.5"
+    "@dotcom-reliability-kit/log-error": "^4.0.6"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.5...log-error-v4.0.6) (2024-04-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.5 to ^3.0.6
+
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.4...log-error-v4.0.5) (2024-03-22)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/logger": "^3.0.5",
+    "@dotcom-reliability-kit/logger": "^3.0.6",
     "@dotcom-reliability-kit/serialize-error": "^3.0.2",
     "@dotcom-reliability-kit/serialize-request": "^3.0.2"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.5...logger-v3.0.6) (2024-04-22)
+
+
+### Bug Fixes
+
+* bump pino from 8.19.0 to 8.20.0 ([2b9cf3d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2b9cf3d7af0a886db0e1daee78c80b078d08c07e))
+
 ## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.4...logger-v3.0.5) (2024-03-22)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.5...middleware-log-errors-v4.0.6) (2024-04-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
+
 ## [4.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.4...middleware-log-errors-v4.0.5) (2024-03-22)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.5"
+    "@dotcom-reliability-kit/log-error": "^4.0.6"
   },
   "devDependencies": {
     "@financial-times/n-express": "^30.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.5...middleware-render-error-info-v5.0.6) (2024-04-22)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
+
 ## [5.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.4...middleware-render-error-info-v5.0.5) (2024-03-22)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/log-error": "^4.0.5",
+    "@dotcom-reliability-kit/log-error": "^4.0.6",
     "@dotcom-reliability-kit/serialize-error": "^3.0.2",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.2...opentelemetry-v1.0.3) (2024-04-22)
+
+
+### Bug Fixes
+
+* update all the OpenTelemetry packages ([0d11391](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d11391560f90ac23c5e6def475925d9e75494c2))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.0.5 to ^3.0.6
+
 ## [1.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.1...opentelemetry-v1.0.2) (2024-03-22)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.0.2",
 		"@dotcom-reliability-kit/errors": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.5",
+		"@dotcom-reliability-kit/logger": "^3.0.6",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.44.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.0.6</summary>

## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.5...crash-handler-v4.0.6) (2024-04-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
</details>

<details><summary>log-error: 4.0.6</summary>

## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.5...log-error-v4.0.6) (2024-04-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.5 to ^3.0.6
</details>

<details><summary>logger: 3.0.6</summary>

## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.5...logger-v3.0.6) (2024-04-22)


### Bug Fixes

* bump pino from 8.19.0 to 8.20.0 ([2b9cf3d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2b9cf3d7af0a886db0e1daee78c80b078d08c07e))
</details>

<details><summary>middleware-log-errors: 4.0.6</summary>

## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.5...middleware-log-errors-v4.0.6) (2024-04-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
</details>

<details><summary>middleware-render-error-info: 5.0.6</summary>

## [5.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.5...middleware-render-error-info-v5.0.6) (2024-04-22)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.5 to ^4.0.6
</details>

<details><summary>opentelemetry: 1.0.3</summary>

## [1.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.2...opentelemetry-v1.0.3) (2024-04-22)


### Bug Fixes

* update all the OpenTelemetry packages ([0d11391](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d11391560f90ac23c5e6def475925d9e75494c2))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.0.5 to ^3.0.6
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).