### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.1",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "1.1.1"
+  "packages/opentelemetry": "1.1.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12946,7 +12946,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.1.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.1...opentelemetry-v1.1.2) (2024-05-17)
+
+
+### Bug Fixes
+
+* add log-error as dependency of opentelemetry ([1e9fb75](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1e9fb758726507c8bc8eaf334dc69dd191abda1d))
+
 ## [1.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.0...opentelemetry-v1.1.1) (2024-05-02)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 1.1.2</summary>

## [1.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.1...opentelemetry-v1.1.2) (2024-05-17)


### Bug Fixes

* add log-error as dependency of opentelemetry ([1e9fb75](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1e9fb758726507c8bc8eaf334dc69dd191abda1d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).