### PR TITLE
chore: add a test for 1069

### DIFF
--- a/packages/logger/test/end-to-end/compatibility-test-cases.js
+++ b/packages/logger/test/end-to-end/compatibility-test-cases.js
@@ -705,6 +705,28 @@ module.exports = [
 		}
 	},
 
+	// Test cases based on observed differences and bug reports
+	{
+		id: 'issue-1069',
+		description: 'timestamp property is not silently removed',
+		call: {
+			method: 'info',
+			args: ['Timestamp test', { timestamp: 123456 }]
+		},
+		expectedOutput: {
+			nextLogger: {
+				level: 'info',
+				message: 'Timestamp test',
+				timestamp: 123456
+			},
+			reliabilityKit: {
+				level: 'info',
+				message: 'Timestamp test',
+				timestamp: 123456
+			}
+		}
+	},
+
 	// Test cases based on real-world usage of n-logger
 	{
 		id: 'next-article-1',


### PR DESCRIPTION
This test illustrates that #1069 is only present when using pino-pretty. In production with JSON logs, the `timestamp` property is present as expected.