### PR TITLE
Refactor the OpenTelemetry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,11 +1900,11 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
-      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.8.tgz",
+      "integrity": "sha512-vYVqYzHicDqyKB+NQhAc54I1QWCBLCrYG6unqOIcBTHx+7x8C9lcoLj3KVJXs2VB4lUbpWY+Kk9NipcbXYWmvg==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.10",
+        "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -1912,13 +1912,13 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.12.tgz",
-      "integrity": "sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1926,90 +1926,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@hapi/b64": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-    },
-    "node_modules/@hapi/cryptiles": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
-      "dependencies": {
-        "@hapi/boom": "9.x.x"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/iron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
-      "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "node_modules/@hapi/podium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
-      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
-      }
-    },
-    "node_modules/@hapi/teamwork": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
-      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@hapi/validate": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3352,53 +3268,55 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.45.0.tgz",
-      "integrity": "sha512-l4+f5S1YyOUS2upiI/c2VipV9Ow7rv593D0lNWTLzx+quSFlzQjSEjNn550kbFb+oqc9ZmaU0ogj5VN3nuYU2g==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.46.1.tgz",
+      "integrity": "sha512-s0CwmY9KYtPawOhV5YO2Gf62uVOQRNvT6Or8IZ0S4gr/kPVNhoMehTsQvqBwSWQfoFrkmW3KKOHiKJEp4dVGXg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/instrumentation-amqplib": "^0.37.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.41.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.41.1",
         "@opentelemetry/instrumentation-aws-sdk": "^0.41.0",
         "@opentelemetry/instrumentation-bunyan": "^0.38.0",
         "@opentelemetry/instrumentation-cassandra-driver": "^0.38.0",
-        "@opentelemetry/instrumentation-connect": "^0.36.0",
+        "@opentelemetry/instrumentation-connect": "^0.36.1",
         "@opentelemetry/instrumentation-cucumber": "^0.6.0",
         "@opentelemetry/instrumentation-dataloader": "^0.9.0",
-        "@opentelemetry/instrumentation-dns": "^0.36.0",
-        "@opentelemetry/instrumentation-express": "^0.38.0",
-        "@opentelemetry/instrumentation-fastify": "^0.36.0",
+        "@opentelemetry/instrumentation-dns": "^0.36.1",
+        "@opentelemetry/instrumentation-express": "^0.39.0",
+        "@opentelemetry/instrumentation-fastify": "^0.36.1",
         "@opentelemetry/instrumentation-fs": "^0.12.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.36.0",
         "@opentelemetry/instrumentation-graphql": "^0.40.0",
         "@opentelemetry/instrumentation-grpc": "^0.51.0",
-        "@opentelemetry/instrumentation-hapi": "^0.37.0",
+        "@opentelemetry/instrumentation-hapi": "^0.38.0",
         "@opentelemetry/instrumentation-http": "^0.51.0",
         "@opentelemetry/instrumentation-ioredis": "^0.40.0",
-        "@opentelemetry/instrumentation-knex": "^0.36.0",
+        "@opentelemetry/instrumentation-knex": "^0.36.1",
         "@opentelemetry/instrumentation-koa": "^0.40.0",
         "@opentelemetry/instrumentation-lru-memoizer": "^0.37.0",
         "@opentelemetry/instrumentation-memcached": "^0.36.0",
         "@opentelemetry/instrumentation-mongodb": "^0.43.0",
-        "@opentelemetry/instrumentation-mongoose": "^0.38.0",
-        "@opentelemetry/instrumentation-mysql": "^0.38.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.38.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.37.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.38.1",
+        "@opentelemetry/instrumentation-mysql": "^0.38.1",
+        "@opentelemetry/instrumentation-mysql2": "^0.38.1",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.37.1",
         "@opentelemetry/instrumentation-net": "^0.36.0",
         "@opentelemetry/instrumentation-pg": "^0.41.0",
-        "@opentelemetry/instrumentation-pino": "^0.38.0",
-        "@opentelemetry/instrumentation-redis": "^0.39.0",
+        "@opentelemetry/instrumentation-pino": "^0.39.0",
+        "@opentelemetry/instrumentation-redis": "^0.39.1",
         "@opentelemetry/instrumentation-redis-4": "^0.39.0",
         "@opentelemetry/instrumentation-restify": "^0.38.0",
         "@opentelemetry/instrumentation-router": "^0.37.0",
         "@opentelemetry/instrumentation-socket.io": "^0.39.0",
-        "@opentelemetry/instrumentation-tedious": "^0.10.0",
+        "@opentelemetry/instrumentation-tedious": "^0.10.1",
+        "@opentelemetry/instrumentation-undici": "^0.2.0",
         "@opentelemetry/instrumentation-winston": "^0.37.0",
         "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.9",
-        "@opentelemetry/resource-detector-aws": "^1.4.2",
+        "@opentelemetry/resource-detector-aws": "^1.5.0",
+        "@opentelemetry/resource-detector-azure": "^0.2.6",
         "@opentelemetry/resource-detector-container": "^0.3.9",
         "@opentelemetry/resource-detector-gcp": "^0.29.9",
-        "@opentelemetry/resources": "^1.12.0",
+        "@opentelemetry/resources": "^1.24.0",
         "@opentelemetry/sdk-node": "^0.51.0"
       },
       "engines": {
@@ -3409,9 +3327,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.0.tgz",
-      "integrity": "sha512-s7xaQ9ifDpJvwbWRLkZD/J5hY35w+MECm4TQUkg6szRcny9lf6oVhWij4w3JJFQgvHQMXU7oXOpX8Z05HxV/8g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.1.tgz",
+      "integrity": "sha512-R5r6DO4kgEOVBxFXhXjwospLQkv+sYxwCfjvoZBe7Zm6KKXAV9kDSJhi/D1BweowdZmO+sdbENLs374gER8hpQ==",
       "engines": {
         "node": ">=14"
       },
@@ -3434,53 +3352,97 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.0.tgz",
-      "integrity": "sha512-xQpxKzS8ZnxYCa1v+3EKWhwMrSK3+RezpJ+AEKaP2pf2QbLfHt7kKfSn7niR2u3A1Tbe2aC7Ptt9+MafhThOOQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.1.tgz",
+      "integrity": "sha512-P9+Hkszih95ITvldGZ+kXvj9HpD1QfS+PwooyHK72GYA+Bgm+yUSAsDkUkDms8+s9HW6poxURv3LcjaMuBBpVQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.0.tgz",
-      "integrity": "sha512-zODqnLZmPOxj9CarFv0TrVlx9mgj0TfCMCiUiTdNi9iA2rgdKVo+bjJjpYF6LCTJOQCR5TScAUCKyzwkgDI+iA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.1.tgz",
+      "integrity": "sha512-n+LhLPsX07URh+HhV2SHVSvz1t4G/l/CE5BjpmhAPqeTceFac1VpyQkavWEJbvnK5bUEXijWt4LxAxFpt2fXyw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.0.tgz",
-      "integrity": "sha512-Fi7r0iMqGoFCQQ+WY0pYOWp395vdinZJIkYKnNbnreHxAN/kVDBl2FxbV3DeOKuRxEY08Gyb9ggPf+Zrqp7l/w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.1.tgz",
+      "integrity": "sha512-SE9f0/6V6EeXC9i+WA4WFjS1EYgaBCpAnI5+lxWvZ7iO7EU1IvHvZhP6Kojr0nLldo83gqg6G7OWFqsID3uF+w==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -3489,21 +3451,65 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.0.tgz",
-      "integrity": "sha512-QeGv0PHONswmu567pf9QliJ6s6DgCu5+ziF+soNS1LTcr1VRRVLViYLmGxmzDFUC48sjNTu7sumcKT0nJXsGBw==",
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.1.tgz",
+      "integrity": "sha512-+Rl/VFmu2n6eaRMnVbyfZx1DqR/1KNyWebYuHyQBZaEAVIn/ZLgmofRpXN1X2nhJ4BNaptQUNxAstCYYz6dKoQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -3542,14 +3548,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.41.0.tgz",
-      "integrity": "sha512-TeK7ZGtmEDqkfuwyAvlexnG11e7kEux0PncShqdyst2h1k1nVKmwnY/woPCUcTyU08PX6fa9YEyJ9E+G6wZacQ==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.41.1.tgz",
+      "integrity": "sha512-/BLG+0DQr2tCILFGJKJH2Fg6eyjhqOlVflYpNddUEXnzyQ/PAhTdgirkqbICFgeSW2XYcEY9zXpuRldrVNw9cA==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/aws-lambda": "8.10.122"
       },
       "engines": {
@@ -3608,13 +3614,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.36.0.tgz",
-      "integrity": "sha512-k9++bmJZ9zDEs3u3DnKTn2l7QTiNFg3gPx7G9rW0TPnP+xZoBSBTrEcGYBaqflQlrFG23Q58+X1sM2ayWPv5Fg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.36.1.tgz",
+      "integrity": "sha512-xI5Q/CMmzBmHshPnzzjD19ptFaYO/rQWzokpNio4QixZYWhJsa35QgRvN9FhPkwgtuJIbt/CWWAufJ3egJNHEA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/connect": "3.4.36"
       },
       "engines": {
@@ -3654,9 +3660,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.36.0.tgz",
-      "integrity": "sha512-Uo4lLqqryToV7IfX7EVg+pOHdq6f2F0gIQoMZoC4LIcr3lO9Uk6pJr0YSB9Y4Pcu+PcGuDDXIIwKuUqEDfcTOw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.36.1.tgz",
+      "integrity": "sha512-NWRbQ7q0E3co/CNTWLZZvUzZoKhB1iTitY282IM8HDTXkA6VRssCfOcvaHw5ezOh23TJbAeYxmmpVj4hFvDPYQ==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -3670,9 +3676,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.38.0.tgz",
-      "integrity": "sha512-izId/qcgMgfWV292ZI9b9E7HdV9446vi0Z5zu5fSlt4MF+R6LZXbZLTQAaboJ4Y2+JbtH7apvko1DF93qTFtqw==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.39.0.tgz",
+      "integrity": "sha512-AG8U7z7D0JcBu/7dDcwb47UMEzj9/FMiJV2iQZqrsZnxR3FjB9J9oIH2iszJYci2eUdp2WbdvtpD9RV/zmME5A==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.51.0",
@@ -3686,9 +3692,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.36.0.tgz",
-      "integrity": "sha512-nJQEi5cInZ7j5eC6QvgwlRsEFUZVGvlI8BDSLZ9xY33GTd6U6fCS8M+i26c1U74MLNRikpNBLV/1baT5GGIayg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.36.1.tgz",
+      "integrity": "sha512-3Nfm43PI0I+3EX+1YbSy6xbDu276R1Dh1tqAk68yd4yirnIh52Kd5B+nJ8CgHA7o3UKakpBjj6vSzi5vNCzJIA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.51.0",
@@ -3761,14 +3767,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.37.0.tgz",
-      "integrity": "sha512-LprBF0Z/wz3WXwdwoatsfU0IaKkl9At98umNfWtMcMUnYqeIiqVJJ+ijsBDHIhfuc3pbeZ9W4n8CAM1SBYFWxg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.38.0.tgz",
+      "integrity": "sha512-ZcOqEuwuutTDYIjhDIStix22ECblG/i9pHje23QGs4Q4YS4RMaZ5hKCoQJxW88Z4K7T53rQkdISmoXFKDV8xMg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/hapi__hapi": "20.0.13"
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -3811,9 +3816,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.36.0.tgz",
-      "integrity": "sha512-UXMZhhOHXlsaS/U9xCj1i7+CjWSmmWnOSEUiwa9iCfCnx7qD96BuMSxmq68h3kUfxpUbFGq8OX7znSXbcatInQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.36.1.tgz",
+      "integrity": "sha512-6bEuiI+yMf3D0+ZWZE2AKmXhIhBvZ0brdO/0A8lUqeqeS+sS4fTcjA1F2CclsCNxYWEgcs8o3QyQqPceBeVRlg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -3890,9 +3895,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.38.0.tgz",
-      "integrity": "sha512-2SnkQQDlsB6GS6OlXb/wQj1FkXMRPgIbwZxjnZ3KUJC+NQgwnzQRKZFxUrRg29l2WLeUWTSBPX1zO7RKBdKtYw==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.38.1.tgz",
+      "integrity": "sha512-zaeiasdnRjXe6VhYCBMdkmAVh1S5MmXC/0spet+yqoaViGnYst/DOxPvhwg3yT4Yag5crZNWsVXnA538UjP6Ow==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.51.0",
@@ -3906,9 +3911,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.38.0.tgz",
-      "integrity": "sha512-EbbvU9/UPmtNnqQ4JVd2ku8IOeMdCY6OcvJz3SgfWQINXyPL8SZhcPm/CW6hkFq88BYMMlLDSOzu1S3gZwJ1+Q==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.38.1.tgz",
+      "integrity": "sha512-+iBAawUaTfX/HAlvySwozx0C2B6LBfNPXX1W8Z2On1Uva33AGkw2UjL9XgIg1Pj4eLZ9R4EoJ/aFz+Xj4E/7Fw==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -3922,9 +3927,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.38.0.tgz",
-      "integrity": "sha512-x6BN7sNKgGzERoQOwkfp9WZdNqDzmQF6c2nSXaAV/kPzhOlPVQ9sJLrpyL+/i/+6iVQRZvA0KaPdCWiUSuBupQ==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.38.1.tgz",
+      "integrity": "sha512-qkpHMgWSDTYVB1vlZ9sspf7l2wdS5DDq/rbIepDwX5BA0N0068JTQqh0CgAh34tdFqSCnWXIhcyOXC2TtRb0sg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -3938,9 +3943,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.37.0.tgz",
-      "integrity": "sha512-9/ZZ9x9s5ZNcWZYrmqTVIGb0ADNGxYaqR65gznkHzxXUXuckgzw9jaXKaErjWEyouW0FOECVLgeAB9NcjYB57g==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.37.1.tgz",
+      "integrity": "sha512-ebYQjHZEmGHWEALwwDGhSQVLBaurFnuLIkZD5igPXrt7ohfF4lc5/4al1LO+vKc0NHk8SJWStuRueT86ISA8Vg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -3986,9 +3991,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.38.0.tgz",
-      "integrity": "sha512-m4tkO+tuKv0zs2uLNxsMw06RwBNjHua8r9FYUlSlVcaF4EHTqC2XOk3h3OWw8HosZAvJvjryAgbEGuX9wJPn7A==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.39.0.tgz",
+      "integrity": "sha512-uA17F2iP77o3NculB63QD2zv3jkJ093Gfb0GxHLEqTIqpYs1ToJ53ybWwjJwqFByxk7GrliaxaxVtWC23PKzBg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0"
       },
@@ -4000,9 +4005,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.39.0.tgz",
-      "integrity": "sha512-yjHWwufY7kfKtf20rliqlETgP32X3ZynGAfoP59NXSSHwTCZS7QMn+S+Hb0iLjwbca/iTM/BooiVFrB943kMrw==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.39.1.tgz",
+      "integrity": "sha512-HUjTerD84jRJnSyDrRPqn6xQ7K91o9qLflRPZqzRvq0GRj5PMfc6TJ/z3q/ayWy/2Kzffhrp7HCIVp0u0TkgUg==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
         "@opentelemetry/redis-common": "^0.36.2",
@@ -4078,12 +4083,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.10.0.tgz",
-      "integrity": "sha512-9P3bMtx6ncM1IPjSy6nilVohqFJ1Y0XutY6/WHO8Xuphca8MIq2vzmjzREbS+9TfW+1Eq4Q6Y4LMNoDrHwSAaw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.10.1.tgz",
+      "integrity": "sha512-maSXMxgS0szU52khQzAROV4nWr+3M8mZajMQOc3/7tYjo+Q3HlWAowOuagPvp4pwROK4x6oDaFYlY+ZSj1qjYA==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/tedious": "^4.0.10"
       },
       "engines": {
@@ -4091,6 +4096,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.2.0.tgz",
+      "integrity": "sha512-RH9WdVRtpnyp8kvya2RYqKsJouPxvHl7jKPsIfrbL8u2QCKloAGi0uEqDHoOS15ZRYPQTDXZ7d8jSpUgSQmvpA==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.51.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
@@ -4109,27 +4129,49 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-hR4c9vWVz1QgzCBSyy9zSDkvfTgaK96E6/tfVP6O4dzdZW9HqWimA3lXV/KXadEGqShvM4GToz9EHp2A5RU5bQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-UYlnOYyDdzo1Gw559EHCzru0RwhvuXCwoH8jGo9J4gO1TE58GjnEmIjomMsKBCym3qWNJfIQXw+9SZCV0DdQNg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-oTRtDvvB0bTRTBVrvKA/oM1gIAqQ6DVQS07pvqiL1cZS8wBrGgpw+2iTd0nV661Y/MhDn/kNWp8lRhMEIKN9bw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-ZAS+4pq8o7dsugGTwV9s6JMKSxi+guIHdn0acOv0bqj26e9pWDFx5Ky+bI0aY46uR9Y0JyXqY+KAEYM/SO3DFA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -4137,15 +4179,37 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-WDANDLSUh11Gu5o6iCzmjZraIv5bK8z1L/t6lxQ2NeEKiKUPo5pVOBBQQC/yAQU2yeqkiO1GRCieH+XahZf60A==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-gxxxwfk0inDMb5DLeuxQ3L8TtptxSiTNHE4nnAJH34IQXAVRhXSXW1rK8PmDKDngRPIZ6J7ncUCjjIn8b+AgqQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -4155,23 +4219,78 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.0.tgz",
-      "integrity": "sha512-ylLgx2xumVoSefDHP9GMAU/LG+TU3+8eacVDXV5o1RqWxsdVOaQmCTY0XyDgeRTn6hIOVAq/HHQbRq3iWOrt2A==",
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.1.tgz",
+      "integrity": "sha512-OppYOXwV9LQqqtYUCywqoOqX/JT9LQ5/FMuPZ//eTkvuHdUC4ZMwz2c6uSoT2R90GWvvGnF1iEqTGyTT3xAt2Q==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
@@ -4186,25 +4305,47 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.0.tgz",
-      "integrity": "sha512-rcuMtEOTZC7TW84tws1QLUVRElrGSbBJwK0b+qa56zJULDiUIiUpS+dSzO+aUchg7MtTJBZSG5OPsfsKpGgNig==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.1.tgz",
+      "integrity": "sha512-RzwoLe6QzsYGcpmxxDbbbgSpe3ncxSM4dtFHXh/rCYGjyq0nZGXKvk26mJtWZ4kQ3nuiIoqSZueIuGmt/mvOTA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.0.tgz",
-      "integrity": "sha512-7TMIDE4+NO5vnkor+zned42wqca+hmhW5gWKhmYjUHC5B5uojo1PvtmBrd7kigFu96XvL4ZUWVzibWRWIQ/++Q==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.1.tgz",
+      "integrity": "sha512-nda97ZwhpZKyUJTXqQuKzNhPMUgMLunbbGWn8kroBwegn+nh6OhtyGkrVQsQLNdVKJl0KeB5z0ZgeWszrYhwFw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -4213,18 +4354,62 @@
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.0.tgz",
-      "integrity": "sha512-r3MX3AmJiUeiWTXSDOdwBeaO+ahvWcFCpuKxmhhsH8Q8LqDnjhNd3krqBh4Qsq9wa0WhWtiQaDs/NOCWoMOlOw==",
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.1.tgz",
+      "integrity": "sha512-7bRBJn3FG1l195A1m+xXRHvgzAOBsfmRi9uZ5Da18oTh7BLmNDiA8+kpk51FpTsU1PCikPVpRDNPhKVB6lyzZg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -4251,12 +4436,27 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.4.2.tgz",
-      "integrity": "sha512-Rt4cztIz8UZZ32wRbotKPVbkRfukiMM8xfzf2C1M+Puv91Cw6kDJHAfWCqkx7FdNe0e6aF4u2lkFweE1849RCg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.5.0.tgz",
+      "integrity": "sha512-JNk/kSzzNQaiMo/F0b/bm8S3Qtr/m89BckN9B4U/cPHSqKLdxX03vgRBOqkXJ5KlAD8kc6K1Etcr8QfvGw6+uA==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/resource-detector-azure": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.2.7.tgz",
+      "integrity": "sha512-+R3VnPaK6rc+kKfdvhgQlYDGXy0+JMAjPNDjcRQSeXY8pVOzHGCIrY+gT6gUrpjsw8w1EgNBVofr+qeNOr+o4A==",
+      "dependencies": {
+        "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -4299,12 +4499,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
+      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -4313,13 +4513,35 @@
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.0.tgz",
-      "integrity": "sha512-K4fMBRFD8hQ6khk0rvYFuo6L9ymeGgByir6BcuFIgQuQ00OhYwBi9AruZz5V733Ejq7P8ObR3YyubkOUIbeVAw==",
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.1.tgz",
+      "integrity": "sha512-ULQQtl82b673PpZc5/0EtH4V+BrwVOgKJZEB7tYZnGTG3I98tQVk89S9/JSixomDr++F4ih+LSJTCqIKBz+MQQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -4329,13 +4551,35 @@
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.0.tgz",
-      "integrity": "sha512-4tJ+E6N019OZVB/nUW/LoK9xHxfeh88TCoaTqHeLBE9wLYfi6irWW6J9cphMav7J8Qk0D5b7/RM4VEY4dArWOA==",
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
+      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
@@ -4345,24 +4589,46 @@
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.0.tgz",
-      "integrity": "sha512-MrPXDQsTAj3lcY8YUCjb7dvSXVZ5jG6wmjD2LB68V1rsLBdP8j70jsI9GaKijY7QB6psbLq6apO1vYeim5U7aw==",
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
-        "@opentelemetry/exporter-zipkin": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/sdk-trace-node": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.1.tgz",
+      "integrity": "sha512-GgmNF9C+6esr8PIJxCqHw84rEOkYm6XdFWZ2+Wyc3qaUt92ACoN7uSw5iKNvaUq62W0xii1wsGxwHzyENtPP8w==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
+        "@opentelemetry/exporter-zipkin": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/sdk-trace-node": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -4371,14 +4637,23 @@
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -4387,16 +4662,92 @@
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.0.tgz",
-      "integrity": "sha512-QgByHmM9uloTpcYEEyW9YJEIMKHFSIM677RH9pJPWWwtM2NQFbEp/8HIJw80Ymtaz6cAxg1Kay1ByqIVzq3t5g==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
+      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.24.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/propagator-b3": "1.24.0",
-        "@opentelemetry/propagator-jaeger": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
+        "@opentelemetry/api-logs": "0.51.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.7.4",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
+      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
+      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.1.tgz",
+      "integrity": "sha512-/FZX8uWaGIAwsDhqI8VvQ+qWtfMNlXjaFYGc+vmxgdRFppCSSIRwrPyIhJO1qx61okyYhoyxVEZAfoiNxrfJCg==",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.24.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/propagator-b3": "1.24.1",
+        "@opentelemetry/propagator-jaeger": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -4404,6 +4755,28 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -4502,24 +4875,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4741,42 +5096,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hapi__catbox": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.6.tgz",
-      "integrity": "sha512-qdMHk4fBlwRfnBBDJaoaxb+fU9Ewi2xqkXD3mNjSPl2v/G/8IJbDpVRBuIcF7oXrcE8YebU5M8cCeKh1NXEn0w=="
-    },
-    "node_modules/@types/hapi__hapi": {
-      "version": "20.0.13",
-      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.13.tgz",
-      "integrity": "sha512-LP4IPfhIO5ZPVOrJo7H8c8Slc0WYTFAUNQX1U0LBPKyXioXhH5H2TawIgxKujIyOhbwoBbpvOsBf6o5+ToJIrQ==",
-      "dependencies": {
-        "@hapi/boom": "^9.0.0",
-        "@hapi/iron": "^6.0.0",
-        "@hapi/podium": "^4.1.3",
-        "@types/hapi__catbox": "*",
-        "@types/hapi__mimos": "*",
-        "@types/hapi__shot": "*",
-        "@types/node": "*",
-        "joi": "^17.3.0"
-      }
-    },
-    "node_modules/@types/hapi__mimos": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
-      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
-      "dependencies": {
-        "@types/mime-db": "*"
-      }
-    },
-    "node_modules/@types/hapi__shot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.6.tgz",
-      "integrity": "sha512-h33NBjx2WyOs/9JgcFeFhkxnioYWQAZxOHdmqDuoJ1Qjxpcs+JGvSjEEoDeWfcrF+1n47kKgqph5IpfmPOnzbg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
@@ -4890,11 +5209,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
-    },
-    "node_modules/@types/mime-db": {
-      "version": "1.43.5",
-      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.5.tgz",
-      "integrity": "sha512-/bfTiIUTNPUBnwnYvUxXAre5MhD88jgagLEQiQtIASjU+bwxd8kS/ASDA4a8ufd8m0Lheu6eeMJHEUpLHoJ28A=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -5080,6 +5394,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -8915,18 +9237,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/joi": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
-      "integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -10758,9 +11068,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12980,16 +13290,24 @@
         "@dotcom-reliability-kit/log-error": "^4.1.1",
         "@dotcom-reliability-kit/logger": "^3.1.1",
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.45.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",
-        "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.51.0",
-        "@opentelemetry/sdk-trace-base": "^1.24.0",
-        "@opentelemetry/semantic-conventions": "^1.24.0"
+        "@opentelemetry/auto-instrumentations-node": "^0.46.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
+        "@opentelemetry/resources": "^1.24.1",
+        "@opentelemetry/sdk-node": "^0.51.1",
+        "@opentelemetry/sdk-trace-base": "^1.24.1",
+        "@opentelemetry/semantic-conventions": "^1.24.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
         "npm": "8.x || 9.x || 10.x"
+      }
+    },
+    "packages/opentelemetry/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/serialize-error": {

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -20,6 +20,7 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
     * [`options.authorizationHeader`](#optionsauthorizationheader)
     * [`options.tracing`](#optionstracing)
     * [`options.tracing.endpoint`](#optionstracingendpoint)
+    * [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader)
     * [`options.tracing.samplePercentage`](#optionstracingsamplepercentage)
     * [`OTEL_` environment variables](#otel_-environment-variables)
 * [Contributing](#contributing)
@@ -209,10 +210,7 @@ setupOpenTelemetry({
 
 #### `options.authorizationHeader`
 
-Set the [`Authorization` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) in requests to the OpenTelemetry collector. Defaults to `undefined`.
-
-**Environment variable:** `OPENTELEMETRY_AUTHORIZATION_HEADER`<br/>
-**Option:** `authorizationHeader` (`String`)
+**Deprecated**. This will still work but has been replaced with [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader), which is now the preferred way to set this option.
 
 #### `options.tracing`
 
@@ -224,6 +222,13 @@ A URL to send OpenTelemetry traces to. E.g. `http://localhost:4318/v1/traces`. D
 
 **Environment variable:** `OPENTELEMETRY_TRACING_ENDPOINT`<br/>
 **Option:** `tracing.endpoint` (`String`)
+
+#### `options.tracing.authorizationHeader`
+
+Set the [`Authorization` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) in requests to the OpenTelemetry tracing collector. Defaults to `undefined`.
+
+**Environment variable:** `OPENTELEMETRY_AUTHORIZATION_HEADER`<br/>
+**Option:** `tracing.authorizationHeader` (`String`)
 
 #### `options.tracing.samplePercentage`
 

--- a/packages/opentelemetry/lib/config/instrumentations.js
+++ b/packages/opentelemetry/lib/config/instrumentations.js
@@ -1,0 +1,60 @@
+const {
+	getNodeAutoInstrumentations
+} = require('@opentelemetry/auto-instrumentations-node');
+const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+const { UserInputError } = require('@dotcom-reliability-kit/errors');
+
+// Request paths that we ignore when instrumenting HTTP requests
+const IGNORED_REQUEST_PATHS = ['/__gtg', '/__health', '/favicon.ico'];
+
+/**
+ * Create a Resource object using gathered app info.
+ *
+ * @returns {import('@opentelemetry/sdk-node').NodeSDKConfiguration['instrumentations']}
+ */
+exports.createInstrumentationConfig = function createInstrumentationConfig() {
+	return [
+		getNodeAutoInstrumentations({
+			'@opentelemetry/instrumentation-http': {
+				ignoreIncomingRequestHook
+			},
+			'@opentelemetry/instrumentation-fs': {
+				enabled: false
+			}
+		})
+	];
+};
+
+/**
+ * NOTE: this is not a filter like you know it. The name gives us a clue:
+ * if the hook returns `true` then the request WILL be ignored.
+ *
+ * @see https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/README.md#http-instrumentation-options
+ * @type {import('@opentelemetry/instrumentation-http').IgnoreIncomingRequestFunction}
+ */
+function ignoreIncomingRequestHook(request) {
+	if (request.url) {
+		try {
+			const url = new URL(request.url, `http://${request.headers.host}`);
+
+			// Don't send traces for paths that we frequently poll
+			if (IGNORED_REQUEST_PATHS.includes(url.pathname)) {
+				return true;
+			}
+		} catch (/** @type {any} */ cause) {
+			// If URL parsing errors then we log it and move on.
+			// We don't ignore URLs that result in an error because
+			// we're interested in the traces from bad requests.
+			logRecoverableError({
+				error: new UserInputError({
+					message: 'Failed to parse the request URL for filtering',
+					code: 'OTEL_REQUEST_FILTER_FAILURE',
+					cause
+				}),
+				includeHeaders: ['host'],
+				request
+			});
+		}
+	}
+	return false;
+}

--- a/packages/opentelemetry/lib/config/instrumentations.js
+++ b/packages/opentelemetry/lib/config/instrumentations.js
@@ -8,7 +8,7 @@ const { UserInputError } = require('@dotcom-reliability-kit/errors');
 const IGNORED_REQUEST_PATHS = ['/__gtg', '/__health', '/favicon.ico'];
 
 /**
- * Create a Resource object using gathered app info.
+ * Create an instrumentations array for configuring OpenTelemetry.
  *
  * @returns {import('@opentelemetry/sdk-node').NodeSDKConfiguration['instrumentations']}
  */

--- a/packages/opentelemetry/lib/config/resource.js
+++ b/packages/opentelemetry/lib/config/resource.js
@@ -11,7 +11,7 @@ const {
 /**
  * Create a Resource object using gathered app info.
  *
- * @returns {Resource}
+ * @returns {import('@opentelemetry/sdk-node').NodeSDKConfiguration['resource']}
  */
 exports.createResourceConfig = function createResourceConfig() {
 	// We set OpenTelemetry resource attributes based on app data

--- a/packages/opentelemetry/lib/config/resource.js
+++ b/packages/opentelemetry/lib/config/resource.js
@@ -1,0 +1,25 @@
+const appInfo = require('@dotcom-reliability-kit/app-info');
+const { Resource } = require('@opentelemetry/resources');
+const {
+	SEMRESATTRS_CLOUD_PROVIDER,
+	SEMRESATTRS_CLOUD_REGION,
+	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+	SEMRESATTRS_SERVICE_NAME,
+	SEMRESATTRS_SERVICE_VERSION
+} = require('@opentelemetry/semantic-conventions');
+
+/**
+ * Create a Resource object using gathered app info.
+ *
+ * @returns {Resource}
+ */
+exports.createResourceConfig = function createResourceConfig() {
+	// We set OpenTelemetry resource attributes based on app data
+	return new Resource({
+		[SEMRESATTRS_SERVICE_NAME]: appInfo.systemCode || undefined,
+		[SEMRESATTRS_SERVICE_VERSION]: appInfo.releaseVersion || undefined,
+		[SEMRESATTRS_CLOUD_PROVIDER]: appInfo.cloudProvider || undefined,
+		[SEMRESATTRS_CLOUD_REGION]: appInfo.region || undefined,
+		[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: appInfo.environment || undefined
+	});
+};

--- a/packages/opentelemetry/lib/config/tracing.js
+++ b/packages/opentelemetry/lib/config/tracing.js
@@ -1,0 +1,74 @@
+const {
+	OTLPTraceExporter
+} = require('@opentelemetry/exporter-trace-otlp-proto');
+const {
+	NoopSpanProcessor,
+	TraceIdRatioBasedSampler
+} = require('@opentelemetry/sdk-trace-base');
+const logger = require('@dotcom-reliability-kit/logger');
+const { TRACING_USER_AGENT } = require('./user-agents');
+
+const DEFAULT_SAMPLE_PERCENTAGE = 5;
+
+/**
+ * @typedef {object} TracingOptions
+ * @property {string} [authorizationHeader]
+ *     The HTTP `Authorization` header to send with OpenTelemetry tracing requests.
+ * @property {string} [endpoint]
+ *     The URL to send OpenTelemetry trace segments to, for example http://localhost:4318/v1/traces.
+ * @property {number} [samplePercentage]
+ *     What percentage of traces should be sent onto the collector.
+ */
+
+/**
+ * Create an OpenTelemetry tracing configuration.
+ *
+ * @param {TracingOptions} options
+ * @returns {Partial<import('@opentelemetry/sdk-node').NodeSDKConfiguration>}
+ */
+exports.createTracingConfig = function createTracingConfig(options) {
+	/** @type {Partial<import('@opentelemetry/sdk-node').NodeSDKConfiguration>} */
+	const config = {};
+
+	// If we have an OpenTelemetry tracing endpoint then set it up,
+	// otherwise we pass a noop span processor so that nothing is exported
+	if (options?.endpoint) {
+		const headers = {
+			'user-agent': TRACING_USER_AGENT
+		};
+		if (options.authorizationHeader) {
+			headers.authorization = options.authorizationHeader;
+		}
+		config.traceExporter = new OTLPTraceExporter({
+			url: options.endpoint,
+			headers
+		});
+
+		// Sample traces
+		let samplePercentage = DEFAULT_SAMPLE_PERCENTAGE;
+		if (options.samplePercentage && !Number.isNaN(options.samplePercentage)) {
+			samplePercentage = options.samplePercentage;
+		}
+		const sampleRatio = samplePercentage / 100;
+		config.sampler = new TraceIdRatioBasedSampler(sampleRatio);
+
+		logger.info({
+			event: 'OTEL_TRACE_STATUS',
+			message: `OpenTelemetry tracing is enabled and exporting to endpoint ${options.endpoint}`,
+			enabled: true,
+			endpoint: options.endpoint,
+			samplePercentage
+		});
+	} else {
+		logger.warn({
+			event: 'OTEL_TRACE_STATUS',
+			message:
+				'OpenTelemetry tracing is disabled because no tracing endpoint was set',
+			enabled: false,
+			endpoint: null
+		});
+		config.spanProcessor = new NoopSpanProcessor();
+	}
+
+	return config;
+};

--- a/packages/opentelemetry/lib/config/user-agents.js
+++ b/packages/opentelemetry/lib/config/user-agents.js
@@ -1,0 +1,7 @@
+const appInfo = require('@dotcom-reliability-kit/app-info');
+const packageJson = require('../../package.json');
+const traceExporterPackageJson = require('@opentelemetry/exporter-trace-otlp-proto/package.json');
+
+const BASE_USER_AGENT = `FTSystem/${appInfo.systemCode} (${packageJson.name}/${packageJson.version})`;
+
+exports.TRACING_USER_AGENT = `${BASE_USER_AGENT} (${traceExporterPackageJson.name}/${traceExporterPackageJson.version})`;

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -1,21 +1,16 @@
-const packageJson = require('../package.json');
 const { createInstrumentationConfig } = require('./config/instrumentations');
 const { createResourceConfig } = require('./config/resource');
 const { diag, DiagLogLevel } = require('@opentelemetry/api');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
-const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
 	OTLPTraceExporter
 } = require('@opentelemetry/exporter-trace-otlp-proto');
-const traceExporterPackageJson = require('@opentelemetry/exporter-trace-otlp-proto/package.json');
 const {
 	NoopSpanProcessor,
 	TraceIdRatioBasedSampler
 } = require('@opentelemetry/sdk-trace-base');
 const logger = require('@dotcom-reliability-kit/logger');
-
-const USER_AGENT = `FTSystem/${appInfo.systemCode} (${packageJson.name}/${packageJson.version})`;
-const TRACING_USER_AGENT = `${USER_AGENT} (${traceExporterPackageJson.name}/${traceExporterPackageJson.version})`;
+const { TRACING_USER_AGENT } = require('./config/user-agents');
 
 const DEFAULT_SAMPLE_PERCENTAGE = 5;
 

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -1,17 +1,10 @@
 const packageJson = require('../package.json');
+const { createResourceConfig } = require('./config/resource');
 const { diag, DiagLogLevel } = require('@opentelemetry/api');
 const {
 	getNodeAutoInstrumentations
 } = require('@opentelemetry/auto-instrumentations-node');
-const { Resource } = require('@opentelemetry/resources');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
-const {
-	SEMRESATTRS_CLOUD_PROVIDER,
-	SEMRESATTRS_CLOUD_REGION,
-	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
-	SEMRESATTRS_SERVICE_NAME,
-	SEMRESATTRS_SERVICE_VERSION
-} = require('@opentelemetry/semantic-conventions');
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
 	OTLPTraceExporter
@@ -80,15 +73,7 @@ function setupOpenTelemetry({ authorizationHeader, tracing } = {}) {
 	// Construct the OpenTelemetry SDK configuration
 	/** @type {opentelemetrySDK.NodeSDKConfiguration} */
 	const openTelemetryConfig = {};
-
-	// Set OpenTelemetry resource attributes based on app data
-	openTelemetryConfig.resource = new Resource({
-		[SEMRESATTRS_SERVICE_NAME]: appInfo.systemCode || undefined,
-		[SEMRESATTRS_SERVICE_VERSION]: appInfo.releaseVersion || undefined,
-		[SEMRESATTRS_CLOUD_PROVIDER]: appInfo.cloudProvider || undefined,
-		[SEMRESATTRS_CLOUD_REGION]: appInfo.region || undefined,
-		[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: appInfo.environment || undefined
-	});
+	openTelemetryConfig.resource = createResourceConfig();
 
 	// Auto-instrument common and built-in Node.js modules
 	openTelemetryConfig.instrumentations = [

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -21,11 +21,11 @@
 		"@dotcom-reliability-kit/log-error": "^4.1.1",
 		"@dotcom-reliability-kit/logger": "^3.1.1",
 		"@opentelemetry/api": "^1.8.0",
-		"@opentelemetry/auto-instrumentations-node": "^0.45.0",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",
-		"@opentelemetry/resources": "^1.24.0",
-		"@opentelemetry/sdk-node": "^0.51.0",
-		"@opentelemetry/sdk-trace-base": "^1.24.0",
-		"@opentelemetry/semantic-conventions": "^1.24.0"
+		"@opentelemetry/auto-instrumentations-node": "^0.46.1",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
+		"@opentelemetry/resources": "^1.24.1",
+		"@opentelemetry/sdk-node": "^0.51.1",
+		"@opentelemetry/sdk-trace-base": "^1.24.1",
+		"@opentelemetry/semantic-conventions": "^1.24.1"
 	}
 }

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -4,6 +4,7 @@ const setupOpenTelemetry = require('./lib/index.js');
 let tracing = undefined;
 if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 	tracing = {
+		authorizationHeader: process.env.OPENTELEMETRY_AUTHORIZATION_HEADER,
 		endpoint: process.env.OPENTELEMETRY_TRACING_ENDPOINT,
 		samplePercentage: process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE
 			? Number(process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE)
@@ -12,6 +13,5 @@ if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 }
 
 setupOpenTelemetry({
-	authorizationHeader: process.env.OPENTELEMETRY_AUTHORIZATION_HEADER,
 	tracing
 });

--- a/packages/opentelemetry/test/unit/lib/config/instrumentation.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/instrumentation.spec.js
@@ -1,0 +1,128 @@
+jest.mock('@opentelemetry/auto-instrumentations-node', () => ({
+	getNodeAutoInstrumentations: jest
+		.fn()
+		.mockReturnValue('mock-auto-instrumentations')
+}));
+jest.mock('@dotcom-reliability-kit/log-error');
+jest.mock('@dotcom-reliability-kit/errors');
+
+const {
+	getNodeAutoInstrumentations
+} = require('@opentelemetry/auto-instrumentations-node');
+const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
+const { UserInputError } = require('@dotcom-reliability-kit/errors');
+
+const {
+	createInstrumentationConfig
+} = require('../../../../lib/config/instrumentations');
+
+describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () => {
+	it('exports a function', () => {
+		expect(typeof createInstrumentationConfig).toBe('function');
+	});
+
+	describe('createInstrumentationConfig()', () => {
+		let instrumentations;
+
+		beforeEach(() => {
+			instrumentations = createInstrumentationConfig();
+		});
+
+		it('creates Node.js auto-instrumentations with some configurations', () => {
+			expect(getNodeAutoInstrumentations).toHaveBeenCalledTimes(1);
+			expect(getNodeAutoInstrumentations).toHaveBeenCalledWith({
+				'@opentelemetry/instrumentation-http': {
+					ignoreIncomingRequestHook: expect.any(Function)
+				},
+				'@opentelemetry/instrumentation-fs': {
+					enabled: false
+				}
+			});
+		});
+
+		describe('ignore incoming request hook function', () => {
+			let ignoreIncomingRequestHook;
+
+			beforeAll(() => {
+				ignoreIncomingRequestHook =
+					getNodeAutoInstrumentations.mock.calls[0][0][
+						'@opentelemetry/instrumentation-http'
+					].ignoreIncomingRequestHook;
+			});
+
+			it('returns `true` with a request to `/__gtg`', () => {
+				const mockRequest = {
+					url: '/__gtg?a=b',
+					headers: { host: 'mock-host' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(true);
+			});
+
+			it('returns `true` with a request to `/__health`', () => {
+				const mockRequest = {
+					url: '/__health?a=b',
+					headers: { host: 'mock-host' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(true);
+			});
+
+			it('returns `true` with a request to `/favicon.ico`', () => {
+				const mockRequest = {
+					url: '/favicon.ico?a=b',
+					headers: { host: 'mock-host' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(true);
+			});
+
+			it('returns `false` with a request to anything else', () => {
+				const mockRequest = {
+					url: '/mock-endpoint',
+					headers: { host: 'mock-host' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(false);
+			});
+
+			it('returns `false` when a request URL is not present', () => {
+				const mockRequest = {
+					url: undefined,
+					headers: { host: 'mock-host' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(false);
+			});
+
+			it("doesn't throw when the host header isn't set", () => {
+				const mockRequest = {
+					url: '/mock-endpoint',
+					headers: {}
+				};
+				expect(() => ignoreIncomingRequestHook(mockRequest)).not.toThrow();
+			});
+
+			it('logs a warning and returns `false` when a request URL cannot be parsed', () => {
+				const mockRequest = {
+					url: '/mock-endpont',
+					headers: { host: '' }
+				};
+				expect(ignoreIncomingRequestHook(mockRequest)).toBe(false);
+				expect(UserInputError).toHaveBeenCalledTimes(1);
+				expect(UserInputError).toHaveBeenCalledWith(
+					expect.objectContaining({
+						code: 'OTEL_REQUEST_FILTER_FAILURE'
+					})
+				);
+				expect(logRecoverableError).toHaveBeenCalledTimes(1);
+				expect(logRecoverableError).toHaveBeenCalledWith(
+					expect.objectContaining({
+						error: expect.any(UserInputError),
+						includeHeaders: ['host'],
+						request: mockRequest
+					})
+				);
+			});
+		});
+
+		it('returns an array of instrumentations', () => {
+			expect(instrumentations).toEqual(['mock-auto-instrumentations']);
+		});
+	});
+});

--- a/packages/opentelemetry/test/unit/lib/config/resource.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/resource.spec.js
@@ -1,0 +1,71 @@
+jest.mock('@dotcom-reliability-kit/app-info', () => ({
+	systemCode: 'mock-system-code',
+	releaseVersion: 'mock-release-version',
+	cloudProvider: 'mock-cloud-provider',
+	region: 'mock-cloud-region',
+	environment: 'mock-environment'
+}));
+jest.mock('@opentelemetry/resources');
+jest.mock('@opentelemetry/semantic-conventions', () => ({
+	SEMRESATTRS_CLOUD_PROVIDER: 'mock-semresattrs-cloud-provider',
+	SEMRESATTRS_CLOUD_REGION: 'mock-semresattrs-cloud-region',
+	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT: 'mock-semresattrs-deployment-environment',
+	SEMRESATTRS_SERVICE_NAME: 'mock-semresattrs-service-name',
+	SEMRESATTRS_SERVICE_VERSION: 'mock-semresattrs-service-version'
+}));
+
+const appInfo = require('@dotcom-reliability-kit/app-info');
+const { Resource } = require('@opentelemetry/resources');
+const { createResourceConfig } = require('../../../../lib/config/resource');
+
+describe('@dotcom-reliability-kit/opentelemetry/lib/config/resource', () => {
+	it('exports a function', () => {
+		expect(typeof createResourceConfig).toBe('function');
+	});
+
+	describe('createResourceConfig()', () => {
+		let resource;
+
+		beforeEach(() => {
+			resource = createResourceConfig();
+		});
+
+		it('creates and returns an OpenTelemetry Resource', () => {
+			expect(Resource).toHaveBeenCalledTimes(1);
+			expect(Resource).toHaveBeenCalledWith({
+				'mock-semresattrs-cloud-provider': 'mock-cloud-provider',
+				'mock-semresattrs-cloud-region': 'mock-cloud-region',
+				'mock-semresattrs-deployment-environment': 'mock-environment',
+				'mock-semresattrs-service-name': 'mock-system-code',
+				'mock-semresattrs-service-version': 'mock-release-version'
+			});
+			expect(resource).toStrictEqual(Resource.mock.instances[0]);
+		});
+
+		describe('when any appInfo properties are falsy', () => {
+			let resource;
+
+			beforeEach(() => {
+				Resource.mockClear();
+				appInfo.systemCode = null;
+				appInfo.releaseVersion = null;
+				appInfo.cloudProvider = null;
+				appInfo.region = null;
+				appInfo.environment = null;
+				resource = createResourceConfig();
+			});
+
+			it('creates and returns an OpenTelemetry Resource with properties set to `undefined`', () => {
+				expect(Resource).toHaveBeenCalledTimes(1);
+				expect(Resource).toHaveBeenCalledWith({
+					'mock-semresattrs-cloud-provider': undefined,
+					'mock-semresattrs-cloud-region': undefined,
+					'mock-semresattrs-deployment-environment': undefined,
+					'mock-semresattrs-service-name': undefined,
+					'mock-semresattrs-service-version': undefined
+				});
+				expect(resource).toStrictEqual(Resource.mock.instances[0]);
+			});
+		});
+	});
+});

--- a/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
@@ -1,0 +1,144 @@
+jest.mock('@opentelemetry/exporter-trace-otlp-proto');
+jest.mock('@opentelemetry/sdk-trace-base');
+jest.mock('@dotcom-reliability-kit/logger');
+jest.mock('../../../../lib/config/user-agents', () => ({
+	TRACING_USER_AGENT: 'mock-tracing-user-agent'
+}));
+
+const logger = require('@dotcom-reliability-kit/logger');
+const {
+	OTLPTraceExporter
+} = require('@opentelemetry/exporter-trace-otlp-proto');
+const {
+	NoopSpanProcessor,
+	TraceIdRatioBasedSampler
+} = require('@opentelemetry/sdk-trace-base');
+const { createTracingConfig } = require('../../../../lib/config/tracing');
+
+describe('@dotcom-reliability-kit/opentelemetry/lib/config/tracing', () => {
+	it('exports a function', () => {
+		expect(typeof createTracingConfig).toBe('function');
+	});
+
+	describe('createTracingConfig(options)', () => {
+		let config;
+
+		beforeAll(() => {
+			config = createTracingConfig({
+				authorizationHeader: 'mock-auth-header',
+				endpoint: 'mock-endpoint',
+				samplePercentage: 10
+			});
+		});
+
+		it('creates a trace exporter', () => {
+			expect(OTLPTraceExporter).toHaveBeenCalledTimes(1);
+			expect(OTLPTraceExporter).toHaveBeenCalledWith({
+				url: 'mock-endpoint',
+				headers: {
+					authorization: 'mock-auth-header',
+					'user-agent': 'mock-tracing-user-agent'
+				}
+			});
+		});
+
+		it('creates a ratio-based trace sampler', () => {
+			expect(TraceIdRatioBasedSampler).toHaveBeenCalledTimes(1);
+			expect(TraceIdRatioBasedSampler).toHaveBeenCalledWith(0.1);
+		});
+
+		it('does not create a noop span processor', () => {
+			expect(NoopSpanProcessor).toHaveBeenCalledTimes(0);
+		});
+
+		it('logs that tracing is enabled', () => {
+			expect(logger.info).toHaveBeenCalledWith({
+				enabled: true,
+				endpoint: 'mock-endpoint',
+				event: 'OTEL_TRACE_STATUS',
+				message:
+					'OpenTelemetry tracing is enabled and exporting to endpoint mock-endpoint',
+				samplePercentage: 10
+			});
+		});
+
+		it('returns the configuration', () => {
+			expect(config).toEqual({
+				traceExporter: OTLPTraceExporter.mock.instances[0],
+				sampler: TraceIdRatioBasedSampler.mock.instances[0]
+			});
+		});
+
+		describe('when options.authorizationHeader is not defined', () => {
+			beforeAll(() => {
+				OTLPTraceExporter.mockClear();
+				config = createTracingConfig({
+					endpoint: 'mock-endpoint',
+					samplePercentage: 10
+				});
+			});
+
+			it('creates a trace exporter without an authorization header', () => {
+				expect(OTLPTraceExporter).toHaveBeenCalledTimes(1);
+				expect(OTLPTraceExporter).toHaveBeenCalledWith({
+					url: 'mock-endpoint',
+					headers: {
+						'user-agent': 'mock-tracing-user-agent'
+					}
+				});
+			});
+		});
+
+		describe('when options.samplePercentage is not defined', () => {
+			beforeAll(() => {
+				TraceIdRatioBasedSampler.mockClear();
+				config = createTracingConfig({
+					authorizationHeader: 'mock-auth-header',
+					endpoint: 'mock-endpoint'
+				});
+			});
+
+			it('creates a ratio-based trace sampler with a default sample ratio', () => {
+				expect(TraceIdRatioBasedSampler).toHaveBeenCalledTimes(1);
+				expect(TraceIdRatioBasedSampler).toHaveBeenCalledWith(0.05);
+			});
+		});
+
+		describe('when options.endpoint is not defined', () => {
+			beforeAll(() => {
+				OTLPTraceExporter.mockClear();
+				TraceIdRatioBasedSampler.mockClear();
+				config = createTracingConfig({});
+			});
+
+			it('does not creates a trace exporter', () => {
+				expect(OTLPTraceExporter).toHaveBeenCalledTimes(0);
+			});
+
+			it('does not create a ratio-based trace sampler', () => {
+				expect(TraceIdRatioBasedSampler).toHaveBeenCalledTimes(0);
+			});
+
+			it('creates a noop span processor', () => {
+				expect(NoopSpanProcessor).toHaveBeenCalledTimes(1);
+				expect(NoopSpanProcessor).toHaveBeenCalledWith();
+			});
+
+			it('logs that tracing is disabled', () => {
+				expect(logger.warn).toHaveBeenCalledWith({
+					enabled: false,
+					endpoint: null,
+					event: 'OTEL_TRACE_STATUS',
+					message:
+						'OpenTelemetry tracing is disabled because no tracing endpoint was set'
+				});
+			});
+
+			it('returns the configuration', () => {
+				expect(config).toEqual({
+					spanProcessor: NoopSpanProcessor.mock.instances[0]
+				});
+			});
+		});
+	});
+});

--- a/packages/opentelemetry/test/unit/lib/config/user-agents.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/user-agents.spec.js
@@ -1,0 +1,23 @@
+jest.mock('@dotcom-reliability-kit/app-info', () => ({
+	systemCode: 'mock-system-code'
+}));
+jest.mock('../../../../package.json', () => ({
+	name: 'mock-package',
+	version: '1.2.3'
+}));
+jest.mock('@opentelemetry/exporter-trace-otlp-proto/package.json', () => ({
+	name: 'mock-otel-tracing-package',
+	version: '3.4.5'
+}));
+
+const { TRACING_USER_AGENT } = require('../../../../lib/config/user-agents');
+
+describe('@dotcom-reliability-kit/opentelemetry/lib/config/resource', () => {
+	describe('.TRACING_USER_AGENT', () => {
+		it('is set based on app info and package versions', () => {
+			expect(TRACING_USER_AGENT).toStrictEqual(
+				'FTSystem/mock-system-code (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
+			);
+		});
+	});
+});

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -1,15 +1,6 @@
-jest.mock('../../../package.json', () => ({
-	name: 'mock-package',
-	version: '1.2.3'
-}));
 jest.mock('@opentelemetry/exporter-trace-otlp-proto');
-jest.mock('@opentelemetry/exporter-trace-otlp-proto/package.json', () => ({
-	name: 'mock-otel-tracing-package',
-	version: '3.4.5'
-}));
 jest.mock('@opentelemetry/sdk-trace-base');
 jest.mock('@opentelemetry/sdk-node');
-jest.mock('@dotcom-reliability-kit/app-info');
 jest.mock('@opentelemetry/api');
 jest.mock('@dotcom-reliability-kit/logger');
 jest.mock('../../../lib/config/instrumentations', () => ({
@@ -20,6 +11,9 @@ jest.mock('../../../lib/config/instrumentations', () => ({
 jest.mock('../../../lib/config/resource', () => ({
 	createResourceConfig: jest.fn().mockReturnValue('mock-resource')
 }));
+jest.mock('../../../lib/config/user-agents', () => ({
+	TRACING_USER_AGENT: 'mock-tracing-user-agent'
+}));
 
 const {
 	createInstrumentationConfig
@@ -28,7 +22,6 @@ const { createResourceConfig } = require('../../../lib/config/resource');
 const { diag, DiagLogLevel } = require('@opentelemetry/api');
 const logger = require('@dotcom-reliability-kit/logger');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
-const appInfo = require('@dotcom-reliability-kit/app-info');
 const {
 	OTLPTraceExporter
 } = require('@opentelemetry/exporter-trace-otlp-proto');
@@ -36,13 +29,6 @@ const {
 	NoopSpanProcessor,
 	TraceIdRatioBasedSampler
 } = require('@opentelemetry/sdk-trace-base');
-
-// Set up the mock
-appInfo.systemCode = 'MOCK_SYSTEM_CODE';
-appInfo.releaseVersion = 'MOCK_RELEASE_VERSION';
-appInfo.cloudProvider = 'MOCK_CLOUD_PROVIDER';
-appInfo.region = 'MOCK_CLOUD_REGION';
-appInfo.environment = 'MOCK_ENVIRONMENT';
 
 logger.createChildLogger.mockReturnValue('mock child logger');
 DiagLogLevel.INFO = 'mock info log level';
@@ -99,8 +85,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 			expect(OTLPTraceExporter).toHaveBeenCalledWith({
 				url: 'MOCK_TRACING_ENDPOINT',
 				headers: {
-					'user-agent':
-						'FTSystem/MOCK_SYSTEM_CODE (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
+					'user-agent': 'mock-tracing-user-agent'
 				}
 			});
 			expect(
@@ -147,8 +132,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 				url: 'MOCK_TRACING_ENDPOINT',
 				headers: {
 					authorization: 'mock-authorization-header',
-					'user-agent':
-						'FTSystem/MOCK_SYSTEM_CODE (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
+					'user-agent': 'mock-tracing-user-agent'
 				}
 			});
 		});

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -14,8 +14,8 @@ describe('setupOpenTelemetry', () => {
 
 		expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
 		expect(setupOpenTelemetry).toHaveBeenCalledWith({
-			authorizationHeader: 'MOCK_AUTH_HEADER',
 			tracing: {
+				authorizationHeader: 'MOCK_AUTH_HEADER',
 				endpoint: 'MOCK_TRACING_ENDPOINT'
 			}
 		});
@@ -28,8 +28,8 @@ describe('setupOpenTelemetry', () => {
 
 			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
 			expect(setupOpenTelemetry).toHaveBeenCalledWith({
-				authorizationHeader: 'MOCK_AUTH_HEADER',
 				tracing: {
+					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',
 					samplePercentage: 50
 				}
@@ -44,8 +44,8 @@ describe('setupOpenTelemetry', () => {
 
 			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
 			expect(setupOpenTelemetry).toHaveBeenCalledWith({
-				authorizationHeader: 'MOCK_AUTH_HEADER',
 				tracing: {
+					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',
 					samplePercentage: NaN
 				}
@@ -59,9 +59,7 @@ describe('setupOpenTelemetry', () => {
 			require('../../setup.js');
 
 			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({
-				authorizationHeader: 'MOCK_AUTH_HEADER'
-			});
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({});
 		});
 	});
 });


### PR DESCRIPTION
This refactors the package, splitting things into more testable modules ahead of adding in metrics support. I tried adding support already but the tests get unwieldy and it was difficult to reason about anything; I took a step back and did some refactoring which will make adding metrics a lot easier.

I tested this manually as well by linking it into a local project and testing that traces come through in Jaeger.