### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,7 +3,7 @@
   "packages/crash-handler": "4.1.0",
   "packages/errors": "3.1.0",
   "packages/eslint-config": "3.1.0",
-  "packages/fetch-error-handler": "0.2.2",
+  "packages/fetch-error-handler": "0.2.3",
   "packages/log-error": "4.1.0",
   "packages/logger": "3.1.0",
   "packages/middleware-log-errors": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12829,7 +12829,7 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^3.1.0"

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.2...fetch-error-handler-v0.2.3) (2024-05-01)
+
+
+### Bug Fixes
+
+* make FetchResponse type compatible with a native Response object ([00fb83d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/00fb83d477a864a26dc59c698e5d2471181ea1eb))
+
 ## [0.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.1...fetch-error-handler-v0.2.2) (2024-04-29)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>fetch-error-handler: 0.2.3</summary>

## [0.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.2...fetch-error-handler-v0.2.3) (2024-05-01)


### Bug Fixes

* make FetchResponse type compatible with a native Response object ([00fb83d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/00fb83d477a864a26dc59c698e5d2471181ea1eb))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).