### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.8",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.11"
+  "packages/opentelemetry": "2.0.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12720,7 +12720,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.11...opentelemetry-v2.0.12) (2024-10-15)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([2319f4f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2319f4f548069acf27fb2ee346f8a925370e65f9))
+* bump @opentelemetry/host-metrics from 0.35.3 to 0.35.4 ([5be3e20](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5be3e206f6c4f7a19762d1268fe8d083c9e0c981))
+
 ## [2.0.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.10...opentelemetry-v2.0.11) (2024-09-30)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.12</summary>

## [2.0.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.11...opentelemetry-v2.0.12) (2024-10-15)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([2319f4f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/2319f4f548069acf27fb2ee346f8a925370e65f9))
* bump @opentelemetry/host-metrics from 0.35.3 to 0.35.4 ([5be3e20](https://github.com/Financial-Times/dotcom-reliability-kit/commit/5be3e206f6c4f7a19762d1268fe8d083c9e0c981))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).