### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.0.2",
-  "packages/crash-handler": "4.0.6",
-  "packages/errors": "3.0.1",
-  "packages/eslint-config": "3.0.2",
-  "packages/fetch-error-handler": "0.2.1",
-  "packages/log-error": "4.0.6",
-  "packages/logger": "3.0.6",
-  "packages/middleware-log-errors": "4.0.6",
-  "packages/middleware-render-error-info": "5.0.6",
-  "packages/serialize-error": "3.0.2",
-  "packages/serialize-request": "3.0.2",
-  "packages/opentelemetry": "1.0.3"
+  "packages/app-info": "3.1.0",
+  "packages/crash-handler": "4.1.0",
+  "packages/errors": "3.1.0",
+  "packages/eslint-config": "3.1.0",
+  "packages/fetch-error-handler": "0.2.2",
+  "packages/log-error": "4.1.0",
+  "packages/logger": "3.1.0",
+  "packages/middleware-log-errors": "4.1.0",
+  "packages/middleware-render-error-info": "5.1.0",
+  "packages/serialize-error": "3.1.0",
+  "packages/serialize-request": "3.1.0",
+  "packages/opentelemetry": "1.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12775,7 +12775,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12784,10 +12784,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.6"
+        "@dotcom-reliability-kit/log-error": "^4.1.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12796,7 +12796,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12805,7 +12805,7 @@
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^8.56.6"
@@ -12820,10 +12820,10 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^3.0.1"
+        "@dotcom-reliability-kit/errors": "^3.1.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -12839,13 +12839,13 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/logger": "^3.0.6",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
-        "@dotcom-reliability-kit/serialize-request": "^3.0.2"
+        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/logger": "^3.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+        "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21"
@@ -12857,11 +12857,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.0.6",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.0.0"
       },
@@ -12902,10 +12902,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.0.6"
+        "@dotcom-reliability-kit/log-error": "^4.1.0"
       },
       "devDependencies": {
         "@financial-times/n-express": "^30.2.0",
@@ -12919,12 +12919,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.0.6",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/log-error": "^4.0.6",
-        "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/log-error": "^4.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
         "entities": "^4.5.0"
       },
       "devDependencies": {
@@ -12937,12 +12937,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.0.2",
-        "@dotcom-reliability-kit/errors": "^3.0.1",
-        "@dotcom-reliability-kit/logger": "^3.0.6",
+        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/errors": "^3.1.0",
+        "@dotcom-reliability-kit/logger": "^3.1.0",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.45.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",
@@ -12958,7 +12958,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12967,7 +12967,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.21"

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.2...app-info-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.1...app-info-v3.0.2) (2024-02-19)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.6...crash-handler-v4.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
+
 ## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.5...crash-handler-v4.0.6) (2024-04-22)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.6"
+    "@dotcom-reliability-kit/log-error": "^4.1.0"
   }
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.0.1...errors-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.0.0...errors-v3.0.1) (2024-01-09)
 
 

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/errors",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A suite of error classes which help you throw the most appropriate error in any situation",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.2...eslint-config-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.1...eslint-config-v3.0.2) (2024-03-22)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/eslint-config",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production",
   "repository": {
     "type": "git",

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.1...fetch-error-handler-v0.2.2) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Bug Fixes
+
+* handle node-fetch memory leak ([6716eca](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6716eca8b4fe0a49431d5bdc77bdf0ed2f7742ce))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^3.0.1 to ^3.1.0
+
 ## [0.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.0...fetch-error-handler-v0.2.1) (2024-01-09)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "^3.0.1"
+    "@dotcom-reliability-kit/errors": "^3.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.6...log-error-v4.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
+    * @dotcom-reliability-kit/logger bumped from ^3.0.6 to ^3.1.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
+    * @dotcom-reliability-kit/serialize-request bumped from ^3.0.2 to ^3.1.0
+
 ## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.5...log-error-v4.0.6) (2024-04-22)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,10 +16,10 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/logger": "^3.0.6",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
-    "@dotcom-reliability-kit/serialize-request": "^3.0.2"
+    "@dotcom-reliability-kit/app-info": "^3.1.0",
+    "@dotcom-reliability-kit/logger": "^3.1.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+    "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21"

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.6...logger-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Bug Fixes
+
+* bump pino from 8.21.0 to 9.0.0 in /packages/logger ([9384e05](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9384e05cd0c2bda8990dd2b30d2ad8777e81b87d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
+
 ## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.5...logger-v3.0.6) (2024-04-22)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+    "@dotcom-reliability-kit/app-info": "^3.1.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.0.0"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.6...middleware-log-errors-v4.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
+
 ## [4.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.5...middleware-log-errors-v4.0.6) (2024-04-22)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.0.6"
+    "@dotcom-reliability-kit/log-error": "^4.1.0"
   },
   "devDependencies": {
     "@financial-times/n-express": "^30.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [5.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.6...middleware-render-error-info-v5.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
+
 ## [5.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.5...middleware-render-error-info-v5.0.6) (2024-04-22)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,9 +16,9 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.0.2",
-    "@dotcom-reliability-kit/log-error": "^4.0.6",
-    "@dotcom-reliability-kit/serialize-error": "^3.0.2",
+    "@dotcom-reliability-kit/app-info": "^3.1.0",
+    "@dotcom-reliability-kit/log-error": "^4.1.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
     "entities": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.3...opentelemetry-v1.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
+
+### Bug Fixes
+
+* update all OpenTelemetry packages ([1a52e1a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1a52e1a0a6d7ddb017dbe2e4ff7b509649ea93b1))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
+    * @dotcom-reliability-kit/errors bumped from ^3.0.1 to ^3.1.0
+    * @dotcom-reliability-kit/logger bumped from ^3.0.6 to ^3.1.0
+
 ## [1.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.2...opentelemetry-v1.0.3) (2024-04-22)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -16,9 +16,9 @@
 	},
 	"main": "lib",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.0.2",
-		"@dotcom-reliability-kit/errors": "^3.0.1",
-		"@dotcom-reliability-kit/logger": "^3.0.6",
+		"@dotcom-reliability-kit/app-info": "^3.1.0",
+		"@dotcom-reliability-kit/errors": "^3.1.0",
+		"@dotcom-reliability-kit/logger": "^3.1.0",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.45.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.2...serialize-error-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.1...serialize-error-v3.0.2) (2024-03-22)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",

--- a/packages/serialize-request/CHANGELOG.md
+++ b/packages/serialize-request/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.2...serialize-request-v3.1.0) (2024-04-29)
+
+
+### Features
+
+* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.1...serialize-request-v3.0.2) (2024-03-22)
 
 

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-request",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.2...app-info-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
</details>

<details><summary>crash-handler: 4.1.0</summary>

## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.6...crash-handler-v4.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
</details>

<details><summary>errors: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.0.1...errors-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
</details>

<details><summary>eslint-config: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.2...eslint-config-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
</details>

<details><summary>fetch-error-handler: 0.2.2</summary>

## [0.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.1...fetch-error-handler-v0.2.2) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Bug Fixes

* handle node-fetch memory leak ([6716eca](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6716eca8b4fe0a49431d5bdc77bdf0ed2f7742ce))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^3.0.1 to ^3.1.0
</details>

<details><summary>log-error: 4.1.0</summary>

## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.6...log-error-v4.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
    * @dotcom-reliability-kit/logger bumped from ^3.0.6 to ^3.1.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
    * @dotcom-reliability-kit/serialize-request bumped from ^3.0.2 to ^3.1.0
</details>

<details><summary>logger: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.6...logger-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Bug Fixes

* bump pino from 8.21.0 to 9.0.0 in /packages/logger ([9384e05](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9384e05cd0c2bda8990dd2b30d2ad8777e81b87d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
</details>

<details><summary>middleware-log-errors: 4.1.0</summary>

## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.6...middleware-log-errors-v4.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
</details>

<details><summary>middleware-render-error-info: 5.1.0</summary>

## [5.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.6...middleware-render-error-info-v5.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
    * @dotcom-reliability-kit/log-error bumped from ^4.0.6 to ^4.1.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.0.2 to ^3.1.0
</details>

<details><summary>opentelemetry: 1.1.0</summary>

## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.3...opentelemetry-v1.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))


### Bug Fixes

* update all OpenTelemetry packages ([1a52e1a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1a52e1a0a6d7ddb017dbe2e4ff7b509649ea93b1))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.0.2 to ^3.1.0
    * @dotcom-reliability-kit/errors bumped from ^3.0.1 to ^3.1.0
    * @dotcom-reliability-kit/logger bumped from ^3.0.6 to ^3.1.0
</details>

<details><summary>serialize-error: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.2...serialize-error-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
</details>

<details><summary>serialize-request: 3.1.0</summary>

## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.2...serialize-request-v3.1.0) (2024-04-29)


### Features

* add support for Node.js 22 ([e083794](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e083794c2b4901a055de9fce483bcbab03b8e522))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).