### PR TITLE
fix: handle node-fetch memory leak

### DIFF
--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -48,6 +48,9 @@ Some of the options below result in more errors being caught, you can weigh this
 
 In all of the APIs below, if the response `ok` property is `false`, i.e. when the status code is `400` or greater, then errors will be thrown.
 
+> [!WARNING]
+> If you're using node-fetch then it's important to read the body of the request because of a [known memory leak](https://github.com/node-fetch/node-fetch/issues/83). If an error is thrown then we automatically drain the response body stream but, if the request is successful, you'll need to do this yourself.
+
 ### Wrap the fetch function
 
 This is the recommended API as this will allow you to handle the most errors (even DNS and timeout errors) correctly:


### PR DESCRIPTION
node-fetch has a memory leak if you don't read the body of a response. Within the library we don't ever know which fetch implementaton we're using so we've had to test for a property (`pipe`) that only exists on the node-fetch response body and not native fetch.

If we're throwing an error and we see that the response body has this method, then we pipe the body into a black hole stream. This means that the body is unusable if there was an error but we can document this limitation. I'd rather not mess with trying to read/parse data from the response body if possible as it adds a lot of complexity and I don't want to add _too_ many cases to deal with node-fetch when we'll be moving to native-fetch relatively soon.

We discussed some alternatives but I decided the best thing to do for now is to fix the memory leak and then we can deal with adding the response body to the thrown errors as a separate feature request.

**Note:** this PR has a bunch of whitespace changes because I had to reindent code to introduce another `try/catch`. It'll be easier to review with [whitespace changes ignored](https://github.com/Financial-Times/dotcom-reliability-kit/pull/1010/files?w=1).

See-Also: [CPREL-1047](https://financialtimes.atlassian.net/browse/CPREL-1047)

[CPREL-1047]: https://financialtimes.atlassian.net/browse/CPREL-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ