### PR TITLE
chore: remove node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13171,8 +13171,7 @@
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.8.0",
-        "@types/express": "^4.17.21",
-        "node-fetch": "^2.7.0"
+        "@types/express": "^4.17.21"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.8.0",
-    "@types/express": "^4.17.21",
-    "node-fetch": "^2.7.0"
+    "@types/express": "^4.17.21"
   }
 }

--- a/packages/middleware-log-errors/test/end-to-end/index.spec.js
+++ b/packages/middleware-log-errors/test/end-to-end/index.spec.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const { fork } = require('node:child_process');
 
 describe('@dotcom-reliability-kit/middleware-log-errors end-to-end', () => {


### PR DESCRIPTION
I'm not sure why we ever included this, we can just use the native fetch method. It's fine as it's a test. This will reduce the number of annoying dependency bump PRs we get.