### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.1.0",
-  "packages/crash-handler": "4.1.1",
+  "packages/app-info": "3.2.0",
+  "packages/crash-handler": "4.1.2",
   "packages/errors": "3.1.0",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.3",
-  "packages/log-error": "4.1.1",
-  "packages/logger": "3.1.1",
-  "packages/middleware-log-errors": "4.1.1",
-  "packages/middleware-render-error-info": "5.1.1",
+  "packages/log-error": "4.1.2",
+  "packages/logger": "3.1.2",
+  "packages/middleware-log-errors": "4.1.2",
+  "packages/middleware-render-error-info": "5.1.2",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "1.1.2"
+  "packages/opentelemetry": "2.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12781,7 +12781,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12790,10 +12790,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.1"
+        "@dotcom-reliability-kit/log-error": "^4.1.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -12845,11 +12845,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.1.0",
-        "@dotcom-reliability-kit/logger": "^3.1.1",
+        "@dotcom-reliability-kit/app-info": "^3.2.0",
+        "@dotcom-reliability-kit/logger": "^3.1.2",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -12863,10 +12863,10 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/app-info": "^3.2.0",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.2.0"
@@ -12887,10 +12887,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.1"
+        "@dotcom-reliability-kit/log-error": "^4.1.2"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.2.0",
@@ -12904,11 +12904,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.1.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.1",
+        "@dotcom-reliability-kit/app-info": "^3.2.0",
+        "@dotcom-reliability-kit/log-error": "^4.1.2",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^4.5.0"
       },
@@ -12922,13 +12922,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "1.1.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.1.0",
+        "@dotcom-reliability-kit/app-info": "^3.2.0",
         "@dotcom-reliability-kit/errors": "^3.1.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.1",
-        "@dotcom-reliability-kit/logger": "^3.1.1",
+        "@dotcom-reliability-kit/log-error": "^4.1.2",
+        "@dotcom-reliability-kit/logger": "^3.1.2",
         "@opentelemetry/auto-instrumentations-node": "^0.47.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.52.0",

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.1.0...app-info-v3.2.0) (2024-06-19)
+
+
+### Features
+
+* add a service ID property ([3571259](https://github.com/Financial-Times/dotcom-reliability-kit/commit/35712597c7bc0582c96d34b584ca4e0944e5b626))
+* add semantic convention aliases ([ae585fc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ae585fc4ff164007a149a7f4224f4d9842e0af6d))
+* pull the release version from package.json ([f32cc27](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f32cc27c2eb65cdfd938ec3110fc763bebec18ef))
+
+
+### Bug Fixes
+
+* always use a UUID for instance ID ([88db1fb](https://github.com/Financial-Times/dotcom-reliability-kit/commit/88db1fb255a701536beac86d1d16211168724517))
+* default semantic attributes to undefined ([b43aab0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b43aab043c1db4dbac27397f435525ccfa22bb49))
+* export the SemanticConventions type ([6cfaca0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6cfaca0edbf023d4577377ad59cbe908c7ae7e27))
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.0.2...app-info-v3.1.0) (2024-04-29)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.1...crash-handler-v4.1.2) (2024-06-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
+
 ## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.0...crash-handler-v4.1.1) (2024-05-02)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.1"
+    "@dotcom-reliability-kit/log-error": "^4.1.2"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.1...log-error-v4.1.2) (2024-06-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
+    * @dotcom-reliability-kit/logger bumped from ^3.1.1 to ^3.1.2
+
 ## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.0...log-error-v4.1.1) (2024-05-02)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.1.0",
-    "@dotcom-reliability-kit/logger": "^3.1.1",
+    "@dotcom-reliability-kit/app-info": "^3.2.0",
+    "@dotcom-reliability-kit/logger": "^3.1.2",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.1...logger-v3.1.2) (2024-06-19)
+
+
+### Bug Fixes
+
+* bump pino from 9.0.0 to 9.1.0 ([3732e3b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3732e3ba6dff33a75cbe215e12028d7de40347da))
+* bump pino from 9.1.0 to 9.2.0 ([5d2f4fb](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5d2f4fb7a313574810d504a7af93814fd8be0be5))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
+
 ## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.0...logger-v3.1.1) (2024-05-02)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.1.0",
+    "@dotcom-reliability-kit/app-info": "^3.2.0",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.2.0"

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.1...middleware-log-errors-v4.1.2) (2024-06-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
+
 ## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.0...middleware-log-errors-v4.1.1) (2024-05-02)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.1"
+    "@dotcom-reliability-kit/log-error": "^4.1.2"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.1...middleware-render-error-info-v5.1.2) (2024-06-19)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
+
 ## [5.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.0...middleware-render-error-info-v5.1.1) (2024-05-02)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.1.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.1",
+    "@dotcom-reliability-kit/app-info": "^3.2.0",
+    "@dotcom-reliability-kit/log-error": "^4.1.2",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.2...opentelemetry-v2.0.0) (2024-06-19)
+
+
+### ⚠ BREAKING CHANGES
+
+* stop using default exports
+
+### Features
+
+* add OpenTelemetry metrics support ([1fd08ec](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1fd08ecc42b83a1fead1b590ec1ae5caa86a5f91))
+* add the ability to get metrics meters ([2d555e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2d555e9b12fd4d5ddb419277d9c1b3511ab9a3af))
+* prevent the setup from running twice ([1d74508](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1d7450805189db4751a35bf80f08be3b4a996dd8))
+* send host metrics ([9217bf7](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9217bf726921cb883ed327b617bcfa1b910da5ac))
+
+
+### Bug Fixes
+
+* downgrade status logs to info ([ca2216e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ca2216e442ebf356959aa2faaa218eacc6eef17d))
+* move tracing config into a new module ([72e123e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/72e123ed33ae647c69e3a59f7c9cb81614ee2fb6))
+* switch away from deprecated `spanProcessor` ([55ba635](https://github.com/Financial-Times/dotcom-reliability-kit/commit/55ba63599454fdf7c932f28d035a326c13ba4206))
+* update all OpenTelemetry packages ([dff05ca](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dff05ca28afc797343e8e4bc8e56f8878c5656ae))
+* update the existing OpenTelemetry packages ([5e81878](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5e81878cad5bdb8a7b6562342980dde8385a4a68))
+
+
+### Documentation Changes
+
+* fix a copy/paste error ([14b4c76](https://github.com/Financial-Times/dotcom-reliability-kit/commit/14b4c765502faf3afa991b3d2ec3ea50f9751fc6))
+
+
+### Miscellaneous
+
+* stop using default exports ([af3504a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/af3504ad46f694a84be2350355d36ce0bead21e1))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
+    * @dotcom-reliability-kit/logger bumped from ^3.1.1 to ^3.1.2
+
 ## [1.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.1...opentelemetry-v1.1.2) (2024-05-17)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "1.1.2",
+	"version": "2.0.0",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -16,10 +16,10 @@
 	},
 	"main": "lib",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.1.0",
+		"@dotcom-reliability-kit/app-info": "^3.2.0",
 		"@dotcom-reliability-kit/errors": "^3.1.0",
-		"@dotcom-reliability-kit/log-error": "^4.1.1",
-		"@dotcom-reliability-kit/logger": "^3.1.1",
+		"@dotcom-reliability-kit/log-error": "^4.1.2",
+		"@dotcom-reliability-kit/logger": "^3.1.2",
 		"@opentelemetry/auto-instrumentations-node": "^0.47.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.52.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.2.0</summary>

## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.1.0...app-info-v3.2.0) (2024-06-19)


### Features

* add a service ID property ([3571259](https://github.com/Financial-Times/dotcom-reliability-kit/commit/35712597c7bc0582c96d34b584ca4e0944e5b626))
* add semantic convention aliases ([ae585fc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ae585fc4ff164007a149a7f4224f4d9842e0af6d))
* pull the release version from package.json ([f32cc27](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f32cc27c2eb65cdfd938ec3110fc763bebec18ef))


### Bug Fixes

* always use a UUID for instance ID ([88db1fb](https://github.com/Financial-Times/dotcom-reliability-kit/commit/88db1fb255a701536beac86d1d16211168724517))
* default semantic attributes to undefined ([b43aab0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b43aab043c1db4dbac27397f435525ccfa22bb49))
* export the SemanticConventions type ([6cfaca0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/6cfaca0edbf023d4577377ad59cbe908c7ae7e27))
</details>

<details><summary>crash-handler: 4.1.2</summary>

## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.1...crash-handler-v4.1.2) (2024-06-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
</details>

<details><summary>log-error: 4.1.2</summary>

## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.1...log-error-v4.1.2) (2024-06-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
    * @dotcom-reliability-kit/logger bumped from ^3.1.1 to ^3.1.2
</details>

<details><summary>logger: 3.1.2</summary>

## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.1...logger-v3.1.2) (2024-06-19)


### Bug Fixes

* bump pino from 9.0.0 to 9.1.0 ([3732e3b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3732e3ba6dff33a75cbe215e12028d7de40347da))
* bump pino from 9.1.0 to 9.2.0 ([5d2f4fb](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5d2f4fb7a313574810d504a7af93814fd8be0be5))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
</details>

<details><summary>middleware-log-errors: 4.1.2</summary>

## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.1...middleware-log-errors-v4.1.2) (2024-06-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
</details>

<details><summary>middleware-render-error-info: 5.1.2</summary>

## [5.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.1...middleware-render-error-info-v5.1.2) (2024-06-19)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
</details>

<details><summary>opentelemetry: 2.0.0</summary>

## [2.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.2...opentelemetry-v2.0.0) (2024-06-19)


### ⚠ BREAKING CHANGES

* stop using default exports

### Features

* add OpenTelemetry metrics support ([1fd08ec](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1fd08ecc42b83a1fead1b590ec1ae5caa86a5f91))
* add the ability to get metrics meters ([2d555e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2d555e9b12fd4d5ddb419277d9c1b3511ab9a3af))
* prevent the setup from running twice ([1d74508](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1d7450805189db4751a35bf80f08be3b4a996dd8))
* send host metrics ([9217bf7](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9217bf726921cb883ed327b617bcfa1b910da5ac))


### Bug Fixes

* downgrade status logs to info ([ca2216e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/ca2216e442ebf356959aa2faaa218eacc6eef17d))
* move tracing config into a new module ([72e123e](https://github.com/Financial-Times/dotcom-reliability-kit/commit/72e123ed33ae647c69e3a59f7c9cb81614ee2fb6))
* switch away from deprecated `spanProcessor` ([55ba635](https://github.com/Financial-Times/dotcom-reliability-kit/commit/55ba63599454fdf7c932f28d035a326c13ba4206))
* update all OpenTelemetry packages ([dff05ca](https://github.com/Financial-Times/dotcom-reliability-kit/commit/dff05ca28afc797343e8e4bc8e56f8878c5656ae))
* update the existing OpenTelemetry packages ([5e81878](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5e81878cad5bdb8a7b6562342980dde8385a4a68))


### Documentation Changes

* fix a copy/paste error ([14b4c76](https://github.com/Financial-Times/dotcom-reliability-kit/commit/14b4c765502faf3afa991b3d2ec3ea50f9751fc6))


### Miscellaneous

* stop using default exports ([af3504a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/af3504ad46f694a84be2350355d36ce0bead21e1))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.1.0 to ^3.2.0
    * @dotcom-reliability-kit/log-error bumped from ^4.1.1 to ^4.1.2
    * @dotcom-reliability-kit/logger bumped from ^3.1.1 to ^3.1.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).