### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.2.0",
-  "packages/crash-handler": "4.1.4",
+  "packages/app-info": "3.3.0",
+  "packages/crash-handler": "4.1.5",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.1.4",
-  "packages/logger": "3.1.3",
-  "packages/middleware-log-errors": "4.1.4",
-  "packages/middleware-render-error-info": "5.1.4",
+  "packages/log-error": "4.1.5",
+  "packages/logger": "3.1.4",
+  "packages/middleware-log-errors": "4.1.5",
+  "packages/middleware-render-error-info": "5.1.5",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.2"
+  "packages/opentelemetry": "2.0.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13123,7 +13123,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13132,10 +13132,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.4"
+        "@dotcom-reliability-kit/log-error": "^4.1.5"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13187,11 +13187,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/logger": "^3.1.3",
+        "@dotcom-reliability-kit/app-info": "^3.3.0",
+        "@dotcom-reliability-kit/logger": "^3.1.4",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -13205,10 +13205,10 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.2.0",
+        "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.2.0"
@@ -13229,10 +13229,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.4"
+        "@dotcom-reliability-kit/log-error": "^4.1.5"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.7.0",
@@ -13246,11 +13246,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.2.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.4",
+        "@dotcom-reliability-kit/app-info": "^3.3.0",
+        "@dotcom-reliability-kit/log-error": "^4.1.5",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13275,13 +13275,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.2.0",
+        "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.1.4",
-        "@dotcom-reliability-kit/logger": "^3.1.3",
+        "@dotcom-reliability-kit/log-error": "^4.1.5",
+        "@dotcom-reliability-kit/logger": "^3.1.4",
         "@opentelemetry/auto-instrumentations-node": "^0.47.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.2.0...app-info-v3.3.0) (2024-07-02)
+
+
+### Features
+
+* allow setting the deployment environment ([3933189](https://github.com/Financial-Times/dotcom-reliability-kit/commit/39331898a32241630720490e62c460d399d5e5c0)), closes [#1111](https://github.com/Financial-Times/dotcom-reliability-kit/issues/1111)
+
 ## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.1.0...app-info-v3.2.0) (2024-06-19)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.4...crash-handler-v4.1.5) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
+
 ## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.3...crash-handler-v4.1.4) (2024-07-01)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.4"
+    "@dotcom-reliability-kit/log-error": "^4.1.5"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.4...log-error-v4.1.5) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
+    * @dotcom-reliability-kit/logger bumped from ^3.1.3 to ^3.1.4
+
 ## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.3...log-error-v4.1.4) (2024-07-01)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.2.0",
-    "@dotcom-reliability-kit/logger": "^3.1.3",
+    "@dotcom-reliability-kit/app-info": "^3.3.0",
+    "@dotcom-reliability-kit/logger": "^3.1.4",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.3...logger-v3.1.4) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
+
 ## [3.1.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.2...logger-v3.1.3) (2024-07-01)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.2.0",
+    "@dotcom-reliability-kit/app-info": "^3.3.0",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.2.0"

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.4...middleware-log-errors-v4.1.5) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
+
 ## [4.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.3...middleware-log-errors-v4.1.4) (2024-07-01)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.4"
+    "@dotcom-reliability-kit/log-error": "^4.1.5"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.7.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.4...middleware-render-error-info-v5.1.5) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
+
 ## [5.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.3...middleware-render-error-info-v5.1.4) (2024-07-01)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,8 +17,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.2.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.4",
+    "@dotcom-reliability-kit/app-info": "^3.3.0",
+    "@dotcom-reliability-kit/log-error": "^4.1.5",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.2...opentelemetry-v2.0.3) (2024-07-02)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
+    * @dotcom-reliability-kit/logger bumped from ^3.1.3 to ^3.1.4
+
 ## [2.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.1...opentelemetry-v2.0.2) (2024-07-01)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,10 +17,10 @@
 	"main": "lib/index.js",
 	"types": "types/index.d.ts",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.2.0",
+		"@dotcom-reliability-kit/app-info": "^3.3.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.1.4",
-		"@dotcom-reliability-kit/logger": "^3.1.3",
+		"@dotcom-reliability-kit/log-error": "^4.1.5",
+		"@dotcom-reliability-kit/logger": "^3.1.4",
 		"@opentelemetry/auto-instrumentations-node": "^0.47.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.3.0</summary>

## [3.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.2.0...app-info-v3.3.0) (2024-07-02)


### Features

* allow setting the deployment environment ([3933189](https://github.com/Financial-Times/dotcom-reliability-kit/commit/39331898a32241630720490e62c460d399d5e5c0)), closes [#1111](https://github.com/Financial-Times/dotcom-reliability-kit/issues/1111)
</details>

<details><summary>crash-handler: 4.1.5</summary>

## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.4...crash-handler-v4.1.5) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
</details>

<details><summary>log-error: 4.1.5</summary>

## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.4...log-error-v4.1.5) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
    * @dotcom-reliability-kit/logger bumped from ^3.1.3 to ^3.1.4
</details>

<details><summary>logger: 3.1.4</summary>

## [3.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.3...logger-v3.1.4) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
</details>

<details><summary>middleware-log-errors: 4.1.5</summary>

## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.4...middleware-log-errors-v4.1.5) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
</details>

<details><summary>middleware-render-error-info: 5.1.5</summary>

## [5.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.4...middleware-render-error-info-v5.1.5) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
</details>

<details><summary>opentelemetry: 2.0.3</summary>

## [2.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.2...opentelemetry-v2.0.3) (2024-07-02)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.2.0 to ^3.3.0
    * @dotcom-reliability-kit/log-error bumped from ^4.1.4 to ^4.1.5
    * @dotcom-reliability-kit/logger bumped from ^3.1.3 to ^3.1.4
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).