### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.3.0",
-  "packages/crash-handler": "4.1.6",
+  "packages/crash-handler": "4.1.7",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.2.0",
-  "packages/logger": "3.1.4",
-  "packages/middleware-log-errors": "4.2.0",
-  "packages/middleware-render-error-info": "5.1.6",
+  "packages/log-error": "4.2.1",
+  "packages/logger": "3.1.5",
+  "packages/middleware-log-errors": "4.2.1",
+  "packages/middleware-render-error-info": "5.1.7",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.5"
+  "packages/opentelemetry": "2.0.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13110,10 +13110,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.0"
+        "@dotcom-reliability-kit/log-error": "^4.2.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13165,11 +13165,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/logger": "^3.1.4",
+        "@dotcom-reliability-kit/logger": "^3.1.5",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -13183,7 +13183,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
@@ -13207,10 +13207,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.0"
+        "@dotcom-reliability-kit/log-error": "^4.2.1"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.0",
@@ -13223,11 +13223,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/log-error": "^4.2.0",
+        "@dotcom-reliability-kit/log-error": "^4.2.1",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13252,13 +13252,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.0",
-        "@dotcom-reliability-kit/logger": "^3.1.4",
+        "@dotcom-reliability-kit/log-error": "^4.2.1",
+        "@dotcom-reliability-kit/logger": "^3.1.5",
         "@opentelemetry/auto-instrumentations-node": "^0.49.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.6...crash-handler-v4.1.7) (2024-08-08)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
+
 ## [4.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.5...crash-handler-v4.1.6) (2024-07-11)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.0"
+    "@dotcom-reliability-kit/log-error": "^4.2.1"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.0...log-error-v4.2.1) (2024-08-08)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.4 to ^3.1.5
+
 ## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.1.5...log-error-v4.2.0) (2024-07-11)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/logger": "^3.1.4",
+    "@dotcom-reliability-kit/logger": "^3.1.5",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.4...logger-v3.1.5) (2024-08-08)
+
+
+### Bug Fixes
+
+* bump pino from 9.2.0 to 9.3.1 ([519de6b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/519de6baef09860cdbdca8661ff032337b3a631e))
+* bump pino from 9.3.1 to 9.3.2 ([079453b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/079453bbc3cfc37e98a585f54cbba55ac32d2bb3))
+
 ## [3.1.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.3...logger-v3.1.4) (2024-07-02)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.0...middleware-log-errors-v4.2.1) (2024-08-08)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
+
 ## [4.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.1.5...middleware-log-errors-v4.2.0) (2024-07-11)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.0"
+    "@dotcom-reliability-kit/log-error": "^4.2.1"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.6...middleware-render-error-info-v5.1.7) (2024-08-08)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
+
 ## [5.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.5...middleware-render-error-info-v5.1.6) (2024-07-11)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/log-error": "^4.2.0",
+    "@dotcom-reliability-kit/log-error": "^4.2.1",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.5...opentelemetry-v2.0.6) (2024-08-08)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([17ff339](https://github.com/Financial-Times/dotcom-reliability-kit/commit/17ff3390df8c10a4910cbc256a60b601c69c3e98))
+* bump the opentelemetry group across 2 directories with 1 update ([fdb0905](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fdb0905248f46ae93d558c5ad3e76af8583a0b0f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
+    * @dotcom-reliability-kit/logger bumped from ^3.1.4 to ^3.1.5
+
 ## [2.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.4...opentelemetry-v2.0.5) (2024-07-11)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.3.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.2.0",
-		"@dotcom-reliability-kit/logger": "^3.1.4",
+		"@dotcom-reliability-kit/log-error": "^4.2.1",
+		"@dotcom-reliability-kit/logger": "^3.1.5",
 		"@opentelemetry/auto-instrumentations-node": "^0.49.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.7</summary>

## [4.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.6...crash-handler-v4.1.7) (2024-08-08)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
</details>

<details><summary>log-error: 4.2.1</summary>

## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.0...log-error-v4.2.1) (2024-08-08)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.4 to ^3.1.5
</details>

<details><summary>logger: 3.1.5</summary>

## [3.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.4...logger-v3.1.5) (2024-08-08)


### Bug Fixes

* bump pino from 9.2.0 to 9.3.1 ([519de6b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/519de6baef09860cdbdca8661ff032337b3a631e))
* bump pino from 9.3.1 to 9.3.2 ([079453b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/079453bbc3cfc37e98a585f54cbba55ac32d2bb3))
</details>

<details><summary>middleware-log-errors: 4.2.1</summary>

## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.0...middleware-log-errors-v4.2.1) (2024-08-08)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
</details>

<details><summary>middleware-render-error-info: 5.1.7</summary>

## [5.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.6...middleware-render-error-info-v5.1.7) (2024-08-08)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
</details>

<details><summary>opentelemetry: 2.0.6</summary>

## [2.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.5...opentelemetry-v2.0.6) (2024-08-08)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([17ff339](https://github.com/Financial-Times/dotcom-reliability-kit/commit/17ff3390df8c10a4910cbc256a60b601c69c3e98))
* bump the opentelemetry group across 2 directories with 1 update ([fdb0905](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fdb0905248f46ae93d558c5ad3e76af8583a0b0f))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.0 to ^4.2.1
    * @dotcom-reliability-kit/logger bumped from ^3.1.4 to ^3.1.5
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).