### PR TITLE
fix: add log-error as dependency of opentelemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,6 +12951,7 @@
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",
         "@dotcom-reliability-kit/errors": "^3.1.0",
+        "@dotcom-reliability-kit/log-error": "^4.1.1",
         "@dotcom-reliability-kit/logger": "^3.1.1",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.45.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.1.0",
 		"@dotcom-reliability-kit/errors": "^3.1.0",
+		"@dotcom-reliability-kit/log-error": "^4.1.1",
 		"@dotcom-reliability-kit/logger": "^3.1.1",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.45.0",


### PR DESCRIPTION
We use logRecoverableError() in the OpenTelemetry package.

Thanks @huxley-ft for spotting this!