### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.2.0",
-  "packages/crash-handler": "4.1.3",
+  "packages/crash-handler": "4.1.4",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
-  "packages/fetch-error-handler": "0.2.4",
-  "packages/log-error": "4.1.3",
-  "packages/logger": "3.1.2",
-  "packages/middleware-log-errors": "4.1.3",
-  "packages/middleware-render-error-info": "5.1.3",
+  "packages/fetch-error-handler": "0.2.5",
+  "packages/log-error": "4.1.4",
+  "packages/logger": "3.1.3",
+  "packages/middleware-log-errors": "4.1.4",
+  "packages/middleware-render-error-info": "5.1.4",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.1"
+  "packages/opentelemetry": "2.0.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13137,10 +13137,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.3"
+        "@dotcom-reliability-kit/log-error": "^4.1.4"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13173,7 +13173,7 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^3.1.1"
@@ -13192,11 +13192,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/logger": "^3.1.2",
+        "@dotcom-reliability-kit/logger": "^3.1.3",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -13210,7 +13210,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
@@ -13234,10 +13234,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.3"
+        "@dotcom-reliability-kit/log-error": "^4.1.4"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.2.0",
@@ -13251,11 +13251,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.3",
+        "@dotcom-reliability-kit/log-error": "^4.1.4",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13280,13 +13280,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.2.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.1.3",
-        "@dotcom-reliability-kit/logger": "^3.1.2",
+        "@dotcom-reliability-kit/log-error": "^4.1.4",
+        "@dotcom-reliability-kit/logger": "^3.1.3",
         "@opentelemetry/auto-instrumentations-node": "^0.47.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.3...crash-handler-v4.1.4) (2024-07-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
+
 ## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.2...crash-handler-v4.1.3) (2024-06-26)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.3"
+    "@dotcom-reliability-kit/log-error": "^4.1.4"
   }
 }

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.4...fetch-error-handler-v0.2.5) (2024-07-01)
+
+
+### Bug Fixes
+
+* add type declarations for fetch-error-handler ([36490d1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/36490d10c820abdd8017422b8f47c3a045e43170))
+
 ## [0.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.3...fetch-error-handler-v0.2.4) (2024-06-26)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.3...log-error-v4.1.4) (2024-07-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.2 to ^3.1.3
+
 ## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.2...log-error-v4.1.3) (2024-06-26)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.2.0",
-    "@dotcom-reliability-kit/logger": "^3.1.2",
+    "@dotcom-reliability-kit/logger": "^3.1.3",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.2...logger-v3.1.3) (2024-07-01)
+
+
+### Bug Fixes
+
+* add type declarations for the logger ([b514c2a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b514c2abf637221ff09390e193fb843b66bfdffa)), closes [#946](https://github.com/Financial-Times/dotcom-reliability-kit/issues/946)
+
 ## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.1...logger-v3.1.2) (2024-06-19)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.3...middleware-log-errors-v4.1.4) (2024-07-01)
+
+
+### Bug Fixes
+
+* add type declarations for error-logging ([9d65e0a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9d65e0a518a44dc3c2f463425ceb338ec0d4badc))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
+
 ## [4.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.2...middleware-log-errors-v4.1.3) (2024-06-26)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.3"
+    "@dotcom-reliability-kit/log-error": "^4.1.4"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.2.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [5.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.3...middleware-render-error-info-v5.1.4) (2024-07-01)
+
+
+### Bug Fixes
+
+* add type declarations for error-rendering ([f6ceed0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6ceed03fdf9aeb7c8eedc766b9d3d62acf60434))
+* bump entities in /packages/middleware-render-error-info ([da0ad99](https://github.com/Financial-Times/dotcom-reliability-kit/commit/da0ad99ccdc558e6943fe4406bea97cfc688317f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
+
 ## [5.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.2...middleware-render-error-info-v5.1.3) (2024-06-26)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.2.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.3",
+    "@dotcom-reliability-kit/log-error": "^4.1.4",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.1...opentelemetry-v2.0.2) (2024-07-01)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
+    * @dotcom-reliability-kit/logger bumped from ^3.1.2 to ^3.1.3
+
 ## [2.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.0...opentelemetry-v2.0.1) (2024-06-26)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.2.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.1.3",
-		"@dotcom-reliability-kit/logger": "^3.1.2",
+		"@dotcom-reliability-kit/log-error": "^4.1.4",
+		"@dotcom-reliability-kit/logger": "^3.1.3",
 		"@opentelemetry/auto-instrumentations-node": "^0.47.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.4</summary>

## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.3...crash-handler-v4.1.4) (2024-07-01)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
</details>

<details><summary>fetch-error-handler: 0.2.5</summary>

## [0.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.4...fetch-error-handler-v0.2.5) (2024-07-01)


### Bug Fixes

* add type declarations for fetch-error-handler ([36490d1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/36490d10c820abdd8017422b8f47c3a045e43170))
</details>

<details><summary>log-error: 4.1.4</summary>

## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.3...log-error-v4.1.4) (2024-07-01)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.2 to ^3.1.3
</details>

<details><summary>logger: 3.1.3</summary>

## [3.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.2...logger-v3.1.3) (2024-07-01)


### Bug Fixes

* add type declarations for the logger ([b514c2a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b514c2abf637221ff09390e193fb843b66bfdffa)), closes [#946](https://github.com/Financial-Times/dotcom-reliability-kit/issues/946)
</details>

<details><summary>middleware-log-errors: 4.1.4</summary>

## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.3...middleware-log-errors-v4.1.4) (2024-07-01)


### Bug Fixes

* add type declarations for error-logging ([9d65e0a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9d65e0a518a44dc3c2f463425ceb338ec0d4badc))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
</details>

<details><summary>middleware-render-error-info: 5.1.4</summary>

## [5.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.3...middleware-render-error-info-v5.1.4) (2024-07-01)


### Bug Fixes

* add type declarations for error-rendering ([f6ceed0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6ceed03fdf9aeb7c8eedc766b9d3d62acf60434))
* bump entities in /packages/middleware-render-error-info ([da0ad99](https://github.com/Financial-Times/dotcom-reliability-kit/commit/da0ad99ccdc558e6943fe4406bea97cfc688317f))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
</details>

<details><summary>opentelemetry: 2.0.2</summary>

## [2.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.1...opentelemetry-v2.0.2) (2024-07-01)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.3 to ^4.1.4
    * @dotcom-reliability-kit/logger bumped from ^3.1.2 to ^3.1.3
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).