### PR TITLE
feat: allow setting the deployment environment

### DIFF
--- a/packages/app-info/README.md
+++ b/packages/app-info/README.md
@@ -49,7 +49,12 @@ For AWS Lambda, you can use a plugin like [serverless-plugin-git-variables](http
 
 ### `appInfo.environment`
 
-Get the application environment, normally either `development` or `production`. This will be a string, using `process.env.NODE_ENV` and defaulting to `development`.
+Get the application environment, normally either `development` or `production`. This will be a string, trying each of the following environment variables in order and defaulting to `development`:
+
+  * `DEPLOYMENT_ENVIRONMENT`
+  * `RELEASE_ENV`
+  * `ENVIRONMENT`
+  * `NODE_ENV`
 
 ### `appInfo.region`
 

--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -80,12 +80,17 @@ exports.commitHash =
 	null;
 
 /**
- * The application environment.
+ * The application deployment environment.
  *
  * @readonly
  * @type {string}
  */
-exports.environment = process.env.NODE_ENV || 'development';
+exports.environment =
+	process.env.DEPLOYMENT_ENVIRONMENT ||
+	process.env.RELEASE_ENV ||
+	process.env.ENVIRONMENT ||
+	process.env.NODE_ENV ||
+	'development';
 
 /**
  * The region the application is running in.

--- a/packages/app-info/test/unit/lib/index.spec.js
+++ b/packages/app-info/test/unit/lib/index.spec.js
@@ -13,7 +13,10 @@ describe('@dotcom-reliability-kit/app-info', () => {
 		process.env.HEROKU_RELEASE_CREATED_AT = 'mock-heroku-release-date';
 		process.env.HEROKU_RELEASE_VERSION = 'mock-heroku-release-version';
 		process.env.HEROKU_SLUG_COMMIT = 'mock-heroku-commit-hash';
-		process.env.NODE_ENV = 'mock-environment';
+		process.env.DEPLOYMENT_ENVIRONMENT = 'mock-deployment-environment';
+		process.env.RELEASE_ENV = 'mock-release-env';
+		process.env.ENVIRONMENT = 'mock-environment';
+		process.env.NODE_ENV = 'mock-node-env';
 		process.env.REGION = 'mock-region';
 		process.env.SYSTEM_CODE = 'mock-system-code';
 		process.env.DYNO = 'mock-heroku-process-type.1';
@@ -74,13 +77,55 @@ describe('@dotcom-reliability-kit/app-info', () => {
 	});
 
 	describe('.environment', () => {
-		it('is set to `process.env.NODE_ENV`', () => {
-			expect(appInfo.environment).toBe('mock-environment');
+		it('is set to `process.env.DEPLOYMENT_ENVIRONMENT`', () => {
+			expect(appInfo.environment).toBe('mock-deployment-environment');
 		});
 
-		describe('when `process.env.NODE_ENV` is not defined', () => {
+		describe('when `process.env.DEPLOYMENT_ENVIRONMENT` is not defined', () => {
 			beforeEach(() => {
 				jest.resetModules();
+				delete process.env.DEPLOYMENT_ENVIRONMENT;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to the value of `process.env.RELEASE_ENV`', () => {
+				expect(appInfo.environment).toBe('mock-release-env');
+			});
+		});
+
+		describe('when `process.env.RELEASE_ENV` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.DEPLOYMENT_ENVIRONMENT;
+				delete process.env.RELEASE_ENV;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to the value of `process.env.ENVIRONMENT`', () => {
+				expect(appInfo.environment).toBe('mock-environment');
+			});
+		});
+
+		describe('when `process.env.ENVIRONMENT` is not defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.DEPLOYMENT_ENVIRONMENT;
+				delete process.env.RELEASE_ENV;
+				delete process.env.ENVIRONMENT;
+				appInfo = require('../../../lib');
+			});
+
+			it('is set to the value of `process.env.NODE_ENV`', () => {
+				expect(appInfo.environment).toBe('mock-node-env');
+			});
+		});
+
+		describe('when none of the related environment variables are defined', () => {
+			beforeEach(() => {
+				jest.resetModules();
+				delete process.env.DEPLOYMENT_ENVIRONMENT;
+				delete process.env.RELEASE_ENV;
+				delete process.env.ENVIRONMENT;
 				delete process.env.NODE_ENV;
 				appInfo = require('../../../lib');
 			});


### PR DESCRIPTION
We're now looking at more different environment variables to determine the deployment environment the app is running in. `NODE_ENV` by itself isn't sufficient because it's nearly always set to `production` when running on a server, even for staging apps.

This resolves #1111.