### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.7",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.8"
+  "packages/opentelemetry": "2.0.9"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13150,7 +13150,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.8...opentelemetry-v2.0.9) (2024-09-03)
+
+
+### Bug Fixes
+
+* bump the opentelemetry group across 2 directories with 2 updates ([cb252db](https://github.com/Financial-Times/dotcom-reliability-kit/commit/cb252dbaebbb07e5b3b17b8a42d885f43c726070))
+* disable OTEL_INTERNALS logs by default ([d38f21b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d38f21ba4a5ffbd548cf5c6f529d054253ed6e61))
+
+
+### Documentation Changes
+
+* clarify the `--require` method and gotchas ([a0a5d4c](https://github.com/Financial-Times/dotcom-reliability-kit/commit/a0a5d4c1320d3d07489139845507207a55be67a0))
+
 ## [2.0.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.7...opentelemetry-v2.0.8) (2024-09-02)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.9</summary>

## [2.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.8...opentelemetry-v2.0.9) (2024-09-03)


### Bug Fixes

* bump the opentelemetry group across 2 directories with 2 updates ([cb252db](https://github.com/Financial-Times/dotcom-reliability-kit/commit/cb252dbaebbb07e5b3b17b8a42d885f43c726070))
* disable OTEL_INTERNALS logs by default ([d38f21b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d38f21ba4a5ffbd548cf5c6f529d054253ed6e61))


### Documentation Changes

* clarify the `--require` method and gotchas ([a0a5d4c](https://github.com/Financial-Times/dotcom-reliability-kit/commit/a0a5d4c1320d3d07489139845507207a55be67a0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).