### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.3.0",
-  "packages/crash-handler": "4.1.5",
+  "packages/crash-handler": "4.1.6",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.1.5",
+  "packages/log-error": "4.2.0",
   "packages/logger": "3.1.4",
-  "packages/middleware-log-errors": "4.1.5",
-  "packages/middleware-render-error-info": "5.1.5",
+  "packages/middleware-log-errors": "4.2.0",
+  "packages/middleware-render-error-info": "5.1.6",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.4"
+  "packages/opentelemetry": "2.0.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13069,10 +13069,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.5"
+        "@dotcom-reliability-kit/log-error": "^4.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13124,7 +13124,7 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.1.5",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
@@ -13166,10 +13166,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.1.5",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.1.5"
+        "@dotcom-reliability-kit/log-error": "^4.2.0"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.8.0",
@@ -13183,11 +13183,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.5",
+      "version": "5.1.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/log-error": "^4.1.5",
+        "@dotcom-reliability-kit/log-error": "^4.2.0",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13212,12 +13212,12 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.1.5",
+        "@dotcom-reliability-kit/log-error": "^4.2.0",
         "@dotcom-reliability-kit/logger": "^3.1.4",
         "@opentelemetry/auto-instrumentations-node": "^0.48.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.5...crash-handler-v4.1.6) (2024-07-11)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
+
 ## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.4...crash-handler-v4.1.5) (2024-07-02)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.5"
+    "@dotcom-reliability-kit/log-error": "^4.2.0"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.5...log-error-v4.2.0) (2024-07-11)
+
+
+### Features
+
+* add a logUserErrorsAsWarnings option ([8c7541a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8c7541aa0952323e5755e4e2e46466bd2bf95c58))
+
 ## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.4...log-error-v4.1.5) (2024-07-02)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.5...middleware-log-errors-v4.2.0) (2024-07-11)
+
+
+### Features
+
+* add a logUserErrorsAsWarnings option ([8c7541a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8c7541aa0952323e5755e4e2e46466bd2bf95c58))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
+
 ## [4.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.4...middleware-log-errors-v4.1.5) (2024-07-02)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.1.5"
+    "@dotcom-reliability-kit/log-error": "^4.2.0"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.8.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.5...middleware-render-error-info-v5.1.6) (2024-07-11)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
+
 ## [5.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.4...middleware-render-error-info-v5.1.5) (2024-07-02)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/log-error": "^4.1.5",
+    "@dotcom-reliability-kit/log-error": "^4.2.0",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.4...opentelemetry-v2.0.5) (2024-07-11)
+
+
+### Bug Fixes
+
+* disable the pino instrumentation ([7daaa7b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/7daaa7b22fb1f90925d0fad0baa1baf4ebda6e1f))
+* manually pass a meterprovider to host metrics ([63c8216](https://github.com/Financial-Times/dotcom-reliability-kit/commit/63c8216f6c26a747246062bae2ec859181f459f8))
+* wrap the Reliability Kit logger ([28640ee](https://github.com/Financial-Times/dotcom-reliability-kit/commit/28640ee52cc41f5e621d6481f92007d8940110d7))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
+
 ## [2.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.3...opentelemetry-v2.0.4) (2024-07-08)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.3.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.1.5",
+		"@dotcom-reliability-kit/log-error": "^4.2.0",
 		"@dotcom-reliability-kit/logger": "^3.1.4",
 		"@opentelemetry/auto-instrumentations-node": "^0.48.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.6</summary>

## [4.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.5...crash-handler-v4.1.6) (2024-07-11)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
</details>

<details><summary>log-error: 4.2.0</summary>

## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.5...log-error-v4.2.0) (2024-07-11)


### Features

* add a logUserErrorsAsWarnings option ([8c7541a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8c7541aa0952323e5755e4e2e46466bd2bf95c58))
</details>

<details><summary>middleware-log-errors: 4.2.0</summary>

## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.5...middleware-log-errors-v4.2.0) (2024-07-11)


### Features

* add a logUserErrorsAsWarnings option ([8c7541a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8c7541aa0952323e5755e4e2e46466bd2bf95c58))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
</details>

<details><summary>middleware-render-error-info: 5.1.6</summary>

## [5.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.5...middleware-render-error-info-v5.1.6) (2024-07-11)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
</details>

<details><summary>opentelemetry: 2.0.5</summary>

## [2.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.4...opentelemetry-v2.0.5) (2024-07-11)


### Bug Fixes

* disable the pino instrumentation ([7daaa7b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/7daaa7b22fb1f90925d0fad0baa1baf4ebda6e1f))
* manually pass a meterprovider to host metrics ([63c8216](https://github.com/Financial-Times/dotcom-reliability-kit/commit/63c8216f6c26a747246062bae2ec859181f459f8))
* wrap the Reliability Kit logger ([28640ee](https://github.com/Financial-Times/dotcom-reliability-kit/commit/28640ee52cc41f5e621d6481f92007d8940110d7))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.1.5 to ^4.2.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).