### PR TITLE
fix: disable OTEL_INTERNALS logs by default

### DIFF
--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -23,6 +23,7 @@ An [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) client 
   * [Implementation details](#implementation-details)
   * [Configuration options](#configuration-options)
     * [`options.authorizationHeader`](#optionsauthorizationheader)
+    * [`options.logInternals`](#optionsloginternals)
     * [`options.metrics`](#optionsmetrics)
     * [`options.metrics.endpoint`](#optionsmetricsendpoint)
     * [`options.metrics.apiGatewayKey`](#optionsmetricsapigatewaykey)
@@ -268,6 +269,10 @@ opentelemetry.setup({
 #### `options.authorizationHeader`
 
 **Deprecated**. This will still work but has been replaced with [`options.tracing.authorizationHeader`](#optionstracingauthorizationheader), which is now the preferred way to set this option.
+
+#### `options.logInternals`
+
+Boolean indicating whether to log internal OpenTelemetry warnings and errors. Defaults to `false`.
 
 #### `options.metrics`
 

--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -26,6 +26,7 @@ let instances;
  */
 function setupOpenTelemetry({
 	authorizationHeader,
+	logInternals,
 	metrics: metricsOptions,
 	tracing: tracingOptions
 } = {}) {
@@ -48,15 +49,19 @@ function setupOpenTelemetry({
 	// We need to create a new logger for OpenTelemetry internals
 	// because the function signature is different and OpenTelemetry
 	// logs mutliple strings. With pino this means we lose data
-	const log = logger.createChildLogger({ event: 'OTEL_INTERNALS' });
-	const opentelemetryLogger = {
-		error: (...args) => log.error(args[0], { details: args.slice(1) }),
-		info: (...args) => log.info(args[0], { details: args.slice(1) }),
-		warn: (...args) => log.warn(args[0], { details: args.slice(1) }),
-		debug: () => {},
-		verbose: () => {}
-	};
-	opentelemetry.api.diag.setLogger(opentelemetryLogger);
+	if (logInternals) {
+		const log = logger.createChildLogger({ event: 'OTEL_INTERNALS' });
+		const opentelemetryLogger = {
+			error: (...args) => log.error(args[0], { details: args.slice(1) }),
+			info: (...args) => log.info(args[0], { details: args.slice(1) }),
+			warn: (...args) => log.warn(args[0], { details: args.slice(1) }),
+			debug: () => {},
+			verbose: () => {}
+		};
+		opentelemetry.api.diag.setLogger(opentelemetryLogger);
+	} else {
+		opentelemetry.api.diag.disable();
+	}
 
 	// Set up and start OpenTelemetry
 	instances = {

--- a/packages/opentelemetry/setup.js
+++ b/packages/opentelemetry/setup.js
@@ -22,6 +22,7 @@ if (process.env.OPENTELEMETRY_METRICS_ENDPOINT) {
 }
 
 opentelemetry.setup({
+	logInternals: Boolean(process.env.OPENTELEMETRY_LOG_INTERNALS),
 	metrics,
 	tracing
 });

--- a/packages/opentelemetry/test/unit/setup.spec.js
+++ b/packages/opentelemetry/test/unit/setup.spec.js
@@ -8,6 +8,7 @@ describe('setup', () => {
 	});
 
 	it('should call opentelemetry.setup with the correct parameters', () => {
+		delete process.env.OPENTELEMETRY_LOG_INTERNALS;
 		process.env.OPENTELEMETRY_TRACING_ENDPOINT = 'MOCK_TRACING_ENDPOINT';
 		process.env.OPENTELEMETRY_AUTHORIZATION_HEADER = 'MOCK_AUTH_HEADER';
 		process.env.OPENTELEMETRY_METRICS_ENDPOINT = 'MOCK_METRICS_ENDPOINT';
@@ -16,6 +17,7 @@ describe('setup', () => {
 
 		expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
 		expect(opentelemetry.setup).toHaveBeenCalledWith({
+			logInternals: false,
 			tracing: {
 				authorizationHeader: 'MOCK_AUTH_HEADER',
 				endpoint: 'MOCK_TRACING_ENDPOINT'
@@ -35,6 +37,7 @@ describe('setup', () => {
 
 			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
 			expect(opentelemetry.setup).toHaveBeenCalledWith({
+				logInternals: false,
 				metrics: {
 					apiGatewayKey: 'MOCK_API_GATEWAY_KEY',
 					endpoint: 'MOCK_METRICS_ENDPOINT'
@@ -51,6 +54,7 @@ describe('setup', () => {
 
 			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
 			expect(opentelemetry.setup).toHaveBeenCalledWith({
+				logInternals: false,
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT'
@@ -67,6 +71,7 @@ describe('setup', () => {
 
 			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
 			expect(opentelemetry.setup).toHaveBeenCalledWith({
+				logInternals: false,
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',
@@ -84,12 +89,27 @@ describe('setup', () => {
 
 			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
 			expect(opentelemetry.setup).toHaveBeenCalledWith({
+				logInternals: false,
 				tracing: {
 					authorizationHeader: 'MOCK_AUTH_HEADER',
 					endpoint: 'MOCK_TRACING_ENDPOINT',
 					samplePercentage: NaN
 				}
 			});
+		});
+	});
+
+	describe('when internal logs are enabled', () => {
+		it('calls OpenTelemetry with the logInternal option set to true', () => {
+			process.env.OPENTELEMETRY_LOG_INTERNALS = 'true';
+			require('../../setup.js');
+
+			expect(opentelemetry.setup).toHaveBeenCalledTimes(1);
+			expect(opentelemetry.setup).toHaveBeenCalledWith(
+				expect.objectContaining({
+					logInternals: true
+				})
+			);
 		});
 	});
 });

--- a/packages/opentelemetry/types/index.d.ts
+++ b/packages/opentelemetry/types/index.d.ts
@@ -16,6 +16,7 @@ declare module '@dotcom-reliability-kit/opentelemetry' {
 	export type Options = {
 		/** @deprecated */
 		authorizationHeader?: string;
+		logInternals?: boolean;
 		metrics?: MetricsOptions;
 		tracing?: TracingOptions;
 	};


### PR DESCRIPTION
These logs are very noisy and provide little to no value. I've disabled them by default but you can enable them via an option or new environment variable in case you're having issues and need to debug.