### PR TITLE
chore: don't run commitlint on dependabot PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
   run-commitlint-on-pr:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'dependabot' }}
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
This fails the build when the commit is just a bit long, it's annoying. There's no need - we merge these PRs anyway.