### PR TITLE
fix: instrument node-fetch properly

### DIFF
--- a/packages/opentelemetry/lib/index.js
+++ b/packages/opentelemetry/lib/index.js
@@ -83,6 +83,12 @@ function setupOpenTelemetry({
 	};
 	instances.sdk.start();
 
+	// HACK: this is required to make sure we record metrics for node-fetch.
+	// This is a known issue, the workaround is to import 'https' to ensure
+	// that the instrumented version is used by node-fetch. See:
+	// https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2440
+	require('https');
+
 	// Set up host metrics if we have a metrics endpoint
 	if (metricsOptions?.endpoint) {
 		const meterProvider = /** @type {MeterProvider} */ (


### PR DESCRIPTION
Due to an issue with the Node.js http auto-instrumentations, requests made with node-fetch do not send metrics. See the code comment for the relevant issue.

Requiring `https` here fixes the issue. I think it's best if we solve this in our client rather than require our teams to update their apps. Technically removing this hack will be a breaking change - I think that's fine, we can coordinate with the removal of node-fetch from our libraries and the migration to native fetch.

---

See-also: [CPREL-1169](https://financialtimes.atlassian.net/browse/CPREL-1169)

[CPREL-1169]: https://financialtimes.atlassian.net/browse/CPREL-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ