### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.8",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.10"
+  "packages/opentelemetry": "2.0.11"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12797,7 +12797,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.10...opentelemetry-v2.0.11) (2024-09-30)
+
+
+### Bug Fixes
+
+* instrument node-fetch properly ([19adfe2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/19adfe24172b7e4dcea7db86b839dc11c9efda5f))
+
 ## [2.0.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.9...opentelemetry-v2.0.10) (2024-09-12)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.10",
+	"version": "2.0.11",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.11</summary>

## [2.0.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.10...opentelemetry-v2.0.11) (2024-09-30)


### Bug Fixes

* instrument node-fetch properly ([19adfe2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/19adfe24172b7e4dcea7db86b839dc11c9efda5f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).