### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.3.0",
-  "packages/crash-handler": "4.1.8",
+  "packages/crash-handler": "4.1.9",
   "packages/errors": "3.1.1",
   "packages/eslint-config": "3.1.0",
   "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.2.2",
-  "packages/logger": "3.1.6",
-  "packages/middleware-log-errors": "4.2.2",
-  "packages/middleware-render-error-info": "5.1.8",
+  "packages/log-error": "4.2.3",
+  "packages/logger": "3.1.7",
+  "packages/middleware-log-errors": "4.2.3",
+  "packages/middleware-render-error-info": "5.1.9",
   "packages/serialize-error": "3.2.0",
   "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.12"
+  "packages/opentelemetry": "2.0.13"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13267,10 +13267,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.2"
+        "@dotcom-reliability-kit/log-error": "^4.2.3"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -13322,11 +13322,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/logger": "^3.1.6",
+        "@dotcom-reliability-kit/logger": "^3.1.7",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "@dotcom-reliability-kit/serialize-request": "^3.1.0"
       },
@@ -13340,7 +13340,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
@@ -13364,10 +13364,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.2"
+        "@dotcom-reliability-kit/log-error": "^4.2.3"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.4",
@@ -13380,11 +13380,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/log-error": "^4.2.2",
+        "@dotcom-reliability-kit/log-error": "^4.2.3",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "entities": "^5.0.0"
       },
@@ -13409,13 +13409,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.2",
-        "@dotcom-reliability-kit/logger": "^3.1.6",
+        "@dotcom-reliability-kit/log-error": "^4.2.3",
+        "@dotcom-reliability-kit/logger": "^3.1.7",
         "@opentelemetry/auto-instrumentations-node": "^0.52.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.54.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.54.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.8...crash-handler-v4.1.9) (2024-10-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
+
 ## [4.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.7...crash-handler-v4.1.8) (2024-09-12)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -17,6 +17,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.2"
+    "@dotcom-reliability-kit/log-error": "^4.2.3"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.2...log-error-v4.2.3) (2024-10-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.1.6 to ^3.1.7
+
 ## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.1...log-error-v4.2.2) (2024-09-12)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/logger": "^3.1.6",
+    "@dotcom-reliability-kit/logger": "^3.1.7",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "@dotcom-reliability-kit/serialize-request": "^3.1.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.6...logger-v3.1.7) (2024-10-29)
+
+
+### Bug Fixes
+
+* bump pino from 9.4.0 to 9.5.0 ([3116f2f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3116f2fe524646169fd99f8f561145842d076bfc))
+
 ## [3.1.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.5...logger-v3.1.6) (2024-09-12)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.2...middleware-log-errors-v4.2.3) (2024-10-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
+
 ## [4.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.1...middleware-log-errors-v4.2.2) (2024-09-12)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.2"
+    "@dotcom-reliability-kit/log-error": "^4.2.3"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.4",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.8...middleware-render-error-info-v5.1.9) (2024-10-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
+
 ## [5.1.8](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.7...middleware-render-error-info-v5.1.8) (2024-09-12)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/log-error": "^4.2.2",
+    "@dotcom-reliability-kit/log-error": "^4.2.3",
     "@dotcom-reliability-kit/serialize-error": "^3.2.0",
     "entities": "^5.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.0.13](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.12...opentelemetry-v2.0.13) (2024-10-29)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([0d16bf0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d16bf01c80a5552bf4188ef91763a646f13a4ef))
+* update all OpenTelemetry packages ([8705a84](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8705a84e35dddebc2253af56da8ed8f217ff0fc5))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
+    * @dotcom-reliability-kit/logger bumped from ^3.1.6 to ^3.1.7
+
 ## [2.0.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.11...opentelemetry-v2.0.12) (2024-10-15)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.3.0",
 		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.2.2",
-		"@dotcom-reliability-kit/logger": "^3.1.6",
+		"@dotcom-reliability-kit/log-error": "^4.2.3",
+		"@dotcom-reliability-kit/logger": "^3.1.7",
 		"@opentelemetry/auto-instrumentations-node": "^0.52.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.54.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.54.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.9</summary>

## [4.1.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.8...crash-handler-v4.1.9) (2024-10-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
</details>

<details><summary>log-error: 4.2.3</summary>

## [4.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.2...log-error-v4.2.3) (2024-10-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.1.6 to ^3.1.7
</details>

<details><summary>logger: 3.1.7</summary>

## [3.1.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.6...logger-v3.1.7) (2024-10-29)


### Bug Fixes

* bump pino from 9.4.0 to 9.5.0 ([3116f2f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3116f2fe524646169fd99f8f561145842d076bfc))
</details>

<details><summary>middleware-log-errors: 4.2.3</summary>

## [4.2.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.2...middleware-log-errors-v4.2.3) (2024-10-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
</details>

<details><summary>middleware-render-error-info: 5.1.9</summary>

## [5.1.9](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.8...middleware-render-error-info-v5.1.9) (2024-10-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
</details>

<details><summary>opentelemetry: 2.0.13</summary>

## [2.0.13](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.12...opentelemetry-v2.0.13) (2024-10-29)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([0d16bf0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d16bf01c80a5552bf4188ef91763a646f13a4ef))
* update all OpenTelemetry packages ([8705a84](https://github.com/Financial-Times/dotcom-reliability-kit/commit/8705a84e35dddebc2253af56da8ed8f217ff0fc5))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.2 to ^4.2.3
    * @dotcom-reliability-kit/logger bumped from ^3.1.6 to ^3.1.7
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).