### PR TITLE
Reduce OpenTelemetry warnings

### DIFF
--- a/packages/opentelemetry/lib/config/instrumentations.js
+++ b/packages/opentelemetry/lib/config/instrumentations.js
@@ -28,6 +28,9 @@ exports.createInstrumentationConfig = function createInstrumentationConfig() {
 			},
 			'@opentelemetry/instrumentation-fs': {
 				enabled: false
+			},
+			'@opentelemetry/instrumentation-pino': {
+				enabled: false
 			}
 		}),
 		new RuntimeNodeInstrumentation()

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -8,6 +8,7 @@ const logger = require('@dotcom-reliability-kit/logger');
 
 /**
  * @import { Instances, Options } from '@dotcom-reliability-kit/opentelemetry'
+ * @import { MeterProvider } from '@opentelemetry/sdk-metrics'
  */
 
 /**
@@ -79,7 +80,10 @@ function setupOpenTelemetry({
 
 	// Set up host metrics if we have a metrics endpoint
 	if (metricsOptions?.endpoint) {
-		instances.hostMetrics = new HostMetrics();
+		const meterProvider = /** @type {MeterProvider} */ (
+			opentelemetry.api.metrics.getMeterProvider()
+		);
+		instances.hostMetrics = new HostMetrics({ meterProvider });
 		instances.hostMetrics.start();
 	}
 

--- a/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
@@ -41,6 +41,9 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 				},
 				'@opentelemetry/instrumentation-fs': {
 					enabled: false
+				},
+				'@opentelemetry/instrumentation-pino': {
+					enabled: false
 				}
 			});
 		});

--- a/packages/opentelemetry/test/unit/lib/index.spec.js
+++ b/packages/opentelemetry/test/unit/lib/index.spec.js
@@ -43,6 +43,7 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 		createTracingConfig =
 			require('../../../lib/config/tracing').createTracingConfig;
 		api = require('@opentelemetry/sdk-node').api;
+		api.metrics.getMeterProvider.mockReturnValue('mock-meter-provider');
 		HostMetrics = require('@opentelemetry/host-metrics').HostMetrics;
 		NodeSDK = require('@opentelemetry/sdk-node').NodeSDK;
 		logger = require('@dotcom-reliability-kit/logger');
@@ -185,7 +186,9 @@ describe('@dotcom-reliability-kit/opentelemetry', () => {
 
 		it('instantiates and starts a HostMetrics collector', () => {
 			expect(HostMetrics).toHaveBeenCalledTimes(1);
-			expect(HostMetrics).toHaveBeenCalledWith();
+			expect(HostMetrics).toHaveBeenCalledWith({
+				meterProvider: 'mock-meter-provider'
+			});
 			expect(HostMetrics.prototype.start).toHaveBeenCalledTimes(1);
 		});
 


### PR DESCRIPTION
This reduces warnings from the OpenTelemetry package:

- **Disable the pino instrumentation:**

    The pino instrumentation is causing us issues because we import our logger before the instrumentation can happen. It's logging an obnoxious warning. I think this is fine to disable because:
    
    1. We use pino to log to stdout so we're not missing a lot of useful info about the way it runs
    
    2. The instrumentation only adds traces, not metrics. We run pino async so it doesn't block further execution and shouldn't impact the timings of the routes etc that use it
    
    3. By default, this instrumentation tries to use the OpenTelemetry logs SDK. I'd rather not load some stuff that we don't want to use.

- **Wrap the Reliability Kit logger:**

    We have been losing information from the OpenTelemetry internal logs because they log multiple messages in a row which pino/reliability kit does not support. We don't support this because we want to maintain consistency with n-logger.
    
    To fix this, we need to wrap the Reliability Kit logger and extract any extra logged information into a new property. I've gone with `details`. Testing this locally, it's not common to get any info but it's important when we do get it - it helped me debug the issue with loading Pino ahead of instrumentation.

- **Manually provide a meter to `HostMetrics`**

    This suppresses an annoying warning. The host metrics class already gets the global meter provider in the same way but logs a warning if it has to. This is a lot of noise in our logs.

What it doesn't do:

- We're not handling `Accessing resource attributes before async attributes settled`, we'll wait to see [what happens with this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4638)