### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.3.0",
-  "packages/crash-handler": "4.1.7",
+  "packages/crash-handler": "4.1.8",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.2.1",
-  "packages/logger": "3.1.5",
-  "packages/middleware-log-errors": "4.2.1",
-  "packages/middleware-render-error-info": "5.1.7",
+  "packages/log-error": "4.2.2",
+  "packages/logger": "3.1.6",
+  "packages/middleware-log-errors": "4.2.2",
+  "packages/middleware-render-error-info": "5.1.8",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.9"
+  "packages/opentelemetry": "2.0.10"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13083,10 +13083,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.1"
+        "@dotcom-reliability-kit/log-error": "^4.2.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13138,11 +13138,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/logger": "^3.1.5",
+        "@dotcom-reliability-kit/logger": "^3.1.6",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -13156,7 +13156,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
@@ -13180,10 +13180,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.1"
+        "@dotcom-reliability-kit/log-error": "^4.2.2"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.2",
@@ -13196,11 +13196,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/log-error": "^4.2.1",
+        "@dotcom-reliability-kit/log-error": "^4.2.2",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13225,13 +13225,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.1",
-        "@dotcom-reliability-kit/logger": "^3.1.5",
+        "@dotcom-reliability-kit/log-error": "^4.2.2",
+        "@dotcom-reliability-kit/logger": "^3.1.6",
         "@opentelemetry/auto-instrumentations-node": "^0.50.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.53.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.7...crash-handler-v4.1.8) (2024-09-12)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
+
 ## [4.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.6...crash-handler-v4.1.7) (2024-08-08)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.1"
+    "@dotcom-reliability-kit/log-error": "^4.2.2"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.1...log-error-v4.2.2) (2024-09-12)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.5 to ^3.1.6
+
 ## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.0...log-error-v4.2.1) (2024-08-08)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/logger": "^3.1.5",
+    "@dotcom-reliability-kit/logger": "^3.1.6",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.5...logger-v3.1.6) (2024-09-12)
+
+
+### Bug Fixes
+
+* bump pino from 9.3.2 to 9.4.0 ([69e4b29](https://github.com/Financial-Times/dotcom-reliability-kit/commit/69e4b29849bfb879b3e8668b7e8d87e03a9a1828))
+* log a better warning if log level is invalid ([cbd6fc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/cbd6fc64e1150ed3d8dc1faba04633818aed9958))
+
 ## [3.1.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.4...logger-v3.1.5) (2024-08-08)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.1...middleware-log-errors-v4.2.2) (2024-09-12)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
+
 ## [4.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.0...middleware-log-errors-v4.2.1) (2024-08-08)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.1"
+    "@dotcom-reliability-kit/log-error": "^4.2.2"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.2",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.7...middleware-render-error-info-v5.1.8) (2024-09-12)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
+
 ## [5.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.6...middleware-render-error-info-v5.1.7) (2024-08-08)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/log-error": "^4.2.1",
+    "@dotcom-reliability-kit/log-error": "^4.2.2",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.9...opentelemetry-v2.0.10) (2024-09-12)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
+    * @dotcom-reliability-kit/logger bumped from ^3.1.5 to ^3.1.6
+
 ## [2.0.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.8...opentelemetry-v2.0.9) (2024-09-03)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.9",
+	"version": "2.0.10",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.3.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.2.1",
-		"@dotcom-reliability-kit/logger": "^3.1.5",
+		"@dotcom-reliability-kit/log-error": "^4.2.2",
+		"@dotcom-reliability-kit/logger": "^3.1.6",
 		"@opentelemetry/auto-instrumentations-node": "^0.50.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.53.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.8</summary>

## [4.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.7...crash-handler-v4.1.8) (2024-09-12)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
</details>

<details><summary>log-error: 4.2.2</summary>

## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.1...log-error-v4.2.2) (2024-09-12)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.5 to ^3.1.6
</details>

<details><summary>logger: 3.1.6</summary>

## [3.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.5...logger-v3.1.6) (2024-09-12)


### Bug Fixes

* bump pino from 9.3.2 to 9.4.0 ([69e4b29](https://github.com/Financial-Times/dotcom-reliability-kit/commit/69e4b29849bfb879b3e8668b7e8d87e03a9a1828))
* log a better warning if log level is invalid ([cbd6fc6](https://github.com/Financial-Times/dotcom-reliability-kit/commit/cbd6fc64e1150ed3d8dc1faba04633818aed9958))
</details>

<details><summary>middleware-log-errors: 4.2.2</summary>

## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.1...middleware-log-errors-v4.2.2) (2024-09-12)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
</details>

<details><summary>middleware-render-error-info: 5.1.8</summary>

## [5.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.7...middleware-render-error-info-v5.1.8) (2024-09-12)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
</details>

<details><summary>opentelemetry: 2.0.10</summary>

## [2.0.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.9...opentelemetry-v2.0.10) (2024-09-12)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.1 to ^4.2.2
    * @dotcom-reliability-kit/logger bumped from ^3.1.5 to ^3.1.6
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).