### PR TITLE
Add OpenTelemetry metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3351,6 +3351,88 @@
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.51.1.tgz",
+      "integrity": "sha512-oFXvif9iksHUxrzG3P8ohMLt7xSrl+oDMqxD/3XXndU761RFAKSbRDpfrQs25U5D+A2aMV3qk+4kfUWdJhZ77g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-metrics": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.51.1.tgz",
+      "integrity": "sha512-jhj8xD6S4cydXGCuf2tp56+4QI0DbDH6g+0MiPPJVdXjxLj+iycQuqB2cwljWpByblFaOjyUsL/VKtm8C7sQ9A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-metrics": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "0.51.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.1.tgz",
@@ -3510,6 +3592,21 @@
       "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/host-metrics": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.1.tgz",
+      "integrity": "sha512-d49/Un/pzqUSsGLeO8PvrX2bLxVAORcaoL3nxjJCzGikXA6gjWXxGOfT8D4qePlgnocozppWszefMHoRFS2MsA==",
+      "dependencies": {
+        "@opentelemetry/sdk-metrics": "^1.8.0",
+        "systeminformation": "^5.21.20"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -4062,6 +4159,20 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-runtime-node": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.4.0.tgz",
+      "integrity": "sha512-/NOgUF5gf3T5c3GMyy6fnQxaVzbOf9j2xcetgymIIX2HSN3Gk7o64G7KDvwHwhaa20ZiF0QDLb3m4AT+tn9eRg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.51.0"
+      },
+      "engines": {
+        "node": ">=14.10.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -12407,6 +12518,31 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/systeminformation": {
+      "version": "5.22.10",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.10.tgz",
+      "integrity": "sha512-RJ3oed80NkqgHtpB0TLkxEKEpQ3pUm2lgVolkHeoaExPidkWsj2D/hO6Rwwi9i+Odl1vm8TMiRNIKK7hBaqDsw==",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13291,8 +13427,12 @@
         "@dotcom-reliability-kit/logger": "^3.1.1",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.46.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
+        "@opentelemetry/host-metrics": "^0.35.1",
+        "@opentelemetry/instrumentation-runtime-node": "^0.4.0",
         "@opentelemetry/resources": "^1.24.1",
+        "@opentelemetry/sdk-metrics": "^1.24.1",
         "@opentelemetry/sdk-node": "^0.51.1",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@opentelemetry/semantic-conventions": "^1.24.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13425,16 +13425,12 @@
         "@dotcom-reliability-kit/errors": "^3.1.0",
         "@dotcom-reliability-kit/log-error": "^4.1.1",
         "@dotcom-reliability-kit/logger": "^3.1.1",
-        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.46.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
         "@opentelemetry/host-metrics": "^0.35.1",
         "@opentelemetry/instrumentation-runtime-node": "^0.4.0",
-        "@opentelemetry/resources": "^1.24.1",
-        "@opentelemetry/sdk-metrics": "^1.24.1",
         "@opentelemetry/sdk-node": "^0.51.1",
-        "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@opentelemetry/semantic-conventions": "^1.24.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,9 +1900,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.8.tgz",
-      "integrity": "sha512-vYVqYzHicDqyKB+NQhAc54I1QWCBLCrYG6unqOIcBTHx+7x8C9lcoLj3KVJXs2VB4lUbpWY+Kk9NipcbXYWmvg==",
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -3257,9 +3257,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -3268,56 +3268,56 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.46.1.tgz",
-      "integrity": "sha512-s0CwmY9KYtPawOhV5YO2Gf62uVOQRNvT6Or8IZ0S4gr/kPVNhoMehTsQvqBwSWQfoFrkmW3KKOHiKJEp4dVGXg==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.47.1.tgz",
+      "integrity": "sha512-W7Iz4SZhj6z5iqYTu4zZXr2woP/zD4dA6zFAz9PQEx21/SGn6+y6plcJTA08KnPVMbRff60D1IBdl547TyGy9A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.37.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.41.1",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.41.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.38.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.38.0",
-        "@opentelemetry/instrumentation-connect": "^0.36.1",
-        "@opentelemetry/instrumentation-cucumber": "^0.6.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.9.0",
-        "@opentelemetry/instrumentation-dns": "^0.36.1",
-        "@opentelemetry/instrumentation-express": "^0.39.0",
-        "@opentelemetry/instrumentation-fastify": "^0.36.1",
-        "@opentelemetry/instrumentation-fs": "^0.12.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.36.0",
-        "@opentelemetry/instrumentation-graphql": "^0.40.0",
-        "@opentelemetry/instrumentation-grpc": "^0.51.0",
-        "@opentelemetry/instrumentation-hapi": "^0.38.0",
-        "@opentelemetry/instrumentation-http": "^0.51.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.40.0",
-        "@opentelemetry/instrumentation-knex": "^0.36.1",
-        "@opentelemetry/instrumentation-koa": "^0.40.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.37.0",
-        "@opentelemetry/instrumentation-memcached": "^0.36.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.43.0",
-        "@opentelemetry/instrumentation-mongoose": "^0.38.1",
-        "@opentelemetry/instrumentation-mysql": "^0.38.1",
-        "@opentelemetry/instrumentation-mysql2": "^0.38.1",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.37.1",
-        "@opentelemetry/instrumentation-net": "^0.36.0",
-        "@opentelemetry/instrumentation-pg": "^0.41.0",
-        "@opentelemetry/instrumentation-pino": "^0.39.0",
-        "@opentelemetry/instrumentation-redis": "^0.39.1",
-        "@opentelemetry/instrumentation-redis-4": "^0.39.0",
-        "@opentelemetry/instrumentation-restify": "^0.38.0",
-        "@opentelemetry/instrumentation-router": "^0.37.0",
-        "@opentelemetry/instrumentation-socket.io": "^0.39.0",
-        "@opentelemetry/instrumentation-tedious": "^0.10.1",
-        "@opentelemetry/instrumentation-undici": "^0.2.0",
-        "@opentelemetry/instrumentation-winston": "^0.37.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.9",
-        "@opentelemetry/resource-detector-aws": "^1.5.0",
-        "@opentelemetry/resource-detector-azure": "^0.2.6",
-        "@opentelemetry/resource-detector-container": "^0.3.9",
-        "@opentelemetry/resource-detector-gcp": "^0.29.9",
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.38.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.42.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.42.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.39.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.39.0",
+        "@opentelemetry/instrumentation-connect": "^0.37.0",
+        "@opentelemetry/instrumentation-cucumber": "^0.7.0",
+        "@opentelemetry/instrumentation-dataloader": "^0.10.0",
+        "@opentelemetry/instrumentation-dns": "^0.37.0",
+        "@opentelemetry/instrumentation-express": "^0.40.1",
+        "@opentelemetry/instrumentation-fastify": "^0.37.0",
+        "@opentelemetry/instrumentation-fs": "^0.13.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.37.0",
+        "@opentelemetry/instrumentation-graphql": "^0.41.0",
+        "@opentelemetry/instrumentation-grpc": "^0.52.0",
+        "@opentelemetry/instrumentation-hapi": "^0.39.0",
+        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.41.0",
+        "@opentelemetry/instrumentation-knex": "^0.37.0",
+        "@opentelemetry/instrumentation-koa": "^0.41.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.38.0",
+        "@opentelemetry/instrumentation-memcached": "^0.37.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.45.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.39.0",
+        "@opentelemetry/instrumentation-mysql": "^0.39.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.39.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.38.0",
+        "@opentelemetry/instrumentation-net": "^0.37.0",
+        "@opentelemetry/instrumentation-pg": "^0.42.0",
+        "@opentelemetry/instrumentation-pino": "^0.40.0",
+        "@opentelemetry/instrumentation-redis": "^0.40.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.40.0",
+        "@opentelemetry/instrumentation-restify": "^0.39.0",
+        "@opentelemetry/instrumentation-router": "^0.38.0",
+        "@opentelemetry/instrumentation-socket.io": "^0.40.0",
+        "@opentelemetry/instrumentation-tedious": "^0.11.0",
+        "@opentelemetry/instrumentation-undici": "^0.3.0",
+        "@opentelemetry/instrumentation-winston": "^0.38.0",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.10",
+        "@opentelemetry/resource-detector-aws": "^1.5.1",
+        "@opentelemetry/resource-detector-azure": "^0.2.9",
+        "@opentelemetry/resource-detector-container": "^0.3.11",
+        "@opentelemetry/resource-detector-gcp": "^0.29.10",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.51.0"
+        "@opentelemetry/sdk-node": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3327,82 +3327,59 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.1.tgz",
-      "integrity": "sha512-R5r6DO4kgEOVBxFXhXjwospLQkv+sYxwCfjvoZBe7Zm6KKXAV9kDSJhi/D1BweowdZmO+sdbENLs374gER8hpQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.0.tgz",
+      "integrity": "sha512-sBW313mnMyFg0cp/40BRzrZBWG+581s2j5gIsa5fgGadswyILk4mNFATsqrCOpAx945RDuZ2B7ThQLgor9OpfA==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.51.1.tgz",
-      "integrity": "sha512-oFXvif9iksHUxrzG3P8ohMLt7xSrl+oDMqxD/3XXndU761RFAKSbRDpfrQs25U5D+A2aMV3qk+4kfUWdJhZ77g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.52.0.tgz",
+      "integrity": "sha512-fpIYQ+h2k74eAyhSMI6dhmWr4w2Tzh6L8lbJZKqqQtiZ/gLlLAoTLBIxADFKXywoTqEZi5SC+HyjpxFinpWcLQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.51.1.tgz",
-      "integrity": "sha512-jhj8xD6S4cydXGCuf2tp56+4QI0DbDH6g+0MiPPJVdXjxLj+iycQuqB2cwljWpByblFaOjyUsL/VKtm8C7sQ9A==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.52.0.tgz",
+      "integrity": "sha512-SwJFiURq6vNPX6VObvdGr9mgUCLLyo3nFBMhXwNLdxftmmRlDNJboAw6a5Zmp5hJZUnFwZvxnFNBdS5D2A8Xdw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -3411,159 +3388,70 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.1.tgz",
-      "integrity": "sha512-P9+Hkszih95ITvldGZ+kXvj9HpD1QfS+PwooyHK72GYA+Bgm+yUSAsDkUkDms8+s9HW6poxURv3LcjaMuBBpVQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.52.0.tgz",
+      "integrity": "sha512-Ln3HU54/ytTeEMrDGNDj01357YV8Kk9PkGDHvBRo1n7bWhwZoTEnX/cTuXLYOiygBIJJjCCM+VMfWCnvtFl4Kw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.1.tgz",
-      "integrity": "sha512-n+LhLPsX07URh+HhV2SHVSvz1t4G/l/CE5BjpmhAPqeTceFac1VpyQkavWEJbvnK5bUEXijWt4LxAxFpt2fXyw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.0.tgz",
+      "integrity": "sha512-umj9tOSEAuUdqw2EZua1Dby3c+FZ6xWGT2OF/KGLFLtyIvxhtTOSeMfBy/9CaxHn4vF8mAynmAP5MvVKnRYunA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.1.tgz",
-      "integrity": "sha512-SE9f0/6V6EeXC9i+WA4WFjS1EYgaBCpAnI5+lxWvZ7iO7EU1IvHvZhP6Kojr0nLldo83gqg6G7OWFqsID3uF+w==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.52.0.tgz",
+      "integrity": "sha512-mpMEZFGaGnvon5pbjLieh7ffE9BuYnrG7qd4O5P3j1fk/4PCR3BcGfGhIfyZi0X8kBcjEhipiBfaHYqI7rxcXg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.1.tgz",
-      "integrity": "sha512-+Rl/VFmu2n6eaRMnVbyfZx1DqR/1KNyWebYuHyQBZaEAVIn/ZLgmofRpXN1X2nhJ4BNaptQUNxAstCYYz6dKoQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.0.tgz",
+      "integrity": "sha512-nnhY0e5DHg8BfUSNCQZoGZnGeqz+zMTeEUOh1dfgtaXmF99uM0QPuTa1i2lH+eZqebP8w1WDWZlewu9FUlHqIg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -3572,35 +3460,13 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/host-metrics": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.1.tgz",
-      "integrity": "sha512-d49/Un/pzqUSsGLeO8PvrX2bLxVAORcaoL3nxjJCzGikXA6gjWXxGOfT8D4qePlgnocozppWszefMHoRFS2MsA==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.2.tgz",
+      "integrity": "sha512-A2THeCFQrqc2CsZi/88eQSR9K14EYCH4cqS6e2sAGsCzg+SGFE8sjUREfZySpquEY+PYYDtMPzTyjsudc9sk9g==",
       "dependencies": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.21.20"
+        "systeminformation": "5.22.9"
       },
       "engines": {
         "node": ">=14"
@@ -3610,13 +3476,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.0.tgz",
+      "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -3629,12 +3495,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.37.0.tgz",
-      "integrity": "sha512-XjOHeAOreh0XX4jlzTTUWWqu1dIGvMWM8yvd43JJdRMAmTZisezjKsxLjMEMIvF0PzQdoXwh9DiS9nYE4/QmpA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.38.0.tgz",
+      "integrity": "sha512-6i1sZl2B329NoOeCFm0R6H/u0DLex7L3NVLEQGSujfM6ztNxEZGmrFhV57eFkzwIHVHUqq9pfmpAAYVkGgrO1w==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -3645,11 +3511,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.41.1.tgz",
-      "integrity": "sha512-/BLG+0DQr2tCILFGJKJH2Fg6eyjhqOlVflYpNddUEXnzyQ/PAhTdgirkqbICFgeSW2XYcEY9zXpuRldrVNw9cA==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.42.0.tgz",
+      "integrity": "sha512-GhV3s62W8gWXDuCdPkWj60W3giHGadHoGBPGW5Wud2fUK9lY6FiYxv6AmCokzugTaiRfB2RjsaJWd9xTtYttVA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -3663,13 +3529,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.41.0.tgz",
-      "integrity": "sha512-7+8WMY0LQeqv6KIObXK+Py44qNFLeCU0ZLLxSZtXEbZ2wJlQISP1St65jRto0NV7isnZoyuOxb2+ZpypPPNv7Q==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.42.0.tgz",
+      "integrity": "sha512-6b4LQAeBSKU5RhKEP9rH+wMcKswlllIT9J65uREmnWQQJo5zogD6cWa2sJ814o9K25/aDi+zheVHDFDuA7iVCQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/propagation-utils": "^0.30.9",
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/propagation-utils": "^0.30.10",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -3680,12 +3546,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.38.0.tgz",
-      "integrity": "sha512-ThNcgTE22W7PKzTzz5qfGxb5Gf7rA3EORousYo2nJWHHcF6gqiMNv2+GXY3MdpjLBr8IgCfhtvbQdD6rlIPUpA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.39.0.tgz",
+      "integrity": "sha512-AQ845Wh5Yhd7S0argkCd1vrThNo4q/p6LJePC4OlFifPa9i5O2MzfLNh4mo8YWa0rYvcc+jbhodkGNa+1YJk/A==",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.51.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@types/bunyan": "1.8.9"
       },
       "engines": {
@@ -3696,12 +3562,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.38.0.tgz",
-      "integrity": "sha512-ML4Vw0it2uIpETfX6skuSIGLHF9D3TUKOfdfrk9lnrzzWSzg2aS6pl3UeepkQX4wXHdzlxVRB0USrUqsmxMd5Q==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.39.0.tgz",
+      "integrity": "sha512-D1p7zNNHQYI6/d0ulAFXe+71oDAgzxctfB0EICT8GpBhOCRlCW0U4rxRWrnZW6T5sJaBJqSsY4QF5CPqvCc00w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3711,12 +3577,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.36.1.tgz",
-      "integrity": "sha512-xI5Q/CMmzBmHshPnzzjD19ptFaYO/rQWzokpNio4QixZYWhJsa35QgRvN9FhPkwgtuJIbt/CWWAufJ3egJNHEA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.37.0.tgz",
+      "integrity": "sha512-SeQktDIH5rNzjiEiazWiJAIXkmnLOnNV7wwHpahrqE0Ph+Z3heqMfxRtoMtbdJSIYLfcNZYO51AjxZ00IXufdw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/connect": "3.4.36"
       },
@@ -3728,12 +3594,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.6.0.tgz",
-      "integrity": "sha512-90eAF2JPSbPAsOuGfYyctYaoYXqy4Clbxt0j/uUgg6dto4oqwUw3AvTyHQEztLGxeXwEzC1EQigDtVPg5ZexYA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.7.0.tgz",
+      "integrity": "sha512-bF9gpkUsDbg5Ii47PrhOzgCJKKrT0Tn0wfowOOgcW8PruqfuXgnQ9q1B6GGdSqtIaFnX3xFxGCyWcmf5emt64w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3743,11 +3609,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.9.0.tgz",
-      "integrity": "sha512-fiyCOAw+tlbneok1x7P5UseoGW5nS60CWWx7NXzYW+WOexpSmDQQW7olttGa8fqE6/sVCoi1l+QdfVoETZi/NQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.10.0.tgz",
+      "integrity": "sha512-yoAHGsgXx0YNFJ5XgCAgPo2Wr7Hy4IQX7YTcCulnKuxdfFXybsM9Yz7wiF9X2X2eB6HRLRJRufXT0sujbHaq1g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3757,12 +3623,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.36.1.tgz",
-      "integrity": "sha512-NWRbQ7q0E3co/CNTWLZZvUzZoKhB1iTitY282IM8HDTXkA6VRssCfOcvaHw5ezOh23TJbAeYxmmpVj4hFvDPYQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.37.0.tgz",
+      "integrity": "sha512-vhIOqqUGq1qwSKS6mF9tpXP7GmVQpQK4zm7bn2UYModpm+YYQzghtf/D8JH6lxXyUMP40zA37xUd2HO6uze/dw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -3773,12 +3638,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.39.0.tgz",
-      "integrity": "sha512-AG8U7z7D0JcBu/7dDcwb47UMEzj9/FMiJV2iQZqrsZnxR3FjB9J9oIH2iszJYci2eUdp2WbdvtpD9RV/zmME5A==",
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.40.1.tgz",
+      "integrity": "sha512-+RKMvVe2zw3kIXRup9c1jFu3T4d0fs5aKy015TpiMyoCKX1UMu3Z0lfgYtuyiSTANvg5hZnDbWmQmqSPj9VTvg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -3789,12 +3654,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.36.1.tgz",
-      "integrity": "sha512-3Nfm43PI0I+3EX+1YbSy6xbDu276R1Dh1tqAk68yd4yirnIh52Kd5B+nJ8CgHA7o3UKakpBjj6vSzi5vNCzJIA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.37.0.tgz",
+      "integrity": "sha512-WRjwzNZgupSzbEYvo9s+QuHJRqZJjVdNxSEpGBwWK8RKLlHGwGVAu0gcc2gPamJWUJsGqPGvahAPWM18ZkWj6A==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -3805,12 +3670,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.12.0.tgz",
-      "integrity": "sha512-Waf+2hekJRxIwq1PmivxOWLdMOtYbY22hKr34gEtfbv2CArSv8FBJH4BmQxB9o5ZcwkdKu589qs009dbuSfNmQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.13.0.tgz",
+      "integrity": "sha512-sZxofhMkul95/Rb4R/Q1eP8mIpgWX8dXNCAOk1jMzl/I8xPJ5tnPgT+PIInPSiDh3kgZDTxK5Up1zMnUh0XqSg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3820,12 +3685,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.36.0.tgz",
-      "integrity": "sha512-CExAEqJvK8jYxrhN8cl6EaGg57EGJi+qsSKouLC5lndXi68gZLOKbZIMZg4pF0kNfp/D4BFaGmA6Ap7d5WoPTw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.37.0.tgz",
+      "integrity": "sha512-l3VivYfu+FRw0/hHu2jlFLz4mfxZrOg4r96usDF5dJgDRQrRUmjtq6xssYGuFKn1FXAfN8Rcn1Tdk/c40PNYEA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3835,11 +3699,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.40.0.tgz",
-      "integrity": "sha512-LVRdEHWACWOczv2imD+mhUrLMxsEjPPi32vIZJT57zygR5aUiA4em8X3aiGOCycgbMWkIu8xOSGSxdx3JmzN+w==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.41.0.tgz",
+      "integrity": "sha512-R/gXeljgIhaRDKquVkKYT5QHPnFouM8ooyePZEP0kqyaVAedtR1V7NfAUJbxfTG5fBQa5wdmLjvu63+tzRXZCA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3849,12 +3713,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.51.0.tgz",
-      "integrity": "sha512-Wfhs9e1Hi4nnULLqzt9s2M6+Tz52EkKj6uZnj9ZL3coldlZiP+WmvuUNepds7jcBJg/qDBjnEe96fThPuO7ddA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.52.0.tgz",
+      "integrity": "sha512-YYhA2pbhMWgF5Hp6eR7AHp1utzZQ3Y0VB8GIwd8zJoLtAuQRZa1N29DUtZ+t/pGRJF+xGPVI+vP+7ugHgeN0zQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -3864,13 +3728,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.38.0.tgz",
-      "integrity": "sha512-ZcOqEuwuutTDYIjhDIStix22ECblG/i9pHje23QGs4Q4YS4RMaZ5hKCoQJxW88Z4K7T53rQkdISmoXFKDV8xMg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.39.0.tgz",
+      "integrity": "sha512-ik2nA9Yj2s2ay+aNY+tJsKCsEx6Tsc2g/MK0iWBW5tibwrWKTy1pdVt5sB3kd5Gkimqj23UV5+FH2JFcQLeKug==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -3880,13 +3744,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.51.0.tgz",
-      "integrity": "sha512-6VsGPBnU6iVKWhVBnuRpwrmiHfxt8EYrqfnH2glfsMpsn4xy+O6U0yGlggPLhoYeOVafV3h70EEk5MU0tpsbiw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.52.0.tgz",
+      "integrity": "sha512-E6ywZuxTa4LnVXZGwL1oj3e2Eog1yIaNqa8KjKXoGkDNKte9/SjQnePXOmhQYI0A9nf0UyFbP9aKd+yHrkJXUA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3897,13 +3761,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.40.0.tgz",
-      "integrity": "sha512-Jv/fH7KhpWe4KBirsiqeUJIYrsdR2iu2l4nWhfOlRvaZ+zYIiLEzTQR6QhBbyRoAbU4OuYJzjWusOmmpGBnwng==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.41.0.tgz",
+      "integrity": "sha512-rxiLloU8VyeJGm5j2fZS8ShVdB82n7VNP8wTwfUQqDwRfHCnkzGr+buKoxuhGD91gtwJ91RHkjHA1Eg6RqsUTg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3913,11 +3777,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.36.1.tgz",
-      "integrity": "sha512-6bEuiI+yMf3D0+ZWZE2AKmXhIhBvZ0brdO/0A8lUqeqeS+sS4fTcjA1F2CclsCNxYWEgcs8o3QyQqPceBeVRlg==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.37.0.tgz",
+      "integrity": "sha512-NyXHezcUYiWnzhiY4gJE/ZMABnaC7ZQUCyx7zNB4J9Snmc4YCsRbLpTkJmCLft3ey/8Qg1Un+6efZcpgthQqbg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -3928,12 +3792,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.40.0.tgz",
-      "integrity": "sha512-dJc3H/bKMcgUYcQpLF+1IbmUKus0e5Fnn/+ru/3voIRHwMADT3rFSUcGLWSczkg68BCgz0vFWGDTvPtcWIFr7A==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.41.0.tgz",
+      "integrity": "sha512-mbPnDt7ELvpM2S0vixYUsde7122lgegLOJQxx8iJQbB8YHal/xnTh9v7IfArSVzIDo+E+080hxZyUZD4boOWkw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3"
@@ -3946,11 +3810,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.37.0.tgz",
-      "integrity": "sha512-dHLrn55qVWsHJQYdForPWPUWDk2HZ2jjzkT+WoQSqpYT1j4HxfoiLfBTF+I3EbEYFAJnDRmRAUfA6nU5GPdCLQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.38.0.tgz",
+      "integrity": "sha512-x41JPoCbltEeOXlHHVxHU6Xcd/91UkaXHNIqj8ejfp9nVQe0lFHBJ8wkUaVJlasu60oEPmiz6VksU3Wa42BrGw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -3960,12 +3824,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.36.0.tgz",
-      "integrity": "sha512-5efkT8ZfN8il5z+yfKYFGm2YR3mhlhaJoGfNOAylKE/6tUH3WDTTWaP7nrURtWGc+fuvDktcEch18Se8qsGS7w==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.37.0.tgz",
+      "integrity": "sha512-30mEfl+JdeuA6m7GRRwO6XYkk7dj4dp0YB70vMQ4MS2qBMVQvkEu3Gb+WFhSHukTYv753zyBeohDkeXw7DEsvw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
         "@types/memcached": "^2.2.6"
       },
       "engines": {
@@ -3976,11 +3840,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.43.0.tgz",
-      "integrity": "sha512-bMKej7Y76QVUD3l55Q9YqizXybHUzF3pujsBFjqbZrRn2WYqtsDtTUlbCK7fvXNPwFInqZ2KhnTqd0gwo8MzaQ==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.45.0.tgz",
+      "integrity": "sha512-xnZP9+ayeB1JJyNE9cIiwhOJTzNEsRhXVdLgfzmrs48Chhhk026mQdM5CITfyXSCfN73FGAIB8d91+pflJEfWQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -3992,12 +3856,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.38.1.tgz",
-      "integrity": "sha512-zaeiasdnRjXe6VhYCBMdkmAVh1S5MmXC/0spet+yqoaViGnYst/DOxPvhwg3yT4Yag5crZNWsVXnA538UjP6Ow==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.39.0.tgz",
+      "integrity": "sha512-J1r66A7zJklPPhMtrFOO7/Ud2p0Pv5u8+r23Cd1JUH6fYPmftNJVsLp2urAt6PHK4jVqpP/YegN8wzjJ2mZNPQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -4008,11 +3872,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.38.1.tgz",
-      "integrity": "sha512-+iBAawUaTfX/HAlvySwozx0C2B6LBfNPXX1W8Z2On1Uva33AGkw2UjL9XgIg1Pj4eLZ9R4EoJ/aFz+Xj4E/7Fw==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.39.0.tgz",
+      "integrity": "sha512-8snHPh83rhrDf31v9Kq0Nf+ts8hdr7NguuszRqZomZBHgE0+UyXZSkXHAAFZoBPPRMGyM68uaFE5hVtFl+wOcA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mysql": "2.15.22"
       },
@@ -4024,11 +3888,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.38.1.tgz",
-      "integrity": "sha512-qkpHMgWSDTYVB1vlZ9sspf7l2wdS5DDq/rbIepDwX5BA0N0068JTQqh0CgAh34tdFqSCnWXIhcyOXC2TtRb0sg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.39.0.tgz",
+      "integrity": "sha512-Iypuq2z6TCfriAXCIZjRq8GTFCKhQv5SpXbmI+e60rYdXw8NHtMH4NXcGF0eKTuoCsC59IYSTUvDQYDKReaszA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
@@ -4040,12 +3904,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.37.1.tgz",
-      "integrity": "sha512-ebYQjHZEmGHWEALwwDGhSQVLBaurFnuLIkZD5igPXrt7ohfF4lc5/4al1LO+vKc0NHk8SJWStuRueT86ISA8Vg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.38.0.tgz",
+      "integrity": "sha512-M381Df1dM8aqihZz2yK+ugvMFK5vlHG/835dc67Sx2hH4pQEQYDA2PpFPTgc9AYYOydQaj7ClFQunESimjXDgg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -4055,12 +3919,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.36.0.tgz",
-      "integrity": "sha512-rZlbSgwAJys8lpug+xIeAdO98ypYMAPVqrHqc4AHuUl5S4MULHEcjGLMZLoE/guEGO4xAQ5XUezpRFGM1SAnsg==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.37.0.tgz",
+      "integrity": "sha512-kLTnWs4R/FtNDvJC7clS7/tBzK7I8DH5IV1I8abog4/1fHh/CFiwWeTRlPlREwcGfVJyL95pDX2Utjviybr5Dg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -4070,11 +3934,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.41.0.tgz",
-      "integrity": "sha512-BSlhpivzBD77meQNZY9fS4aKgydA8AJBzv2dqvxXFy/Hq64b7HURgw/ztbmwFeYwdF5raZZUifiiNSMLpOJoSA==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.42.0.tgz",
+      "integrity": "sha512-sjgcM8CswYy8zxHgXv4RAZ09DlYhQ+9TdlourUs63Df/ek5RrB1ZbjznqW7PB6c3TyJJmX6AVtPTjAsROovEjA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
@@ -4088,11 +3952,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.39.0.tgz",
-      "integrity": "sha512-uA17F2iP77o3NculB63QD2zv3jkJ093Gfb0GxHLEqTIqpYs1ToJ53ybWwjJwqFByxk7GrliaxaxVtWC23PKzBg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.40.0.tgz",
+      "integrity": "sha512-29B7mpabiB5m9YeVuUpWNceKv2E2semh44Y0EngFn7Z/Dwg13j+jsD3h6RaLPLUmUynWKSa160jZm0XrWbx40w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -4102,11 +3966,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.39.1.tgz",
-      "integrity": "sha512-HUjTerD84jRJnSyDrRPqn6xQ7K91o9qLflRPZqzRvq0GRj5PMfc6TJ/z3q/ayWy/2Kzffhrp7HCIVp0u0TkgUg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.40.0.tgz",
+      "integrity": "sha512-vf2EwBrb979ztLMbf8ew+65ECP3yMxeFwpMLu9KjX6+hFf1Ng776jlM2H9GeP1YePbvoBB5Jbo0MBU6Y0HEgzA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -4118,11 +3982,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.39.0.tgz",
-      "integrity": "sha512-Zpfqfi83KeKgVQ0C2083GZPon3ZPYQ5E59v9FAbhubtOoUb9Rh7n111YD8FPW3sgx6JKp1odXmBmfQhWCaTOpQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.40.0.tgz",
+      "integrity": "sha512-0ieQYJb6yl35kXA75LQUPhHtGjtQU9L85KlWa7d4ohBbk/iQKZ3X3CFl5jC5vNMq/GGPB3+w3IxNvALlHtrp7A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -4134,12 +3998,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.38.0.tgz",
-      "integrity": "sha512-VYK47Z9GBaZX5MQLL7kZDdzQDdyUtHRD4J/GSr6kdwmIpdpUQXLsV3EnboeB8P+BlpucF57FyJKE8yWTOEMfnA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.39.0.tgz",
+      "integrity": "sha512-+KDpaGvJLW28LYoT3AZAEVnywzy8dGS+wTWirXU6edKXu4w5mwdxui3UB3Vy/+FV7gbMWidzedaihTDlQvZXRA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -4150,11 +4014,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.37.0.tgz",
-      "integrity": "sha512-+OPcm7C9I5oPqnpStE+1WkdPWjRx0k5XKratxQmIDFZrmhRcqvMte3vrrzE/OBPg9iqh2tKrSe0y7+0sRfTJyQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.38.0.tgz",
+      "integrity": "sha512-HMeeBva/rqIqg/KHzmKcvutK4JS90Sk59i4qCnLhHW57CMVruj18aXEpBT+QMVJRjmzrvhkJnIpNcPu5vglmRg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
@@ -4165,11 +4029,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-runtime-node": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.4.0.tgz",
-      "integrity": "sha512-/NOgUF5gf3T5c3GMyy6fnQxaVzbOf9j2xcetgymIIX2HSN3Gk7o64G7KDvwHwhaa20ZiF0QDLb3m4AT+tn9eRg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.5.0.tgz",
+      "integrity": "sha512-ABW2g44Efq4OLHNCGzj1iKVosl+MJ0bQM8DUQu94VBrc3mpsci5h0tNXvlE2mhMHayqFUFg+DD1qNghvKQew5g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14.10.0"
@@ -4179,12 +4043,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-socket.io": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.39.0.tgz",
-      "integrity": "sha512-4J2ehk5mJyDT6j2yJCOuPxAjit5QB1Fwzhx0LID5jjvhI9LxzZIGDNAPTTHyghSiaRDeNMzceXKkkEQJkg2MNw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.40.0.tgz",
+      "integrity": "sha512-BJFMytiHnvKM7n6n67pT9eTBGpZetY+LHic8UKrIQ313uBp+MBbRyqiJY6dT4bcN1B6sl47JzCyKmVprSuSnBA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -4194,11 +4058,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.10.1.tgz",
-      "integrity": "sha512-maSXMxgS0szU52khQzAROV4nWr+3M8mZajMQOc3/7tYjo+Q3HlWAowOuagPvp4pwROK4x6oDaFYlY+ZSj1qjYA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.11.0.tgz",
+      "integrity": "sha512-Dh93CyaR7vldKf0oXwtYlSEdqvMGUTv270N0YGBQtODPKtgIMr9816vIA7cJPCZ4SbbREgLNQJfbh0qeadAM4Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/tedious": "^4.0.10"
       },
@@ -4210,12 +4074,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.2.0.tgz",
-      "integrity": "sha512-RH9WdVRtpnyp8kvya2RYqKsJouPxvHl7jKPsIfrbL8u2QCKloAGi0uEqDHoOS15ZRYPQTDXZ7d8jSpUgSQmvpA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.3.0.tgz",
+      "integrity": "sha512-LMbOE4ofjpQyZ3266Ah6XL9JIBaShebLN0aaZPvqXozKPu41rHmggO3qk0H+Unv8wbiUnHgYZDvq8yxXyKAadg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -4225,12 +4089,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.37.0.tgz",
-      "integrity": "sha512-vOx55fxdNjo2XojJf8JN4jP7VVvQCh7UQzzQ2Q2FpGJpt8Z3EErKaY8xOBkOuJH0TtL/Q72rmIn9c+mRG46BxA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.38.0.tgz",
+      "integrity": "sha512-rBAoVkv5HGyKFIpM3Xy5raPNJ/Le1JsAFPbxwbfOZUxpLT2YBB99h/jJYsHm+eNueJ7EBwz2ftqY8rEpVlk3XA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.51.0",
-        "@opentelemetry/instrumentation": "^0.51.0"
+        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -4240,174 +4104,61 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.1.tgz",
-      "integrity": "sha512-UYlnOYyDdzo1Gw559EHCzru0RwhvuXCwoH8jGo9J4gO1TE58GjnEmIjomMsKBCym3qWNJfIQXw+9SZCV0DdQNg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.0.tgz",
+      "integrity": "sha512-rlyg5UKW9yMTNMUxYYib9XxEE/krpH7Q6mIuJNOBMbjLwmqe1WQ2MNKNzobVZTKop/FX4CvyNN3wUEl/6gnvfw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-transformer": "0.52.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.1.tgz",
-      "integrity": "sha512-ZAS+4pq8o7dsugGTwV9s6JMKSxi+guIHdn0acOv0bqj26e9pWDFx5Ky+bI0aY46uR9Y0JyXqY+KAEYM/SO3DFA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.52.0.tgz",
+      "integrity": "sha512-iVq3wCElOoKUkxBOuvV8cfaELG8WO/zfLWIZil6iw/6hj6rktLodnJ7kVOneVmLki7Po1BjE1K7JOp2G3UPgYg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "protobufjs": "^7.2.3"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.1.tgz",
-      "integrity": "sha512-gxxxwfk0inDMb5DLeuxQ3L8TtptxSiTNHE4nnAJH34IQXAVRhXSXW1rK8PmDKDngRPIZ6J7ncUCjjIn8b+AgqQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.1.tgz",
-      "integrity": "sha512-OppYOXwV9LQqqtYUCywqoOqX/JT9LQ5/FMuPZ//eTkvuHdUC4ZMwz2c6uSoT2R90GWvvGnF1iEqTGyTT3xAt2Q==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.0.tgz",
+      "integrity": "sha512-40acy3JxCAqQYcYepypF/64GVB8jerC6Oiz1HRUXxiSTVwg+ud7UtywfOkPRpc9bjHiyJouWxTjiUPQ9VBMKbg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "protobufjs": "^7.3.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.9",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.9.tgz",
-      "integrity": "sha512-DP2Y91zyw2uNgKLbej6c3IIjyF27sKnRK/UY/6msMIVGPIbZgtH9L0JOioN5L5kYjEkH4CDvt921SjutN7hY4A==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.10.tgz",
+      "integrity": "sha512-hhTW8pFp9PSyosYzzuUL9rdm7HF97w3OCyElufFHyUnYnKkCBbu8ne2LyF/KSdI/xZ81ubxWZs78hX4S7pLq5g==",
       "engines": {
         "node": ">=14"
       },
@@ -4416,111 +4167,45 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.1.tgz",
-      "integrity": "sha512-RzwoLe6QzsYGcpmxxDbbbgSpe3ncxSM4dtFHXh/rCYGjyq0nZGXKvk26mJtWZ4kQ3nuiIoqSZueIuGmt/mvOTA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.0.tgz",
+      "integrity": "sha512-+honT9J/Xa6Mxk7AO/VlSUGaVSSQzqHr0wZDWrSunnc3eVbS5YTuv7UrcoHTED+AYziawTlx7ICeAX2VPc1M+w==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.1.tgz",
-      "integrity": "sha512-nda97ZwhpZKyUJTXqQuKzNhPMUgMLunbbGWn8kroBwegn+nh6OhtyGkrVQsQLNdVKJl0KeB5z0ZgeWszrYhwFw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.0.tgz",
+      "integrity": "sha512-/A+1Tbnf0uwnP51OkoaQlrb9YILdHsoqIISna1MNXpZRzf42xm6LVLb49i+m/zlJoW1e8P4ekcrditR5pfmwog==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.1.tgz",
-      "integrity": "sha512-7bRBJn3FG1l195A1m+xXRHvgzAOBsfmRi9uZ5Da18oTh7BLmNDiA8+kpk51FpTsU1PCikPVpRDNPhKVB6lyzZg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.0.tgz",
+      "integrity": "sha512-uwA5xqaPISXeX+YutqbjmzENnCGCvrIXlqIXP5gRoA5N6S3W28p+ExL77TugMKHN5gXklapF67jDfz7lq5ETzQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -4532,9 +4217,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.9.tgz",
-      "integrity": "sha512-cTV2YFFkKAZUZgs5SMknIX4MmFb/0KQhrJuiz2dtJKnI1n7OanCgnMkuXzJ5+CbifRB57I2g3HnwcSPOx3zsKw==",
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.10.tgz",
+      "integrity": "sha512-TZv/1Y2QCL6sJ+X9SsPPBXe4786bc/Qsw0hQXFsNTbJzDTGGUmOAlSZ2qPiuqAd4ZheUYfD+QA20IvAjUz9Hhg==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -4547,9 +4232,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.5.0.tgz",
-      "integrity": "sha512-JNk/kSzzNQaiMo/F0b/bm8S3Qtr/m89BckN9B4U/cPHSqKLdxX03vgRBOqkXJ5KlAD8kc6K1Etcr8QfvGw6+uA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.5.1.tgz",
+      "integrity": "sha512-+IUh4gAwJf49vOJM6PIjmgOapRH5zr21ZpFnNU0QZmxRi52AXVhZN7A89pKW6GAQheWnVQLD7iUN87ieYt70tw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -4563,9 +4248,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-azure": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.2.7.tgz",
-      "integrity": "sha512-+R3VnPaK6rc+kKfdvhgQlYDGXy0+JMAjPNDjcRQSeXY8pVOzHGCIrY+gT6gUrpjsw8w1EgNBVofr+qeNOr+o4A==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.2.9.tgz",
+      "integrity": "sha512-16Z6kyrmszoa7J1uj1kbSAgZuk11K07yEDj6fa3I9XBf8Debi8y4K8ex94kpxbCfEraWagXji3bCWvaq3k4dRg==",
       "dependencies": {
         "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -4578,9 +4263,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.9.tgz",
-      "integrity": "sha512-kfJ78av51EKk09fn5cwe5UNt+G7UBLvPTmfK/nZzvmNs7enw/TGB8X0j0JUHb9487ypRGph6MBoeP1+qZh+w1A==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.11.tgz",
+      "integrity": "sha512-22ndMDakxX+nuhAYwqsciexV8/w26JozRUV0FN9kJiqSWtA1b5dCVtlp3J6JivG5t8kDN9UF5efatNnVbqRT9Q==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -4593,9 +4278,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.9",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.9.tgz",
-      "integrity": "sha512-rTUm0U0cF8f75JzeMpMLbQ4m1uLph+Q31DQKk8ekdDe6SZ1EPD4rM1JgRnbxZtsC2sE8ju87s5nEio77xPz7dQ==",
+      "version": "0.29.10",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.10.tgz",
+      "integrity": "sha512-rm2HKJ9lsdoVvrbmkr9dkOzg3Uk0FksXNxvNBgrCprM1XhMoJwThI5i0h/5sJypISUAJlEeJS6gn6nROj/NpkQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -4610,290 +4295,117 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
-      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.1.tgz",
-      "integrity": "sha512-ULQQtl82b673PpZc5/0EtH4V+BrwVOgKJZEB7tYZnGTG3I98tQVk89S9/JSixomDr++F4ih+LSJTCqIKBz+MQQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.0.tgz",
+      "integrity": "sha512-Dp6g7w7WglrDZMn2yHBMAKRGqQy8C0PUbFovkSwcSsmL47n4FSEc3eeGblZTtueOUW+rTsPJpLHoUpEdS0Wibw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.9.0",
-        "@opentelemetry/api-logs": ">=0.39.1"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
-      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.0.tgz",
+      "integrity": "sha512-IF+Sv4VHgBr/BPMKabl+GouJIhEqAOexCHgXVTISdz3q9P9H/uA8ScCF+22gitQ69aFtESbdYOV+Fen5+avQng==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.1.tgz",
-      "integrity": "sha512-GgmNF9C+6esr8PIJxCqHw84rEOkYm6XdFWZ2+Wyc3qaUt92ACoN7uSw5iKNvaUq62W0xii1wsGxwHzyENtPP8w==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.52.0.tgz",
+      "integrity": "sha512-3RNnsoHGutya3oVsoc2WRrk/TKlxr+R2uN6H4boNJvW7kc8yxS4QrOI6DlbQYAgEMeC1PMu95jW9LirPOWcMGw==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
-      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.4",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
-      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
-      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
+      "integrity": "sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.1.tgz",
-      "integrity": "sha512-/FZX8uWaGIAwsDhqI8VvQ+qWtfMNlXjaFYGc+vmxgdRFppCSSIRwrPyIhJO1qx61okyYhoyxVEZAfoiNxrfJCg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.0.tgz",
+      "integrity": "sha512-sYdZmNCkqthPpjwCxAJk5aQNLxCOQjT1u3JMGvO6rb3Ic8uFdnzXavP13Md9uYPcZBo+KxetyDhCf0x8wJGRng==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/propagator-jaeger": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/propagator-jaeger": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
       }
@@ -5499,14 +5011,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-import-attributes": {
@@ -7848,9 +7352,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.5.0.tgz",
-      "integrity": "sha512-R9QGdv8j4/dlNoQbX3hSaK/S0rkMijqjVvW3YM06CoBdbU/VdKd159j4hePpng0KuE6Lh6JJ7UdmVGJZFcAG1w==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.6.0.tgz",
+      "integrity": "sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -8369,12 +7873,12 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "dependencies": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
@@ -11179,9 +10683,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12519,9 +12023,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.22.10",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.10.tgz",
-      "integrity": "sha512-RJ3oed80NkqgHtpB0TLkxEKEpQ3pUm2lgVolkHeoaExPidkWsj2D/hO6Rwwi9i+Odl1vm8TMiRNIKK7hBaqDsw==",
+      "version": "5.22.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.9.tgz",
+      "integrity": "sha512-qUWJhQ9JSBhdjzNUQywpvc0icxUAjMY3sZqUoS0GOtaJV9Ijq8s9zEP8Gaqmymn1dOefcICyPXK1L3kgKxlUpg==",
       "os": [
         "darwin",
         "linux",
@@ -13425,25 +12929,17 @@
         "@dotcom-reliability-kit/errors": "^3.1.0",
         "@dotcom-reliability-kit/log-error": "^4.1.1",
         "@dotcom-reliability-kit/logger": "^3.1.1",
-        "@opentelemetry/auto-instrumentations-node": "^0.46.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
-        "@opentelemetry/host-metrics": "^0.35.1",
-        "@opentelemetry/instrumentation-runtime-node": "^0.4.0",
-        "@opentelemetry/sdk-node": "^0.51.1",
-        "@opentelemetry/semantic-conventions": "^1.24.1"
+        "@opentelemetry/auto-instrumentations-node": "^0.47.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.52.0",
+        "@opentelemetry/host-metrics": "^0.35.2",
+        "@opentelemetry/instrumentation-runtime-node": "^0.5.0",
+        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.25.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
         "npm": "8.x || 9.x || 10.x"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/serialize-error": {

--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -103,7 +103,7 @@ This is derived from the dyno metadata
 
 ### `appInfo.instanceId`
 
-Get the ID of the instance that's running the application. This is derived from `process.env.HEROKU_DYNO_ID` if present, otherwise it will be set to a random UUID that identifies the currently running process.
+Get the unique identifier for the instance that's running the application. This will be a different UUID for each running process, including cluster workers.
 
 ### `appInfo.semanticConventions`
 

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -156,7 +156,7 @@ exports.herokuDynoId = process.env.HEROKU_DYNO_ID || null;
  * @readonly
  * @type {string}
  */
-exports.instanceId = process.env.HEROKU_DYNO_ID || randomUUID();
+exports.instanceId = randomUUID();
 
 /**
  * @type {import('@dotcom-reliability-kit/app-info').SemanticConventions}

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -382,27 +382,14 @@ describe('@dotcom-reliability-kit/app-info', () => {
 
 		beforeEach(() => {
 			jest.resetModules();
-			process.env.HEROKU_DYNO_ID = 'mock-heroku-dyno-id';
+			randomUUID = require('node:crypto').randomUUID;
+			randomUUID.mockReturnValue('mock-generated-uuid');
 			appInfo = require('../../../lib');
 		});
 
-		it('is set to `process.env.HEROKU_DYNO_ID`', () => {
-			expect(appInfo.instanceId).toBe('mock-heroku-dyno-id');
-		});
-
-		describe('when `process.env.HEROKU_DYNO_ID` is not defined', () => {
-			beforeEach(() => {
-				jest.resetModules();
-				randomUUID = require('node:crypto').randomUUID;
-				randomUUID.mockReturnValue('mock-generated-uuid');
-				delete process.env.HEROKU_DYNO_ID;
-				appInfo = require('../../../lib');
-			});
-
-			it('is set to a random UUID', () => {
-				expect(randomUUID).toHaveBeenCalledTimes(1);
-				expect(appInfo.instanceId).toBe('mock-generated-uuid');
-			});
+		it('is set to a random UUID', () => {
+			expect(randomUUID).toHaveBeenCalledTimes(1);
+			expect(appInfo.instanceId).toBe('mock-generated-uuid');
 		});
 	});
 

--- a/packages/app-info/types/index.d.ts
+++ b/packages/app-info/types/index.d.ts
@@ -10,6 +10,7 @@ declare module '@dotcom-reliability-kit/app-info' {
 	export const herokuAppId: string | null;
 	export const herokuDynoId: string | null;
 	export const instanceId: string;
+	export const semanticConventions: SemanticConventions;
 
 	export type SemanticConventions = {
 		cloud: {

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -152,6 +152,8 @@ opentelemetry.setup({ /* ... */ });
     </tr>
 </table>
 
+This method returns any SDK instances created during setup. Calling this method a second time will return the same instances without rerunning setup.
+
 ### Running in production
 
 #### Production metrics

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -276,7 +276,7 @@ A URL to send OpenTelemetry metrics to. E.g. `http://localhost:4318/v1/metrics`.
 
 #### `options.metrics.apiGatewayKey`
 
-Set the `Authorization` HTTP header in requests to the central API-Gateway-backed OpenTelemetry metrics collector. Defaults to `undefined`.
+Set the `X-OTel-Key` HTTP header in requests to the central API-Gateway-backed OpenTelemetry metrics collector. Defaults to `undefined`.
 
 **Environment variable:** `OPENTELEMETRY_API_GATEWAY_KEY`<br/>
 **Option:** `metrics.apiGatewayKey` (`String`)

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -30,6 +30,7 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
     * [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader)
     * [`options.tracing.samplePercentage`](#optionstracingsamplepercentage)
     * [`OTEL_` environment variables](#otel_-environment-variables)
+* [Migrating](#migrating)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -117,9 +118,9 @@ OpenTelemetry will be [configured](#configuration-options) with environment vari
 If you'd like to customise the OpenTelemetry config more and have control over what runs, you can include in your code:
 
 ```js
-import setupOpenTelemetry from '@dotcom-reliability-kit/opentelemetry';
+import * as opentelemetry from '@dotcom-reliability-kit/opentelemetry';
 // or
-const setupOpenTelemetry = require('@dotcom-reliability-kit/opentelemetry');
+const opentelemetry = require('@dotcom-reliability-kit/opentelemetry');
 ```
 
 Call the function, passing in [configuration options](#configuration-options):
@@ -128,7 +129,7 @@ Call the function, passing in [configuration options](#configuration-options):
 > This **must** be the first function called in your application for OpenTelemetry to be set up correctly (including before other `import`/`require` statements).
 
 ```js
-setupOpenTelemetry({ /* ... */ });
+opentelemetry.setup({ /* ... */ });
 ```
 
 <table>
@@ -225,7 +226,7 @@ EXAMPLE=true npm start
 For the [manual setup](#manual-setup), you'll need to use an options object, e.g.
 
 ```js
-setupOpenTelemetry({
+opentelemetry.setup({
     example: true
 });
 ```
@@ -283,6 +284,11 @@ OpenTelemetry itself can be configured through `OTEL_`-prefixed environment vari
 
 > [!CAUTION]
 > We strongly advise against using these. The power of this module is consistency and any application-specific changes should be considered. If you use these environment variables we won't offer support if things break.
+
+
+## Migrating
+
+Consult the [Migration Guide](./docs/migration.md) if you're trying to migrate to a later major version of this package.
 
 
 ## Contributing

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -11,6 +11,7 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
     * [Automated setup with `--require`](#automated-setup-with---require)
     * [Automated setup with `require()`](#automated-setup-with-require)
     * [Manual setup](#manual-setup)
+  * [Sending custom metrics](#sending-custom-metrics)
   * [Running in production](#running-in-production)
     * [Production metrics](#production-metrics)
     * [Production tracing](#production-tracing)
@@ -153,6 +154,31 @@ opentelemetry.setup({ /* ... */ });
 </table>
 
 This method returns any SDK instances created during setup. Calling this method a second time will return the same instances without rerunning setup.
+
+### Sending custom metrics
+
+Many metrics are taken care of by OpenTelemetry's auto-instrumentation (e.g. HTTP request data), but you sometimes need to send your own metrics. We expose the OpenTelemetry `getMeter` method ([documentation](https://opentelemetry.io/docs/languages/js/instrumentation/#acquiring-a-meter)) which allows you to do this.
+
+In your code, load in the `getMeter` function:
+
+```js
+import getMeter from '@dotcom-reliability-kit/opentelemetry';
+// or
+const { getMeter } = require('@dotcom-reliability-kit/opentelemetry');
+```
+
+You can now use it in the same way as the built-in OpenTelemetry equivalent. For more information, see the [OpenTelemetry Meter documentation](https://opentelemetry.io/docs/specs/otel/metrics/api/#meter).
+
+```js
+// Assumes that `app` is an Express application instance
+const meter = getMeter('my-app');
+const hitCounter = meter.createCounter('my-app.hits');
+
+app.get('/', (request, response) => {
+    hitCounter.add(1);
+    response.send('Thanks for visiting');
+});
+```
 
 ### Running in production
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -12,12 +12,19 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
     * [Automated setup with `require()`](#automated-setup-with-require)
     * [Manual setup](#manual-setup)
   * [Running in production](#running-in-production)
+    * [Production metrics](#production-metrics)
+    * [Production tracing](#production-tracing)
   * [Running locally](#running-locally)
-    * [Running a backend](#running-a-backend)
-    * [Sending traces to your local backend](#sending-traces-to-your-local-backend)
+    * [Local metrics](#local-metrics)
+    * [Local tracing](#local-tracing)
+      * [Running a backend](#running-a-backend)
+      * [Sending traces to your local backend](#sending-traces-to-your-local-backend)
   * [Implementation details](#implementation-details)
   * [Configuration options](#configuration-options)
     * [`options.authorizationHeader`](#optionsauthorizationheader)
+    * [`options.metrics`](#optionsmetrics)
+    * [`options.metrics.endpoint`](#optionsmetricsendpoint)
+    * [`options.metrics.apiGatewayKey`](#optionsmetricsapigatewaykey)
     * [`options.tracing`](#optionstracing)
     * [`options.tracing.endpoint`](#optionstracingendpoint)
     * [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader)
@@ -146,6 +153,15 @@ setupOpenTelemetry({ /* ... */ });
 
 ### Running in production
 
+#### Production metrics
+
+To send metrics in production, you'll need an API Gateway key and the URL of the FT's official metrics collector. [You can find this information in Tech Hub](https://tech.in.ft.com/tech-topics/observability/opentelemetry).
+
+#### Production tracing
+
+> [!WARNING]<br />
+> Tracing is not supported centrally yet and these instructions assume your team or group will be setting up their own collector.
+
 To use this package in production you'll need a [Collector](https://opentelemetry.io/docs/collector/) that can receive traces over HTTP. This could be something you run (e.g. the [AWS Distro for OpenTelemetry](https://aws.amazon.com/otel/)) or a third-party service.
 
 Having traces collected centrally will give you a good view of how your production application is performing, allowing you to debug issues more effectively.
@@ -154,15 +170,21 @@ OpenTelemetry can generate a huge amount of data which, depending on where you s
 
 ### Running locally
 
+#### Local metrics
+
+We don't recommend trying to get a metrics exporter set up locally, if your `NODE_ENV` environment variable is not set to production, then local metrics will be available in Grafana under `OpenTelemetry Test`.
+
+#### Local tracing
+
 If you want to debug specific performance issues then setting up a local Collector can help you. You shouldn't be sending traces in local development to your production backend as this could make it harder to debug real production issues. You probably also don't want to sample traces in local development – you'll want to collect all traffic because the volume will be much lower.
 
-#### Running a backend
+##### Running a backend
 
 To view traces locally, you'll need a backend for them to be sent to. In this example we'll be using [Jaeger](https://www.jaegertracing.io/) via [Docker](https://www.docker.com/). You'll need Docker (or a compatible [alternative](https://podman.io/)) to be set up first.
 
 [Jaeger maintains a useful guide for this](https://www.jaegertracing.io/docs/1.53/getting-started/#all-in-one).
 
-#### Sending traces to your local backend
+##### Sending traces to your local backend
 
 Once your backend is running you'll need to make some configuration changes.
 
@@ -211,6 +233,24 @@ setupOpenTelemetry({
 #### `options.authorizationHeader`
 
 **Deprecated**. This will still work but has been replaced with [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader), which is now the preferred way to set this option.
+
+#### `options.metrics`
+
+An object containing other metrics-specific configurations. Defaults to `undefined` which means that OpenTelemetry metrics will not be sent.
+
+#### `options.metrics.endpoint`
+
+A URL to send OpenTelemetry metrics to. E.g. `http://localhost:4318/v1/metrics`. Defaults to `undefined` which means that OpenTelemetry metrics will not be sent.
+
+**Environment variable:** `OPENTELEMETRY_METRICS_ENDPOINT`<br/>
+**Option:** `metrics.endpoint` (`String`)
+
+#### `options.metrics.apiGatewayKey`
+
+Set the `Authorization` HTTP header in requests to the central API-Gateway-backed OpenTelemetry metrics collector. Defaults to `undefined`.
+
+**Environment variable:** `OPENTELEMETRY_API_GATEWAY_KEY`<br/>
+**Option:** `metrics.apiGatewayKey` (`String`)
 
 #### `options.tracing`
 

--- a/packages/opentelemetry/docs/migration.md
+++ b/packages/opentelemetry/docs/migration.md
@@ -1,0 +1,33 @@
+
+# Migration guide for @dotcom-reliability-kit/opentelemetry
+
+This document outlines how to migrate to the latest version of the Reliability Kit opentelemetry package. Throughout this guide we use the following emoji and labels to indicate the level of change required:
+
+Emoji           | Label             | Meaning
+----------------|:------------------|:-------
+:red_circle:    | Breaking          | A breaking change which will likely require code or config changes to resolve
+:orange_circle: | Possibly Breaking | A breaking change that is unlikely to require code changes but things outside of the code (e.g. logs) may have changed
+:yellow_circle: | Deprecation       | A deprecated feature which will require code changes in the future
+
+* [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+  * [JavaScript API changes](#javascript-api-changes)
+
+
+## Migrating from v1 to v2
+
+### JavaScript API changes
+
+**:red_circle: Breaking:** If you're using the manual setup of OpenTelemetry via the JavaScript API, the setup method is no longer a default export. Instead, use a named `setup` export:
+
+```diff
+- import setupOpenTelemetry from '@dotcom-reliability-kit/opentelemetry';
++ import * as opentelemetry from '@dotcom-reliability-kit/opentelemetry';
+// or
+- const setupOpenTelemetry = require('@dotcom-reliability-kit/opentelemetry');
++ const opentelemetry = require('@dotcom-reliability-kit/opentelemetry');
+
+- setupOpenTelemetry({ /* ... */ });
++ opentelemetry.setup({ /* ... */ });
+```
+
+If you're using the `--require` method or importing `@dotcom-reliability-kit/opentelemetry/setup` then this is not a breaking change.

--- a/packages/opentelemetry/lib/config/instrumentations.js
+++ b/packages/opentelemetry/lib/config/instrumentations.js
@@ -1,6 +1,9 @@
 const {
 	getNodeAutoInstrumentations
 } = require('@opentelemetry/auto-instrumentations-node');
+const {
+	RuntimeNodeInstrumentation
+} = require('@opentelemetry/instrumentation-runtime-node');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const { UserInputError } = require('@dotcom-reliability-kit/errors');
 
@@ -21,7 +24,8 @@ exports.createInstrumentationConfig = function createInstrumentationConfig() {
 			'@opentelemetry/instrumentation-fs': {
 				enabled: false
 			}
-		})
+		}),
+		new RuntimeNodeInstrumentation()
 	];
 };
 

--- a/packages/opentelemetry/lib/config/metrics.js
+++ b/packages/opentelemetry/lib/config/metrics.js
@@ -49,7 +49,7 @@ exports.createMetricsConfig = function createMetricsConfig(options) {
 			endpoint: options.endpoint
 		});
 	} else {
-		logger.warn({
+		logger.info({
 			event: 'OTEL_METRICS_STATUS',
 			message:
 				'OpenTelemetry metrics are disabled because no metrics endpoint was set',

--- a/packages/opentelemetry/lib/config/metrics.js
+++ b/packages/opentelemetry/lib/config/metrics.js
@@ -2,7 +2,9 @@ const {
 	OTLPMetricExporter
 } = require('@opentelemetry/exporter-metrics-otlp-proto');
 const { CompressionAlgorithm } = require('@opentelemetry/otlp-exporter-base');
-const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+require('@opentelemetry/sdk-node');
+const { PeriodicExportingMetricReader } =
+	require('@opentelemetry/sdk-node').metrics;
 const logger = require('@dotcom-reliability-kit/logger');
 const { METRICS_USER_AGENT } = require('./user-agents');
 

--- a/packages/opentelemetry/lib/config/metrics.js
+++ b/packages/opentelemetry/lib/config/metrics.js
@@ -1,0 +1,60 @@
+const {
+	OTLPMetricExporter
+} = require('@opentelemetry/exporter-metrics-otlp-proto');
+const { CompressionAlgorithm } = require('@opentelemetry/otlp-exporter-base');
+const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+const logger = require('@dotcom-reliability-kit/logger');
+const { METRICS_USER_AGENT } = require('./user-agents');
+
+/**
+ * @typedef {object} MetricsOptions
+ * @property {string} [apiGatewayKey]
+ *     The API key to send to the metrics collector if you're using the FT's official metrics collector endpoint.
+ * @property {string} [endpoint]
+ *     The URL to send OpenTelemetry metrics to, for example http://localhost:4318/v1/metrics.
+ */
+
+/**
+ * Create an OpenTelemetry metrics configuration.
+ *
+ * @param {MetricsOptions} options
+ * @returns {Partial<import('@opentelemetry/sdk-node').NodeSDKConfiguration>}
+ */
+exports.createMetricsConfig = function createMetricsConfig(options) {
+	/** @type {Partial<import('@opentelemetry/sdk-node').NodeSDKConfiguration>} */
+	const config = {};
+
+	// If we have an OpenTelemetry metrics endpoint then set it up
+	if (options?.endpoint) {
+		const headers = {
+			'user-agent': METRICS_USER_AGENT
+		};
+		if (options.apiGatewayKey) {
+			headers['X-OTel-Key'] = options.apiGatewayKey;
+		}
+		config.metricReader = new PeriodicExportingMetricReader({
+			exporter: new OTLPMetricExporter({
+				url: options.endpoint,
+				compression: CompressionAlgorithm.GZIP,
+				headers
+			})
+		});
+
+		logger.info({
+			event: 'OTEL_METRICS_STATUS',
+			message: `OpenTelemetry metrics are enabled and exporting to endpoint ${options.endpoint}`,
+			enabled: true,
+			endpoint: options.endpoint
+		});
+	} else {
+		logger.warn({
+			event: 'OTEL_METRICS_STATUS',
+			message:
+				'OpenTelemetry metrics are disabled because no metrics endpoint was set',
+			enabled: false,
+			endpoint: null
+		});
+	}
+
+	return config;
+};

--- a/packages/opentelemetry/lib/config/resource.js
+++ b/packages/opentelemetry/lib/config/resource.js
@@ -1,5 +1,5 @@
 const appInfo = require('@dotcom-reliability-kit/app-info').semanticConventions;
-const { Resource } = require('@opentelemetry/resources');
+const { Resource } = require('@opentelemetry/sdk-node').resources;
 const {
 	SEMRESATTRS_CLOUD_PROVIDER,
 	SEMRESATTRS_CLOUD_REGION,
@@ -12,7 +12,7 @@ const {
 /**
  * Create a Resource object using gathered app info.
  *
- * @returns {import('@opentelemetry/sdk-node').NodeSDKConfiguration['resource']}
+ * @returns {import('@opentelemetry/sdk-node').resources.Resource}
  */
 exports.createResourceConfig = function createResourceConfig() {
 	// We set OpenTelemetry resource attributes based on app data

--- a/packages/opentelemetry/lib/config/resource.js
+++ b/packages/opentelemetry/lib/config/resource.js
@@ -1,9 +1,10 @@
-const appInfo = require('@dotcom-reliability-kit/app-info');
+const appInfo = require('@dotcom-reliability-kit/app-info').semanticConventions;
 const { Resource } = require('@opentelemetry/resources');
 const {
 	SEMRESATTRS_CLOUD_PROVIDER,
 	SEMRESATTRS_CLOUD_REGION,
 	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+	SEMRESATTRS_SERVICE_INSTANCE_ID,
 	SEMRESATTRS_SERVICE_NAME,
 	SEMRESATTRS_SERVICE_VERSION
 } = require('@opentelemetry/semantic-conventions');
@@ -16,10 +17,11 @@ const {
 exports.createResourceConfig = function createResourceConfig() {
 	// We set OpenTelemetry resource attributes based on app data
 	return new Resource({
-		[SEMRESATTRS_SERVICE_NAME]: appInfo.systemCode || undefined,
-		[SEMRESATTRS_SERVICE_VERSION]: appInfo.releaseVersion || undefined,
-		[SEMRESATTRS_CLOUD_PROVIDER]: appInfo.cloudProvider || undefined,
-		[SEMRESATTRS_CLOUD_REGION]: appInfo.region || undefined,
-		[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: appInfo.environment || undefined
+		[SEMRESATTRS_SERVICE_NAME]: appInfo.service.name,
+		[SEMRESATTRS_SERVICE_VERSION]: appInfo.service.version,
+		[SEMRESATTRS_SERVICE_INSTANCE_ID]: appInfo.service.instance.id,
+		[SEMRESATTRS_CLOUD_PROVIDER]: appInfo.cloud.provider,
+		[SEMRESATTRS_CLOUD_REGION]: appInfo.cloud.region,
+		[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: appInfo.deployment.environment
 	});
 };

--- a/packages/opentelemetry/lib/config/tracing.js
+++ b/packages/opentelemetry/lib/config/tracing.js
@@ -66,7 +66,7 @@ exports.createTracingConfig = function createTracingConfig(options) {
 			enabled: false,
 			endpoint: null
 		});
-		config.spanProcessor = new NoopSpanProcessor();
+		config.spanProcessors = [new NoopSpanProcessor()];
 	}
 
 	return config;

--- a/packages/opentelemetry/lib/config/tracing.js
+++ b/packages/opentelemetry/lib/config/tracing.js
@@ -59,7 +59,7 @@ exports.createTracingConfig = function createTracingConfig(options) {
 			samplePercentage
 		});
 	} else {
-		logger.warn({
+		logger.info({
 			event: 'OTEL_TRACE_STATUS',
 			message:
 				'OpenTelemetry tracing is disabled because no tracing endpoint was set',

--- a/packages/opentelemetry/lib/config/tracing.js
+++ b/packages/opentelemetry/lib/config/tracing.js
@@ -1,10 +1,9 @@
 const {
 	OTLPTraceExporter
 } = require('@opentelemetry/exporter-trace-otlp-proto');
-const {
-	NoopSpanProcessor,
-	TraceIdRatioBasedSampler
-} = require('@opentelemetry/sdk-trace-base');
+const { NoopSpanProcessor, TraceIdRatioBasedSampler } =
+	require('@opentelemetry/sdk-node').tracing;
+
 const logger = require('@dotcom-reliability-kit/logger');
 const { TRACING_USER_AGENT } = require('./user-agents');
 

--- a/packages/opentelemetry/lib/config/tracing.js
+++ b/packages/opentelemetry/lib/config/tracing.js
@@ -13,7 +13,7 @@ const DEFAULT_SAMPLE_PERCENTAGE = 5;
 /**
  * @typedef {object} TracingOptions
  * @property {string} [authorizationHeader]
- *     The HTTP `Authorization` header to send with OpenTelemetry tracing requests.
+ *     The HTTP `Authorization` header to send with OpenTelemetry tracing requests if you're using the Customer Products trace collector endpoint.
  * @property {string} [endpoint]
  *     The URL to send OpenTelemetry trace segments to, for example http://localhost:4318/v1/traces.
  * @property {number} [samplePercentage]

--- a/packages/opentelemetry/lib/config/user-agents.js
+++ b/packages/opentelemetry/lib/config/user-agents.js
@@ -1,7 +1,9 @@
 const appInfo = require('@dotcom-reliability-kit/app-info');
 const packageJson = require('../../package.json');
+const metricExporterPackageJson = require('@opentelemetry/exporter-metrics-otlp-proto/package.json');
 const traceExporterPackageJson = require('@opentelemetry/exporter-trace-otlp-proto/package.json');
 
 const BASE_USER_AGENT = `FTSystem/${appInfo.systemCode} (${packageJson.name}/${packageJson.version})`;
 
+exports.METRICS_USER_AGENT = `${BASE_USER_AGENT} (${metricExporterPackageJson.name}/${metricExporterPackageJson.version})`;
 exports.TRACING_USER_AGENT = `${BASE_USER_AGENT} (${traceExporterPackageJson.name}/${traceExporterPackageJson.version})`;

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -79,7 +79,4 @@ function setupOpenTelemetry({
 	sdk.start();
 }
 
-module.exports = setupOpenTelemetry;
-
-// @ts-ignore
-module.exports.default = module.exports;
+exports.setup = setupOpenTelemetry;

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -2,7 +2,6 @@ const { createInstrumentationConfig } = require('./config/instrumentations');
 const { createMetricsConfig } = require('./config/metrics');
 const { createResourceConfig } = require('./config/resource');
 const { createTracingConfig } = require('./config/tracing');
-const { diag, DiagLogLevel } = require('@opentelemetry/api');
 const opentelemetrySDK = require('@opentelemetry/sdk-node');
 const logger = require('@dotcom-reliability-kit/logger');
 
@@ -52,13 +51,13 @@ function setupOpenTelemetry({
 	// the LOG_LEVEL environment variable) takes over. We set the
 	// OpenTelemetry log level to the maximum value that we want
 	// Reliability Kit to consider logging
-	diag.setLogger(
+	opentelemetrySDK.api.diag.setLogger(
 		// @ts-ignore this complains because DiagLogger accepts a type
 		// of unknown whereas our logger is stricter. This is fine though,
 		// if something unknown is logged then we do our best with it.
 		// It's easier to ignore this error than fix it.
 		logger.createChildLogger({ event: 'OTEL_INTERNALS' }),
-		DiagLogLevel.INFO
+		opentelemetrySDK.api.DiagLogLevel.INFO
 	);
 
 	// Set up and start OpenTelemetry

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -32,7 +32,7 @@ const logger = require('@dotcom-reliability-kit/logger');
 /**
  * Stores the singleton instances that were created during OpenTelemetry setup.
  *
- * @type {Instances}
+ * @type {Instances | undefined}
  */
 let instances;
 
@@ -101,4 +101,31 @@ function setupOpenTelemetry({
 	return instances;
 }
 
+/**
+ * Get a metrics meter from the configured OpenTelemetry SDK.
+ *
+ * @param {string} name
+ *     The meter name.
+ * @param {string} [version]
+ *     The meter version.
+ * @param {opentelemetry.api.MeterOptions} [options]
+ *     Additional configuration options for the meter.
+ * @returns {opentelemetry.api.Meter}
+ *      Returns a metrics meter.
+ */
+function getMeter(name, version, options) {
+	if (!instances) {
+		throw Object.assign(
+			new Error(
+				'Reliability Kit OpenTelemetry must be set up before meters can be created. See the setup guide for more information: https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/opentelemetry#setup'
+			),
+			{
+				code: 'OTEL_MISSING_SETUP'
+			}
+		);
+	}
+	return opentelemetry.api.metrics.getMeter(name, version, options);
+}
+
 exports.setup = setupOpenTelemetry;
+exports.getMeter = getMeter;

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -22,8 +22,12 @@
 		"@dotcom-reliability-kit/logger": "^3.1.1",
 		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.46.1",
+		"@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
+		"@opentelemetry/host-metrics": "^0.35.1",
+		"@opentelemetry/instrumentation-runtime-node": "^0.4.0",
 		"@opentelemetry/resources": "^1.24.1",
+		"@opentelemetry/sdk-metrics": "^1.24.1",
 		"@opentelemetry/sdk-node": "^0.51.1",
 		"@opentelemetry/sdk-trace-base": "^1.24.1",
 		"@opentelemetry/semantic-conventions": "^1.24.1"

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -20,16 +20,12 @@
 		"@dotcom-reliability-kit/errors": "^3.1.0",
 		"@dotcom-reliability-kit/log-error": "^4.1.1",
 		"@dotcom-reliability-kit/logger": "^3.1.1",
-		"@opentelemetry/api": "^1.8.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.46.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
 		"@opentelemetry/host-metrics": "^0.35.1",
 		"@opentelemetry/instrumentation-runtime-node": "^0.4.0",
-		"@opentelemetry/resources": "^1.24.1",
-		"@opentelemetry/sdk-metrics": "^1.24.1",
 		"@opentelemetry/sdk-node": "^0.51.1",
-		"@opentelemetry/sdk-trace-base": "^1.24.1",
 		"@opentelemetry/semantic-conventions": "^1.24.1"
 	}
 }

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -20,12 +20,12 @@
 		"@dotcom-reliability-kit/errors": "^3.1.0",
 		"@dotcom-reliability-kit/log-error": "^4.1.1",
 		"@dotcom-reliability-kit/logger": "^3.1.1",
-		"@opentelemetry/auto-instrumentations-node": "^0.46.1",
-		"@opentelemetry/exporter-metrics-otlp-proto": "^0.51.1",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.51.1",
-		"@opentelemetry/host-metrics": "^0.35.1",
-		"@opentelemetry/instrumentation-runtime-node": "^0.4.0",
-		"@opentelemetry/sdk-node": "^0.51.1",
-		"@opentelemetry/semantic-conventions": "^1.24.1"
+		"@opentelemetry/auto-instrumentations-node": "^0.47.1",
+		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.0",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.52.0",
+		"@opentelemetry/host-metrics": "^0.35.2",
+		"@opentelemetry/instrumentation-runtime-node": "^0.5.0",
+		"@opentelemetry/sdk-node": "^0.52.0",
+		"@opentelemetry/semantic-conventions": "^1.25.0"
 	}
 }

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -1,6 +1,6 @@
-const setupOpenTelemetry = require('./lib/index.js');
+const opentelemetry = require('.');
 
-/** @type {setupOpenTelemetry.TracingOptions | undefined} */
+/** @type {opentelemetry.TracingOptions | undefined} */
 let tracing = undefined;
 if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 	tracing = {
@@ -12,7 +12,7 @@ if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 	};
 }
 
-/** @type {setupOpenTelemetry.MetricsOptions | undefined} */
+/** @type {opentelemetry.MetricsOptions | undefined} */
 let metrics = undefined;
 if (process.env.OPENTELEMETRY_METRICS_ENDPOINT) {
 	metrics = {
@@ -21,7 +21,7 @@ if (process.env.OPENTELEMETRY_METRICS_ENDPOINT) {
 	};
 }
 
-setupOpenTelemetry({
+opentelemetry.setup({
 	metrics,
 	tracing
 });

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -12,6 +12,16 @@ if (process.env.OPENTELEMETRY_TRACING_ENDPOINT) {
 	};
 }
 
+/** @type {setupOpenTelemetry.MetricsOptions | undefined} */
+let metrics = undefined;
+if (process.env.OPENTELEMETRY_METRICS_ENDPOINT) {
+	metrics = {
+		apiGatewayKey: process.env.OPENTELEMETRY_API_GATEWAY_KEY,
+		endpoint: process.env.OPENTELEMETRY_METRICS_ENDPOINT
+	};
+}
+
 setupOpenTelemetry({
+	metrics,
 	tracing
 });

--- a/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
@@ -3,12 +3,16 @@ jest.mock('@opentelemetry/auto-instrumentations-node', () => ({
 		.fn()
 		.mockReturnValue('mock-auto-instrumentations')
 }));
+jest.mock('@opentelemetry/instrumentation-runtime-node');
 jest.mock('@dotcom-reliability-kit/log-error');
 jest.mock('@dotcom-reliability-kit/errors');
 
 const {
 	getNodeAutoInstrumentations
 } = require('@opentelemetry/auto-instrumentations-node');
+const {
+	RuntimeNodeInstrumentation
+} = require('@opentelemetry/instrumentation-runtime-node');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const { UserInputError } = require('@dotcom-reliability-kit/errors');
 
@@ -25,6 +29,7 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 		let instrumentations;
 
 		beforeEach(() => {
+			RuntimeNodeInstrumentation.mockReset();
 			instrumentations = createInstrumentationConfig();
 		});
 
@@ -38,6 +43,11 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 					enabled: false
 				}
 			});
+		});
+
+		it('sets up runtime Node.js instrumentations', () => {
+			expect(RuntimeNodeInstrumentation).toHaveBeenCalledTimes(1);
+			expect(RuntimeNodeInstrumentation).toHaveBeenCalledWith();
 		});
 
 		describe('ignore incoming request hook function', () => {
@@ -122,7 +132,10 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 		});
 
 		it('returns an array of instrumentations', () => {
-			expect(instrumentations).toEqual(['mock-auto-instrumentations']);
+			expect(instrumentations).toEqual([
+				'mock-auto-instrumentations',
+				expect.any(RuntimeNodeInstrumentation)
+			]);
 		});
 	});
 });

--- a/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
@@ -1,0 +1,116 @@
+jest.mock('@opentelemetry/exporter-metrics-otlp-proto');
+jest.mock('@opentelemetry/otlp-exporter-base');
+jest.mock('@opentelemetry/sdk-metrics');
+jest.mock('@dotcom-reliability-kit/logger');
+jest.mock('../../../../lib/config/user-agents', () => ({
+	METRICS_USER_AGENT: 'mock-metrics-user-agent'
+}));
+
+const logger = require('@dotcom-reliability-kit/logger');
+const {
+	OTLPMetricExporter
+} = require('@opentelemetry/exporter-metrics-otlp-proto');
+const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+const { createMetricsConfig } = require('../../../../lib/config/metrics');
+
+describe('@dotcom-reliability-kit/opentelemetry/lib/config/metrics', () => {
+	it('exports a function', () => {
+		expect(typeof createMetricsConfig).toBe('function');
+	});
+
+	describe('createMetricsConfig(options)', () => {
+		let config;
+
+		beforeAll(() => {
+			config = createMetricsConfig({
+				apiGatewayKey: 'mock-api-gateway-key',
+				endpoint: 'mock-endpoint'
+			});
+		});
+
+		it('creates a metrics exporter', () => {
+			expect(OTLPMetricExporter).toHaveBeenCalledTimes(1);
+			expect(OTLPMetricExporter).toHaveBeenCalledWith({
+				url: 'mock-endpoint',
+				compression: 'gzip',
+				headers: {
+					'X-OTel-Key': 'mock-api-gateway-key',
+					'user-agent': 'mock-metrics-user-agent'
+				}
+			});
+		});
+
+		it('creates a metrics reader with the configured exporter', () => {
+			expect(PeriodicExportingMetricReader).toHaveBeenCalledTimes(1);
+			expect(PeriodicExportingMetricReader).toHaveBeenCalledWith({
+				exporter: expect.any(OTLPMetricExporter)
+			});
+		});
+
+		it('logs that metrics are enabled', () => {
+			expect(logger.info).toHaveBeenCalledWith({
+				enabled: true,
+				endpoint: 'mock-endpoint',
+				event: 'OTEL_METRICS_STATUS',
+				message:
+					'OpenTelemetry metrics are enabled and exporting to endpoint mock-endpoint'
+			});
+		});
+
+		it('returns the configuration', () => {
+			expect(config).toEqual({
+				metricReader: PeriodicExportingMetricReader.mock.instances[0]
+			});
+		});
+
+		describe('when options.apiGatewayKey is not defined', () => {
+			beforeAll(() => {
+				OTLPMetricExporter.mockClear();
+				config = createMetricsConfig({
+					endpoint: 'mock-endpoint'
+				});
+			});
+
+			it('creates a metrics exporter without an X-OTel-Key header', () => {
+				expect(OTLPMetricExporter).toHaveBeenCalledTimes(1);
+				expect(OTLPMetricExporter).toHaveBeenCalledWith({
+					url: 'mock-endpoint',
+					compression: 'gzip',
+					headers: {
+						'user-agent': 'mock-metrics-user-agent'
+					}
+				});
+			});
+		});
+
+		describe('when options.endpoint is not defined', () => {
+			beforeAll(() => {
+				OTLPMetricExporter.mockClear();
+				PeriodicExportingMetricReader.mockClear();
+				config = createMetricsConfig({});
+			});
+
+			it('does not create a metrics exporter', () => {
+				expect(OTLPMetricExporter).toHaveBeenCalledTimes(0);
+			});
+
+			it('does not create a metrics reader', () => {
+				expect(PeriodicExportingMetricReader).toHaveBeenCalledTimes(0);
+			});
+
+			it('logs that metrics are disabled', () => {
+				expect(logger.warn).toHaveBeenCalledWith({
+					enabled: false,
+					endpoint: null,
+					event: 'OTEL_METRICS_STATUS',
+					message:
+						'OpenTelemetry metrics are disabled because no metrics endpoint was set'
+				});
+			});
+
+			it('returns the empty configuration', () => {
+				expect(config).toEqual({});
+			});
+		});
+	});
+});

--- a/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
@@ -100,7 +100,7 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/metrics', () => {
 			});
 
 			it('logs that metrics are disabled', () => {
-				expect(logger.warn).toHaveBeenCalledWith({
+				expect(logger.info).toHaveBeenCalledWith({
 					enabled: false,
 					endpoint: null,
 					event: 'OTEL_METRICS_STATUS',

--- a/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/metrics.spec.js
@@ -1,6 +1,6 @@
 jest.mock('@opentelemetry/exporter-metrics-otlp-proto');
 jest.mock('@opentelemetry/otlp-exporter-base');
-jest.mock('@opentelemetry/sdk-metrics');
+jest.mock('@opentelemetry/sdk-node');
 jest.mock('@dotcom-reliability-kit/logger');
 jest.mock('../../../../lib/config/user-agents', () => ({
 	METRICS_USER_AGENT: 'mock-metrics-user-agent'
@@ -10,7 +10,8 @@ const logger = require('@dotcom-reliability-kit/logger');
 const {
 	OTLPMetricExporter
 } = require('@opentelemetry/exporter-metrics-otlp-proto');
-const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+const { PeriodicExportingMetricReader } =
+	require('@opentelemetry/sdk-node').metrics;
 const { createMetricsConfig } = require('../../../../lib/config/metrics');
 
 describe('@dotcom-reliability-kit/opentelemetry/lib/config/metrics', () => {

--- a/packages/opentelemetry/test/unit/lib/config/resource.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/resource.spec.js
@@ -1,9 +1,20 @@
 jest.mock('@dotcom-reliability-kit/app-info', () => ({
-	systemCode: 'mock-system-code',
-	releaseVersion: 'mock-release-version',
-	cloudProvider: 'mock-cloud-provider',
-	region: 'mock-cloud-region',
-	environment: 'mock-environment'
+	semanticConventions: {
+		service: {
+			name: 'mock-service-name',
+			version: 'mock-service-version',
+			instance: {
+				id: 'mock-service-instance-id'
+			}
+		},
+		cloud: {
+			provider: 'mock-cloud-provider',
+			region: 'mock-cloud-region'
+		},
+		deployment: {
+			environment: 'mock-deployment-environment'
+		}
+	}
 }));
 jest.mock('@opentelemetry/resources');
 jest.mock('@opentelemetry/semantic-conventions', () => ({
@@ -11,10 +22,10 @@ jest.mock('@opentelemetry/semantic-conventions', () => ({
 	SEMRESATTRS_CLOUD_REGION: 'mock-semresattrs-cloud-region',
 	SEMRESATTRS_DEPLOYMENT_ENVIRONMENT: 'mock-semresattrs-deployment-environment',
 	SEMRESATTRS_SERVICE_NAME: 'mock-semresattrs-service-name',
-	SEMRESATTRS_SERVICE_VERSION: 'mock-semresattrs-service-version'
+	SEMRESATTRS_SERVICE_VERSION: 'mock-semresattrs-service-version',
+	SEMRESATTRS_SERVICE_INSTANCE_ID: 'mock-semresattrs-service-instance-id'
 }));
 
-const appInfo = require('@dotcom-reliability-kit/app-info');
 const { Resource } = require('@opentelemetry/resources');
 const { createResourceConfig } = require('../../../../lib/config/resource');
 
@@ -35,37 +46,13 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/resource', () => {
 			expect(Resource).toHaveBeenCalledWith({
 				'mock-semresattrs-cloud-provider': 'mock-cloud-provider',
 				'mock-semresattrs-cloud-region': 'mock-cloud-region',
-				'mock-semresattrs-deployment-environment': 'mock-environment',
-				'mock-semresattrs-service-name': 'mock-system-code',
-				'mock-semresattrs-service-version': 'mock-release-version'
+				'mock-semresattrs-deployment-environment':
+					'mock-deployment-environment',
+				'mock-semresattrs-service-name': 'mock-service-name',
+				'mock-semresattrs-service-version': 'mock-service-version',
+				'mock-semresattrs-service-instance-id': 'mock-service-instance-id'
 			});
 			expect(resource).toStrictEqual(Resource.mock.instances[0]);
-		});
-
-		describe('when any appInfo properties are falsy', () => {
-			let resource;
-
-			beforeEach(() => {
-				Resource.mockClear();
-				appInfo.systemCode = null;
-				appInfo.releaseVersion = null;
-				appInfo.cloudProvider = null;
-				appInfo.region = null;
-				appInfo.environment = null;
-				resource = createResourceConfig();
-			});
-
-			it('creates and returns an OpenTelemetry Resource with properties set to `undefined`', () => {
-				expect(Resource).toHaveBeenCalledTimes(1);
-				expect(Resource).toHaveBeenCalledWith({
-					'mock-semresattrs-cloud-provider': undefined,
-					'mock-semresattrs-cloud-region': undefined,
-					'mock-semresattrs-deployment-environment': undefined,
-					'mock-semresattrs-service-name': undefined,
-					'mock-semresattrs-service-version': undefined
-				});
-				expect(resource).toStrictEqual(Resource.mock.instances[0]);
-			});
 		});
 	});
 });

--- a/packages/opentelemetry/test/unit/lib/config/resource.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/resource.spec.js
@@ -16,7 +16,7 @@ jest.mock('@dotcom-reliability-kit/app-info', () => ({
 		}
 	}
 }));
-jest.mock('@opentelemetry/resources');
+jest.mock('@opentelemetry/sdk-node');
 jest.mock('@opentelemetry/semantic-conventions', () => ({
 	SEMRESATTRS_CLOUD_PROVIDER: 'mock-semresattrs-cloud-provider',
 	SEMRESATTRS_CLOUD_REGION: 'mock-semresattrs-cloud-region',
@@ -26,7 +26,7 @@ jest.mock('@opentelemetry/semantic-conventions', () => ({
 	SEMRESATTRS_SERVICE_INSTANCE_ID: 'mock-semresattrs-service-instance-id'
 }));
 
-const { Resource } = require('@opentelemetry/resources');
+const { Resource } = require('@opentelemetry/sdk-node').resources;
 const { createResourceConfig } = require('../../../../lib/config/resource');
 
 describe('@dotcom-reliability-kit/opentelemetry/lib/config/resource', () => {

--- a/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
@@ -123,7 +123,7 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/tracing', () => {
 			});
 
 			it('logs that tracing is disabled', () => {
-				expect(logger.warn).toHaveBeenCalledWith({
+				expect(logger.info).toHaveBeenCalledWith({
 					enabled: false,
 					endpoint: null,
 					event: 'OTEL_TRACE_STATUS',

--- a/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
@@ -9,10 +9,8 @@ const logger = require('@dotcom-reliability-kit/logger');
 const {
 	OTLPTraceExporter
 } = require('@opentelemetry/exporter-trace-otlp-proto');
-const {
-	NoopSpanProcessor,
-	TraceIdRatioBasedSampler
-} = require('@opentelemetry/sdk-trace-base');
+const { NoopSpanProcessor, TraceIdRatioBasedSampler } =
+	require('@opentelemetry/sdk-node').tracing;
 const { createTracingConfig } = require('../../../../lib/config/tracing');
 
 describe('@dotcom-reliability-kit/opentelemetry/lib/config/tracing', () => {

--- a/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/tracing.spec.js
@@ -134,7 +134,7 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/tracing', () => {
 
 			it('returns the configuration', () => {
 				expect(config).toEqual({
-					spanProcessor: NoopSpanProcessor.mock.instances[0]
+					spanProcessors: [NoopSpanProcessor.mock.instances[0]]
 				});
 			});
 		});

--- a/packages/opentelemetry/test/unit/lib/config/user-agents.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/user-agents.spec.js
@@ -5,18 +5,33 @@ jest.mock('../../../../package.json', () => ({
 	name: 'mock-package',
 	version: '1.2.3'
 }));
-jest.mock('@opentelemetry/exporter-trace-otlp-proto/package.json', () => ({
-	name: 'mock-otel-tracing-package',
+jest.mock('@opentelemetry/exporter-metrics-otlp-proto/package.json', () => ({
+	name: 'mock-otel-metrics-package',
 	version: '3.4.5'
 }));
+jest.mock('@opentelemetry/exporter-trace-otlp-proto/package.json', () => ({
+	name: 'mock-otel-tracing-package',
+	version: '6.7.8'
+}));
 
-const { TRACING_USER_AGENT } = require('../../../../lib/config/user-agents');
+const {
+	METRICS_USER_AGENT,
+	TRACING_USER_AGENT
+} = require('../../../../lib/config/user-agents');
 
 describe('@dotcom-reliability-kit/opentelemetry/lib/config/resource', () => {
+	describe('.METRICS_USER_AGENT', () => {
+		it('is set based on app info and package versions', () => {
+			expect(METRICS_USER_AGENT).toStrictEqual(
+				'FTSystem/mock-system-code (mock-package/1.2.3) (mock-otel-metrics-package/3.4.5)'
+			);
+		});
+	});
+
 	describe('.TRACING_USER_AGENT', () => {
 		it('is set based on app info and package versions', () => {
 			expect(TRACING_USER_AGENT).toStrictEqual(
-				'FTSystem/mock-system-code (mock-package/1.2.3) (mock-otel-tracing-package/3.4.5)'
+				'FTSystem/mock-system-code (mock-package/1.2.3) (mock-otel-tracing-package/6.7.8)'
 			);
 		});
 	});

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -30,16 +30,12 @@ logger.createChildLogger.mockReturnValue('mock child logger');
 DiagLogLevel.INFO = 'mock info log level';
 
 // Import the OTel function for testing
-const setupOpenTelemetry = require('../../../lib/index');
+const opentelemetry = require('../../../lib/index');
 
 describe('@dotcom-reliability-kit/opentelemetry', () => {
-	it('exports a function', () => {
-		expect(typeof setupOpenTelemetry).toStrictEqual('function');
-	});
-
-	describe('setupOpenTelemetry(options)', () => {
+	describe('.setup(options)', () => {
 		beforeAll(() => {
-			setupOpenTelemetry({
+			opentelemetry.setup({
 				tracing: {
 					endpoint: 'mock-tracing-endpoint',
 					samplePercentage: 137
@@ -101,7 +97,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		describe('when no options are set', () => {
 			beforeAll(() => {
 				NodeSDK.mockClear();
-				setupOpenTelemetry();
+				opentelemetry.setup();
 			});
 
 			it('still instantiates and starts the OpenTelemetry Node SDK with the created config', () => {
@@ -118,7 +114,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		describe('when an authorization header is passed into the root options (deprecated)', () => {
 			beforeAll(() => {
 				createTracingConfig.mockReset();
-				setupOpenTelemetry({
+				opentelemetry.setup({
 					authorizationHeader: 'mock-authorization-header-root',
 					tracing: {
 						endpoint: 'mock-tracing-endpoint'
@@ -138,7 +134,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		describe('when an authorization header is passed into the tracing options', () => {
 			beforeAll(() => {
 				createTracingConfig.mockReset();
-				setupOpenTelemetry({
+				opentelemetry.setup({
 					tracing: {
 						authorizationHeader: 'mock-authorization-header-tracing',
 						endpoint: 'mock-tracing-endpoint'
@@ -158,7 +154,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		describe('when an authorization header is passed into both the root options (deprecated) and tracing options', () => {
 			beforeAll(() => {
 				createTracingConfig.mockReset();
-				setupOpenTelemetry({
+				opentelemetry.setup({
 					authorizationHeader: 'mock-authorization-header-root',
 					tracing: {
 						authorizationHeader: 'mock-authorization-header-tracing',
@@ -179,7 +175,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		describe('when OTEL_ environment variables are defined', () => {
 			beforeAll(() => {
 				process.env.OTEL_MOCK = 'mock';
-				setupOpenTelemetry();
+				opentelemetry.setup();
 			});
 
 			it('logs a warning that these environment variables are not supported', () => {

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -1,5 +1,4 @@
 jest.mock('@opentelemetry/sdk-node');
-jest.mock('@opentelemetry/api');
 jest.mock('@dotcom-reliability-kit/logger');
 jest.mock('../../../lib/config/instrumentations', () => ({
 	createInstrumentationConfig: jest
@@ -22,7 +21,7 @@ const {
 const { createMetricsConfig } = require('../../../lib/config/metrics');
 const { createResourceConfig } = require('../../../lib/config/resource');
 const { createTracingConfig } = require('../../../lib/config/tracing');
-const { diag, DiagLogLevel } = require('@opentelemetry/api');
+const { diag, DiagLogLevel } = require('@opentelemetry/sdk-node').api;
 const { NodeSDK } = require('@opentelemetry/sdk-node');
 const logger = require('@dotcom-reliability-kit/logger');
 

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -6,6 +6,9 @@ jest.mock('../../../lib/config/instrumentations', () => ({
 		.fn()
 		.mockReturnValue('mock-instrumentations')
 }));
+jest.mock('../../../lib/config/metrics', () => ({
+	createMetricsConfig: jest.fn().mockReturnValue({ metrics: 'mock-metrics' })
+}));
 jest.mock('../../../lib/config/resource', () => ({
 	createResourceConfig: jest.fn().mockReturnValue('mock-resource')
 }));
@@ -16,6 +19,7 @@ jest.mock('../../../lib/config/tracing', () => ({
 const {
 	createInstrumentationConfig
 } = require('../../../lib/config/instrumentations');
+const { createMetricsConfig } = require('../../../lib/config/metrics');
 const { createResourceConfig } = require('../../../lib/config/resource');
 const { createTracingConfig } = require('../../../lib/config/tracing');
 const { diag, DiagLogLevel } = require('@opentelemetry/api');
@@ -39,6 +43,9 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 				tracing: {
 					endpoint: 'mock-tracing-endpoint',
 					samplePercentage: 137
+				},
+				metrics: {
+					endpoint: 'mock-metrics-endpoint'
 				}
 			});
 		});
@@ -73,12 +80,20 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 			});
 		});
 
+		it('creates metrics config', () => {
+			expect(createMetricsConfig).toHaveBeenCalledTimes(1);
+			expect(createMetricsConfig).toHaveBeenCalledWith({
+				endpoint: 'mock-metrics-endpoint'
+			});
+		});
+
 		it('instantiates and starts the OpenTelemetry Node SDK with the created config', () => {
 			expect(NodeSDK).toHaveBeenCalledTimes(1);
 			expect(NodeSDK).toHaveBeenCalledWith({
 				instrumentations: 'mock-instrumentations',
 				resource: 'mock-resource',
-				tracing: 'mock-tracing'
+				tracing: 'mock-tracing',
+				metrics: 'mock-metrics'
 			});
 			expect(NodeSDK.prototype.start).toHaveBeenCalledTimes(1);
 		});
@@ -94,7 +109,8 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 				expect(NodeSDK).toHaveBeenCalledWith({
 					instrumentations: 'mock-instrumentations',
 					resource: 'mock-resource',
-					tracing: 'mock-tracing'
+					tracing: 'mock-tracing',
+					metrics: 'mock-metrics'
 				});
 			});
 		});

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -1,21 +1,21 @@
-describe('setupOpenTelemetry', () => {
-	let setupOpenTelemetry;
+describe('setup', () => {
+	let opentelemetry;
 
 	beforeEach(() => {
 		jest.resetModules();
-		jest.mock('../../lib/index.js', () => jest.fn());
-		setupOpenTelemetry = require('../../lib/index.js');
+		jest.mock('../..', () => ({ setup: jest.fn() }));
+		opentelemetry = require('../..');
 	});
 
-	it('should call setupOpenTelemetry with the correct parameters', () => {
+	it('should call opentelemetry.setup with the correct parameters', () => {
 		process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
 		process.env.OPENTELEMETRY_AUTHORIZATION_HEADER = 'MOCK_AUTH_HEADER';
 		process.env.OPENTELEMETRY_METRICS_ENDPOINT = 'MOCK_METRICS_ENDPOINT';
 		process.env.OPENTELEMETRY_API_GATEWAY_KEY = 'MOCK_API_GATEWAY_KEY';
 		require('../../setup.js');
 
-		expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-		expect(setupOpenTelemetry).toHaveBeenCalledWith({
+		expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+		expect(opentelemetry.setup).toHaveBeenCalledWith({
 			tracing: {
 				authorizationHeader: 'MOCK_AUTH_HEADER',
 				endpoint: 'MOCK_TRACING_ENDPOINT'
@@ -33,8 +33,8 @@ describe('setupOpenTelemetry', () => {
 			process.env.OPENTELEMETRY_METRICS_ENDPOINT = 'MOCK_METRICS_ENDPOINT';
 			require('../../setup.js');
 
-			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+			expect(opentelemetry.setup).toHaveBeenCalledWith({
 				metrics: {
 					apiGatewayKey: 'MOCK_API_GATEWAY_KEY',
 					endpoint: 'MOCK_METRICS_ENDPOINT'
@@ -49,8 +49,8 @@ describe('setupOpenTelemetry', () => {
 			process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
 			require('../../setup.js');
 
-			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+			expect(opentelemetry.setup).toHaveBeenCalledWith({
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT'
@@ -65,8 +65,8 @@ describe('setupOpenTelemetry', () => {
 			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = '50';
 			require('../../setup.js');
 
-			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+			expect(opentelemetry.setup).toHaveBeenCalledWith({
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',
@@ -82,8 +82,8 @@ describe('setupOpenTelemetry', () => {
 			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = 'nope';
 			require('../../setup.js');
 
-			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+			expect(opentelemetry.setup).toHaveBeenCalledWith({
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -10,6 +10,8 @@ describe('setupOpenTelemetry', () => {
 	it('should call setupOpenTelemetry with the correct parameters', () => {
 		process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
 		process.env.OPENTELEMETRY_AUTHORIZATION_HEADER = 'MOCK_AUTH_HEADER';
+		process.env.OPENTELEMETRY_METRICS_ENDPOINT = 'MOCK_METRICS_ENDPOINT';
+		process.env.OPENTELEMETRY_API_GATEWAY_KEY = 'MOCK_API_GATEWAY_KEY';
 		require('../../setup.js');
 
 		expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
@@ -17,12 +19,49 @@ describe('setupOpenTelemetry', () => {
 			tracing: {
 				authorizationHeader: 'MOCK_AUTH_HEADER',
 				endpoint: 'MOCK_TRACING_ENDPOINT'
+			},
+			metrics: {
+				apiGatewayKey: 'MOCK_API_GATEWAY_KEY',
+				endpoint: 'MOCK_METRICS_ENDPOINT'
 			}
+		});
+	});
+
+	describe('when no traces endpoint is specified', () => {
+		it('should not include tracing configuration', () => {
+			delete process.env.OPENTELEMETRY_TRACING_ENDPOINT;
+			process.env.OPENTELEMETRY_METRICS_ENDPOINT = 'MOCK_METRICS_ENDPOINT';
+			require('../../setup.js');
+
+			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+				metrics: {
+					apiGatewayKey: 'MOCK_API_GATEWAY_KEY',
+					endpoint: 'MOCK_METRICS_ENDPOINT'
+				}
+			});
+		});
+	});
+
+	describe('when no metrics endpoint is specified', () => {
+		it('should not include metrics configuration', () => {
+			delete process.env.OPENTELEMETRY_METRICS_ENDPOINT;
+			process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
+			require('../../setup.js');
+
+			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
+			expect(setupOpenTelemetry).toHaveBeenCalledWith({
+				tracing: {
+					authorizationHeader: 'MOCK_AUTH_HEADER',
+					endpoint: 'MOCK_TRACING_ENDPOINT'
+				}
+			});
 		});
 	});
 
 	describe('when a sample rate is specified', () => {
 		it('calls OpenTelemetry with the given sample percentage as a number', () => {
+			delete process.env.OPENTELEMETRY_METRICS_ENDPOINT;
 			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = '50';
 			require('../../setup.js');
 
@@ -39,6 +78,7 @@ describe('setupOpenTelemetry', () => {
 
 	describe('when a non-numeric sample rate is specified', () => {
 		it('calls OpenTelemetry with NaN as a percentage', () => {
+			delete process.env.OPENTELEMETRY_METRICS_ENDPOINT;
 			process.env.OPENTELEMETRY_TRACING_SAMPLE_PERCENTAGE = 'nope';
 			require('../../setup.js');
 
@@ -50,16 +90,6 @@ describe('setupOpenTelemetry', () => {
 					samplePercentage: NaN
 				}
 			});
-		});
-	});
-
-	describe('when no traces endpoint is specified', () => {
-		it('should not include tracing configuration', () => {
-			delete process.env.OPENTELEMETRY_TRACING_ENDPOINT;
-			require('../../setup.js');
-
-			expect(setupOpenTelemetry).toHaveBeenCalledTimes(1);
-			expect(setupOpenTelemetry).toHaveBeenCalledWith({});
 		});
 	});
 });


### PR DESCRIPTION
This adds metrics to the OpenTelemetry package, allowing apps using Reliability Kit to send metrics via the FT's metrics collector. Under the hood this essentially runs the same code as is outlined [in the Tech Hub guide](https://tech.in.ft.com/tech-topics/observability/opentelemetry/heroku) but will less boilerplate required for an app.

## Basic setup

Instead of copy/pasting example code, you should now be able to do the following:

Install the Reliability Kit `opentelemetry` package:

```
npm install @dotcom-reliability-kit/opentelemetry
```

Add it to your startup script:

```
node --require @dotcom-reliability-kit/opentelemetry/setup ./my-app.js
```

Add some environment variables to your app (see the [internal collector repo](https://github.com/Financial-Times/observability/tree/main/services/otel-gateway-collector#readme) for these values, this is a public repo so I don't want to share them in this PR description):

```
OPENTELEMETRY_METRICS_ENDPOINT=<value>
OPENTELEMETRY_API_GATEWAY_KEY=<value>
```

> [!TIP]
> Note that the environment variable names are different to the ones in the Tech Hub guides!

(see the README for more ways to set up)

## Custom metrics

As outlined in the updated README, we alias some OpenTelemetry methods to make it easier to send custom metrics (easier as in you don't also need to install the related `@opentelemetry/...` packages separately):

```js
const { getMeter } = require('@dotcom-reliability-kit/opentelemetry');

const meter = getMeter('my-app');
const hitCounter = meter.createCounter('my-app.hits');

// Assumes that `app` is an Express application instance
app.get('/', (request, response) => {
    hitCounter.add(1);
    response.send('Thanks for visiting');
});
```

## Testing this code locally

I've been testing locally using [Reliability Dashboards](https://github.com/Financial-Times/reliability-dashboards) which already has the `@dotcom-reliability-kit/opentelemetry` package installed. Clone the repo, install dependencies, and then link to a local copy of the package on this branch:

```
rm -rf node_modules/@dotcom-reliability-kit/opentelemetry
ln -s <RELIABILITY_KIT_DIR>/packages/opentelemetry node_modules/@dotcom-reliability-kit/opentelemetry
```

You can then start the app, passing in environment variables:

```
OPENTELEMETRY_API_GATEWAY_KEY=XXXXXX OPENTELEMETRY_METRICS_ENDPOINT=XXXXXX npm start
```

You should soon see metrics in Grafana in the `OpenTelemetry Test` data source.

---

See-also: [CPREL-1087](https://financialtimes.atlassian.net/browse/CPREL-1087)

[CPREL-1087]: https://financialtimes.atlassian.net/browse/CPREL-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ