### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.7",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.6"
+  "packages/opentelemetry": "2.0.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13327,7 +13327,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.6...opentelemetry-v2.0.7) (2024-08-28)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([4f86338](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4f8633890fc70269c1f40e54f744820448ccc572))
+* bump @opentelemetry/semantic-conventions ([3ed3c02](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3ed3c026c646ca1c2c84a602dd7756e53d8b0885))
+
 ## [2.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.5...opentelemetry-v2.0.6) (2024-08-08)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.7</summary>

## [2.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.6...opentelemetry-v2.0.7) (2024-08-28)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([4f86338](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4f8633890fc70269c1f40e54f744820448ccc572))
* bump @opentelemetry/semantic-conventions ([3ed3c02](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3ed3c026c646ca1c2c84a602dd7756e53d8b0885))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).