### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.5",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.3"
+  "packages/opentelemetry": "2.0.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13226,7 +13226,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.3...opentelemetry-v2.0.4) (2024-07-08)
+
+
+### Bug Fixes
+
+* bump the opentelemetry group with 3 updates ([f3af044](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f3af0447e12071a5a29da0fb727aede65e8a6eb0))
+
+
+### Documentation Changes
+
+* clarify local metrics guide ([48e2123](https://github.com/Financial-Times/dotcom-reliability-kit/commit/48e2123c1c5652f96db58ecea2d8ff052b356d6a))
+
 ## [2.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.2...opentelemetry-v2.0.3) (2024-07-02)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.4</summary>

## [2.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.3...opentelemetry-v2.0.4) (2024-07-08)


### Bug Fixes

* bump the opentelemetry group with 3 updates ([f3af044](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f3af0447e12071a5a29da0fb727aede65e8a6eb0))


### Documentation Changes

* clarify local metrics guide ([48e2123](https://github.com/Financial-Times/dotcom-reliability-kit/commit/48e2123c1c5652f96db58ecea2d8ff052b356d6a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).