### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.7",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.7"
+  "packages/opentelemetry": "2.0.8"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13858,7 +13858,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.7...opentelemetry-v2.0.8) (2024-09-02)
+
+
+### Bug Fixes
+
+* bump the opentelemetry group across 2 directories with 4 updates ([4961d6d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4961d6d93ac03981a27ead1f8d34f5af1dc12fe4))
+
 ## [2.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.6...opentelemetry-v2.0.7) (2024-08-28)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.8</summary>

## [2.0.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.7...opentelemetry-v2.0.8) (2024-09-02)


### Bug Fixes

* bump the opentelemetry group across 2 directories with 4 updates ([4961d6d](https://github.com/Financial-Times/dotcom-reliability-kit/commit/4961d6d93ac03981a27ead1f8d34f5af1dc12fe4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).