### PR TITLE
chore: bump all OpenTelemetry packages at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      opentelemetry:
+        patterns:
+          - "@opentelemetry/*"
 
   - package-ecosystem: "npm"
     directory: "/resources/logos"
@@ -120,6 +123,3 @@ updates:
       opentelemetry:
         patterns:
           - "@opentelemetry/*"
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
We see a lot of PRs for OpenTelemetry packages because many of them are technically breaking changes - e.g. bumping from 0.4.0 to 0.5.0. It's annoying and I have to do lots of extra work to keep these packages up to date. This should mean we only get one.