### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.1.0",
-  "packages/crash-handler": "4.1.0",
+  "packages/crash-handler": "4.1.1",
   "packages/errors": "3.1.0",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.3",
-  "packages/log-error": "4.1.0",
-  "packages/logger": "3.1.0",
-  "packages/middleware-log-errors": "4.1.0",
-  "packages/middleware-render-error-info": "5.1.0",
-  "packages/serialize-error": "3.1.0",
+  "packages/log-error": "4.1.1",
+  "packages/logger": "3.1.1",
+  "packages/middleware-log-errors": "4.1.1",
+  "packages/middleware-render-error-info": "5.1.1",
+  "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "1.1.0"
+  "packages/opentelemetry": "1.1.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12793,10 +12793,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.0"
+        "@dotcom-reliability-kit/log-error": "^4.1.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12848,12 +12848,12 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",
-        "@dotcom-reliability-kit/logger": "^3.1.0",
-        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+        "@dotcom-reliability-kit/logger": "^3.1.1",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
       "devDependencies": {
@@ -12866,11 +12866,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",
-        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.0.0"
       },
@@ -12911,10 +12911,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.0"
+        "@dotcom-reliability-kit/log-error": "^4.1.1"
       },
       "devDependencies": {
         "@financial-times/n-express": "^30.2.0",
@@ -12928,12 +12928,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.0",
-        "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+        "@dotcom-reliability-kit/log-error": "^4.1.1",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^4.5.0"
       },
       "devDependencies": {
@@ -12946,12 +12946,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",
         "@dotcom-reliability-kit/errors": "^3.1.0",
-        "@dotcom-reliability-kit/logger": "^3.1.0",
+        "@dotcom-reliability-kit/logger": "^3.1.1",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.45.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",
@@ -12967,7 +12967,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.0...crash-handler-v4.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
+
 ## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.0.6...crash-handler-v4.1.0) (2024-04-29)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.0"
+    "@dotcom-reliability-kit/log-error": "^4.1.1"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.0...log-error-v4.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.0 to ^3.1.1
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
+
 ## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.0.6...log-error-v4.1.0) (2024-04-29)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.1.0",
-    "@dotcom-reliability-kit/logger": "^3.1.0",
-    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+    "@dotcom-reliability-kit/logger": "^3.1.1",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.0...logger-v3.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.0.6...logger-v3.1.0) (2024-04-29)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.1.0",
-    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.0.0"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.0...middleware-log-errors-v4.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
+
 ## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.0.6...middleware-log-errors-v4.1.0) (2024-04-29)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.0"
+    "@dotcom-reliability-kit/log-error": "^4.1.1"
   },
   "devDependencies": {
     "@financial-times/n-express": "^30.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.0...middleware-render-error-info-v5.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
+
 ## [5.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.0.6...middleware-render-error-info-v5.1.0) (2024-04-29)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.1.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.0",
-    "@dotcom-reliability-kit/serialize-error": "^3.1.0",
+    "@dotcom-reliability-kit/log-error": "^4.1.1",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.0...opentelemetry-v1.1.1) (2024-05-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.0 to ^3.1.1
+
 ## [1.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.0.3...opentelemetry-v1.1.0) (2024-04-29)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.1.0",
 		"@dotcom-reliability-kit/errors": "^3.1.0",
-		"@dotcom-reliability-kit/logger": "^3.1.0",
+		"@dotcom-reliability-kit/logger": "^3.1.1",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.45.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.1.0...serialize-error-v3.2.0) (2024-05-02)
+
+
+### Features
+
+* serialise an AggregateError's sub-errors ([1b66c9f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1b66c9fa4462811a658666cb1a44f478d62de37b))
+
+
+### Documentation Changes
+
+* **serialize-error:** document the errors property on SerializedError ([5fe380c](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5fe380c08479c83248d87671f68e92493678d293))
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.0.2...serialize-error-v3.1.0) (2024-04-29)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.1</summary>

## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.0...crash-handler-v4.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
</details>

<details><summary>log-error: 4.1.1</summary>

## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.0...log-error-v4.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.0 to ^3.1.1
    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
</details>

<details><summary>logger: 3.1.1</summary>

## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.0...logger-v3.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
</details>

<details><summary>middleware-log-errors: 4.1.1</summary>

## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.0...middleware-log-errors-v4.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
</details>

<details><summary>middleware-render-error-info: 5.1.1</summary>

## [5.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.0...middleware-render-error-info-v5.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.0 to ^4.1.1
    * @dotcom-reliability-kit/serialize-error bumped from ^3.1.0 to ^3.2.0
</details>

<details><summary>opentelemetry: 1.1.1</summary>

## [1.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.0...opentelemetry-v1.1.1) (2024-05-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.0 to ^3.1.1
</details>

<details><summary>serialize-error: 3.2.0</summary>

## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.1.0...serialize-error-v3.2.0) (2024-05-02)


### Features

* serialise an AggregateError's sub-errors ([1b66c9f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1b66c9fa4462811a658666cb1a44f478d62de37b))


### Documentation Changes

* **serialize-error:** document the errors property on SerializedError ([5fe380c](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5fe380c08479c83248d87671f68e92493678d293))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).