### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.2.0",
-  "packages/crash-handler": "4.1.2",
-  "packages/errors": "3.1.0",
+  "packages/crash-handler": "4.1.3",
+  "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
-  "packages/fetch-error-handler": "0.2.3",
-  "packages/log-error": "4.1.2",
+  "packages/fetch-error-handler": "0.2.4",
+  "packages/log-error": "4.1.3",
   "packages/logger": "3.1.2",
-  "packages/middleware-log-errors": "4.1.2",
-  "packages/middleware-render-error-info": "5.1.2",
+  "packages/middleware-log-errors": "4.1.3",
+  "packages/middleware-render-error-info": "5.1.3",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.0"
+  "packages/opentelemetry": "2.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13115,10 +13115,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.2"
+        "@dotcom-reliability-kit/log-error": "^4.1.3"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13127,7 +13127,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13151,10 +13151,10 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^3.1.0"
+        "@dotcom-reliability-kit/errors": "^3.1.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -13170,7 +13170,7 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
@@ -13212,10 +13212,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.2"
+        "@dotcom-reliability-kit/log-error": "^4.1.3"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.2.0",
@@ -13229,11 +13229,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.2",
+        "@dotcom-reliability-kit/log-error": "^4.1.3",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^4.5.0"
       },
@@ -13247,12 +13247,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/errors": "^3.1.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.2",
+        "@dotcom-reliability-kit/errors": "^3.1.1",
+        "@dotcom-reliability-kit/log-error": "^4.1.3",
         "@dotcom-reliability-kit/logger": "^3.1.2",
         "@opentelemetry/auto-instrumentations-node": "^0.47.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.2...crash-handler-v4.1.3) (2024-06-26)
+
+
+### Bug Fixes
+
+* add type declarations for crash-handler ([d9d274f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d9d274f19d32591187fb8ddaed11cc9a046cf56e))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
+
 ## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.1...crash-handler-v4.1.2) (2024-06-19)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.2"
+    "@dotcom-reliability-kit/log-error": "^4.1.3"
   }
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.0...errors-v3.1.1) (2024-06-26)
+
+
+### Bug Fixes
+
+* add type declarations for errors ([f6aef2b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6aef2b556974827cf1f3538f8043bac25c55708))
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.0.1...errors-v3.1.0) (2024-04-29)
 
 

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/errors",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A suite of error classes which help you throw the most appropriate error in any situation",
   "repository": {
     "type": "git",

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.3...fetch-error-handler-v0.2.4) (2024-06-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^3.1.0 to ^3.1.1
+
 ## [0.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.2...fetch-error-handler-v0.2.3) (2024-05-01)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "^3.1.0"
+    "@dotcom-reliability-kit/errors": "^3.1.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.2...log-error-v4.1.3) (2024-06-26)
+
+
+### Bug Fixes
+
+* add type declarations for log-error ([d2c3f84](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d2c3f84790bf736212fd54638674eaeb15876007))
+
 ## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.1...log-error-v4.1.2) (2024-06-19)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.2...middleware-log-errors-v4.1.3) (2024-06-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
+
 ## [4.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.1...middleware-log-errors-v4.1.2) (2024-06-19)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.2"
+    "@dotcom-reliability-kit/log-error": "^4.1.3"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.2...middleware-render-error-info-v5.1.3) (2024-06-26)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
+
 ## [5.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.1...middleware-render-error-info-v5.1.2) (2024-06-19)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.2.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.2",
+    "@dotcom-reliability-kit/log-error": "^4.1.3",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^4.5.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.0...opentelemetry-v2.0.1) (2024-06-26)
+
+
+### Bug Fixes
+
+* add type declarations for opentelemetry ([5b60286](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5b60286550ee8c152bec456fdd8c023b31fa10d1))
+* bump the opentelemetry group with 4 updates ([59dcc75](https://github.com/Financial-Times/dotcom-reliability-kit/commit/59dcc756cff198f789aebd633695883f4793be63))
+
+
+### Documentation Changes
+
+* correct the ESM opentelemetry example ([071806a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/071806a9dbc3a5eabef9357bdf84727d04038863))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^3.1.0 to ^3.1.1
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
+
 ## [2.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v1.1.2...opentelemetry-v2.0.0) (2024-06-19)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -18,8 +18,8 @@
 	"types": "types/index.d.ts",
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.2.0",
-		"@dotcom-reliability-kit/errors": "^3.1.0",
-		"@dotcom-reliability-kit/log-error": "^4.1.2",
+		"@dotcom-reliability-kit/errors": "^3.1.1",
+		"@dotcom-reliability-kit/log-error": "^4.1.3",
 		"@dotcom-reliability-kit/logger": "^3.1.2",
 		"@opentelemetry/auto-instrumentations-node": "^0.47.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.3</summary>

## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.2...crash-handler-v4.1.3) (2024-06-26)


### Bug Fixes

* add type declarations for crash-handler ([d9d274f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d9d274f19d32591187fb8ddaed11cc9a046cf56e))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
</details>

<details><summary>errors: 3.1.1</summary>

## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.0...errors-v3.1.1) (2024-06-26)


### Bug Fixes

* add type declarations for errors ([f6aef2b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6aef2b556974827cf1f3538f8043bac25c55708))
</details>

<details><summary>fetch-error-handler: 0.2.4</summary>

## [0.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.3...fetch-error-handler-v0.2.4) (2024-06-26)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^3.1.0 to ^3.1.1
</details>

<details><summary>log-error: 4.1.3</summary>

## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.2...log-error-v4.1.3) (2024-06-26)


### Bug Fixes

* add type declarations for log-error ([d2c3f84](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d2c3f84790bf736212fd54638674eaeb15876007))
</details>

<details><summary>middleware-log-errors: 4.1.3</summary>

## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.2...middleware-log-errors-v4.1.3) (2024-06-26)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
</details>

<details><summary>middleware-render-error-info: 5.1.3</summary>

## [5.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.2...middleware-render-error-info-v5.1.3) (2024-06-26)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
</details>

<details><summary>opentelemetry: 2.0.1</summary>

## [2.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.0...opentelemetry-v2.0.1) (2024-06-26)


### Bug Fixes

* add type declarations for opentelemetry ([5b60286](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5b60286550ee8c152bec456fdd8c023b31fa10d1))
* bump the opentelemetry group with 4 updates ([59dcc75](https://github.com/Financial-Times/dotcom-reliability-kit/commit/59dcc756cff198f789aebd633695883f4793be63))


### Documentation Changes

* correct the ESM opentelemetry example ([071806a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/071806a9dbc3a5eabef9357bdf84727d04038863))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^3.1.0 to ^3.1.1
    * @dotcom-reliability-kit/log-error bumped from ^4.1.2 to ^4.1.3
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).