### PR TITLE
Broad app info improvements (required for OpenTelemetry metrics)

### DIFF
--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -116,6 +116,8 @@ This object contains aliases for the main `appInfo` properties that correspond t
   * `appInfo.semanticConventions.service.version` aliases `appInfo.releaseVersion`
   * `appInfo.semanticConventions.service.instance.id` aliases `appInfo.instanceId`
 
+> [!WARNING]
+> While all other properties default to `null` if they can't be calculated, the semantic conventions properties default to `undefined`. This is to ensure better compatibility with OpenTelemetry SDKs.
 
 ## Migrating
 

--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -12,8 +12,9 @@ A utility to get application information (e.g. the system code) in a consistent 
     * [`appInfo.systemCode`](#appinfosystemcode)
     * [`appInfo.processType`](#appinfoprocesstype)
     * [`appInfo.cloudProvider`](#appinfocloudprovider)
-    * [`appInfo.herokuAppId`](#appinfoherokuappId)
-    * [`appInfo.herokuDynoId`](#appinfoherokudynoId)
+    * [`appInfo.herokuAppId`](#appinfoherokuappid)
+    * [`appInfo.herokuDynoId`](#appinfoherokudynoid)
+    * [`appInfo.semanticConventions`](#appinfosemanticconventions)
   * [Migrating](#migrating)
   * [Contributing](#contributing)
   * [License](#license)
@@ -98,6 +99,16 @@ This is derived from the dyno metadata
 Get the `process.env.HEROKU_DYNO_ID` which is the dyno identifier
 
 This is derived from the dyno metadata
+
+### `appInfo.semanticConventions`
+
+This object contains aliases for the main `appInfo` properties that correspond to OpenTelemetry's [Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/). We use the following mapping:
+
+  * `appInfo.semanticConventions.cloud.provider` aliases `appInfo.cloudProvider`
+  * `appInfo.semanticConventions.cloud.region` aliases `appInfo.region`
+  * `appInfo.semanticConventions.deployment.environment` aliases `appInfo.environment`
+  * `appInfo.semanticConventions.service.name` aliases `appInfo.systemCode`
+  * `appInfo.semanticConventions.service.version` aliases `appInfo.releaseVersion`
 
 
 ## Migrating

--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -14,6 +14,7 @@ A utility to get application information (e.g. the system code) in a consistent 
     * [`appInfo.cloudProvider`](#appinfocloudprovider)
     * [`appInfo.herokuAppId`](#appinfoherokuappid)
     * [`appInfo.herokuDynoId`](#appinfoherokudynoid)
+    * [`appInfo.instanceId`](#appinfoinstanceid)
     * [`appInfo.semanticConventions`](#appinfosemanticconventions)
   * [Migrating](#migrating)
   * [Contributing](#contributing)
@@ -100,6 +101,10 @@ Get the `process.env.HEROKU_DYNO_ID` which is the dyno identifier
 
 This is derived from the dyno metadata
 
+### `appInfo.instanceId`
+
+Get the ID of the instance that's running the application. This is derived from `process.env.HEROKU_DYNO_ID` if present, otherwise it will be set to a random UUID that identifies the currently running process.
+
 ### `appInfo.semanticConventions`
 
 This object contains aliases for the main `appInfo` properties that correspond to OpenTelemetry's [Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/). We use the following mapping:
@@ -109,6 +114,7 @@ This object contains aliases for the main `appInfo` properties that correspond t
   * `appInfo.semanticConventions.deployment.environment` aliases `appInfo.environment`
   * `appInfo.semanticConventions.service.name` aliases `appInfo.systemCode`
   * `appInfo.semanticConventions.service.version` aliases `appInfo.releaseVersion`
+  * `appInfo.semanticConventions.service.instance.id` aliases `appInfo.instanceId`
 
 
 ## Migrating

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -163,15 +163,15 @@ exports.instanceId = process.env.HEROKU_DYNO_ID || randomUUID();
  */
 exports.semanticConventions = {
 	cloud: {
-		provider: exports.cloudProvider,
-		region: exports.region
+		provider: exports.cloudProvider || undefined,
+		region: exports.region || undefined
 	},
 	deployment: {
 		environment: exports.environment
 	},
 	service: {
-		name: exports.systemCode,
-		version: exports.releaseVersion,
+		name: exports.systemCode || undefined,
+		version: exports.releaseVersion || undefined,
 		instance: {
 			id: exports.instanceId
 		}

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -149,6 +149,23 @@ exports.herokuAppId = process.env.HEROKU_APP_ID || null;
  */
 exports.herokuDynoId = process.env.HEROKU_DYNO_ID || null;
 
+/**
+ * @type {import('@dotcom-reliability-kit/app-info').SemanticConventions}
+ */
+exports.semanticConventions = {
+	cloud: {
+		provider: exports.cloudProvider,
+		region: exports.region
+	},
+	deployment: {
+		environment: exports.environment
+	},
+	service: {
+		name: exports.systemCode,
+		version: exports.releaseVersion
+	}
+};
+
 // @ts-ignore
 module.exports.default = module.exports;
 module.exports = Object.freeze(module.exports);

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -1,4 +1,5 @@
 const path = require('node:path');
+const { randomUUID } = require('node:crypto');
 
 // This package relies on Heroku and AWS Lambda environment variables.
 // Documentation for these variables is available here:
@@ -150,6 +151,14 @@ exports.herokuAppId = process.env.HEROKU_APP_ID || null;
 exports.herokuDynoId = process.env.HEROKU_DYNO_ID || null;
 
 /**
+ * The ID of the running instance of the service.
+ *
+ * @readonly
+ * @type {string}
+ */
+exports.instanceId = process.env.HEROKU_DYNO_ID || randomUUID();
+
+/**
  * @type {import('@dotcom-reliability-kit/app-info').SemanticConventions}
  */
 exports.semanticConventions = {
@@ -162,7 +171,10 @@ exports.semanticConventions = {
 	},
 	service: {
 		name: exports.systemCode,
-		version: exports.releaseVersion
+		version: exports.releaseVersion,
+		instance: {
+			id: exports.instanceId
+		}
 	}
 };
 

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -349,6 +349,7 @@ describe('@dotcom-reliability-kit/app-info', () => {
 			});
 		});
 	});
+
 	describe('.herokuAppId', () => {
 		it('returns HEROKU_APP_ID when process.env.HEROKU_APP_ID exists', () => {
 			expect(appInfo.herokuAppId).toBe('mock-heroku-app-id');
@@ -361,6 +362,7 @@ describe('@dotcom-reliability-kit/app-info', () => {
 			expect(appInfo.herokuAppId).toBe(null);
 		});
 	});
+
 	describe('.herokuDynoId', () => {
 		it('returns HEROKU_DYNO_ID when `process.env.HEROKU_DYNO_ID` exists', () => {
 			expect(appInfo.herokuDynoId).toBe('mock-heroku-dyno-id');
@@ -370,6 +372,52 @@ describe('@dotcom-reliability-kit/app-info', () => {
 			delete process.env.HEROKU_DYNO_ID;
 			appInfo = require('../../../lib');
 			expect(appInfo.herokuDynoId).toBe(null);
+		});
+	});
+
+	describe('.semanticConventions', () => {
+		describe('.cloud', () => {
+			describe('.provider', () => {
+				it('is an alias of `cloudProvider`', () => {
+					expect(appInfo.semanticConventions.cloud.provider).toBe(
+						appInfo.cloudProvider
+					);
+				});
+			});
+
+			describe('.region', () => {
+				it('is an alias of `region`', () => {
+					expect(appInfo.semanticConventions.cloud.region).toBe(appInfo.region);
+				});
+			});
+		});
+
+		describe('.deployment', () => {
+			describe('.environment', () => {
+				it('is an alias of `environment`', () => {
+					expect(appInfo.semanticConventions.deployment.environment).toBe(
+						appInfo.environment
+					);
+				});
+			});
+		});
+
+		describe('.service', () => {
+			describe('.name', () => {
+				it('is an alias of `systemCode`', () => {
+					expect(appInfo.semanticConventions.service.name).toBe(
+						appInfo.systemCode
+					);
+				});
+			});
+
+			describe('.version', () => {
+				it('is an alias of `releaseVersion`', () => {
+					expect(appInfo.semanticConventions.service.version).toBe(
+						appInfo.releaseVersion
+					);
+				});
+			});
 		});
 	});
 });

--- a/packages/app-info/types/index.d.ts
+++ b/packages/app-info/types/index.d.ts
@@ -10,6 +10,20 @@ declare module '@dotcom-reliability-kit/app-info' {
 	export const herokuAppId: string | null;
 	export const herokuDynoId: string | null;
 
+	export type SemanticConventions = {
+		cloud: {
+			provider: string | null,
+			region: string | null
+		},
+		deployment: {
+			environment: string | null
+		},
+		service: {
+			name: string | null
+			version: string | null
+		}
+	};
+
 	type appInfo = {
 		systemCode: typeof systemCode,
 		processType: typeof processType,
@@ -20,7 +34,8 @@ declare module '@dotcom-reliability-kit/app-info' {
 		releaseVersion: typeof releaseVersion,
 		cloudProvider: typeof cloudProvider,
 		herokuAppId: typeof herokuAppId,
-		herokuDynoId: typeof herokuDynoId
+		herokuDynoId: typeof herokuDynoId,
+		semanticConventions: SemanticConventions
 	};
 
 	export default appInfo;

--- a/packages/app-info/types/index.d.ts
+++ b/packages/app-info/types/index.d.ts
@@ -9,6 +9,7 @@ declare module '@dotcom-reliability-kit/app-info' {
 	export const cloudProvider: string | null;
 	export const herokuAppId: string | null;
 	export const herokuDynoId: string | null;
+	export const instanceId: string;
 
 	export type SemanticConventions = {
 		cloud: {
@@ -16,11 +17,14 @@ declare module '@dotcom-reliability-kit/app-info' {
 			region: string | null
 		},
 		deployment: {
-			environment: string | null
+			environment: string
 		},
 		service: {
 			name: string | null
-			version: string | null
+			version: string | null,
+			instance: {
+				id: string
+			}
 		}
 	};
 
@@ -35,6 +39,7 @@ declare module '@dotcom-reliability-kit/app-info' {
 		cloudProvider: typeof cloudProvider,
 		herokuAppId: typeof herokuAppId,
 		herokuDynoId: typeof herokuDynoId,
+		instanceId: typeof instanceId,
 		semanticConventions: SemanticConventions
 	};
 

--- a/packages/app-info/types/index.d.ts
+++ b/packages/app-info/types/index.d.ts
@@ -13,15 +13,15 @@ declare module '@dotcom-reliability-kit/app-info' {
 
 	export type SemanticConventions = {
 		cloud: {
-			provider: string | null,
-			region: string | null
+			provider?: string,
+			region?: string
 		},
 		deployment: {
 			environment: string
 		},
 		service: {
-			name: string | null
-			version: string | null,
+			name?: string
+			version?: string,
 			instance: {
 				id: string
 			}


### PR DESCRIPTION
These are all required to add OpenTelemetry metrics, we need to solidify the app info properties that we rely on otherwise our metrics are rejected. This does the following:

  * Firms up the `releaseVersion` property, required in our metrics
  * Adds in an `instanceId` property, required in our metrics
  * Adds aliases for OpenTelemetry semantic conventions, which is the first step towards adopting them fully. We'll deprecate old property names in future (resolves #818)
