### PR TITLE
fix: log a better warning if log level is invalid

### DIFF
--- a/packages/logger/types/logger.d.ts
+++ b/packages/logger/types/logger.d.ts
@@ -11,6 +11,7 @@ export type LogLevel =
 export type LogLevelInfo = {
 	logLevel: LogLevel;
 	isDeprecated: boolean;
+	isDefaulted: boolean;
 };
 
 export type BaseLogData = { [key: string]: any };


### PR DESCRIPTION
Previously we were logging that the level was deprecated if we didn't recognise it. This made it difficult for Content Discovery to debug a logging issue. Now the same issue will log a more specific warning alongside an error so you can trace it back to the place in the source code where the level is being used.

See Slack message from @fenglish [here](https://financialtimes.slack.com/archives/C02B89GEQHF/p1726132897240619).