### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.3.0",
-  "packages/crash-handler": "4.1.10",
-  "packages/errors": "3.1.1",
-  "packages/eslint-config": "3.1.0",
-  "packages/fetch-error-handler": "0.2.5",
-  "packages/log-error": "4.2.4",
-  "packages/logger": "3.2.0",
-  "packages/middleware-log-errors": "4.2.4",
-  "packages/middleware-render-error-info": "5.1.10",
-  "packages/serialize-error": "3.2.0",
-  "packages/serialize-request": "3.1.0",
-  "packages/opentelemetry": "2.0.14"
+  "packages/app-info": "3.3.1",
+  "packages/crash-handler": "4.1.11",
+  "packages/errors": "3.1.2",
+  "packages/eslint-config": "3.1.1",
+  "packages/fetch-error-handler": "0.2.6",
+  "packages/log-error": "4.2.5",
+  "packages/logger": "3.2.1",
+  "packages/middleware-log-errors": "4.2.5",
+  "packages/middleware-render-error-info": "5.1.11",
+  "packages/serialize-error": "3.2.1",
+  "packages/serialize-request": "3.1.1",
+  "packages/opentelemetry": "2.0.15"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13257,7 +13257,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -13265,10 +13265,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.4"
+        "@dotcom-reliability-kit/log-error": "^4.2.5"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -13276,7 +13276,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -13284,7 +13284,7 @@
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^8.56.6"
@@ -13298,10 +13298,10 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^3.1.1"
+        "@dotcom-reliability-kit/errors": "^3.1.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -13316,13 +13316,13 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/logger": "^3.2.0",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
-        "@dotcom-reliability-kit/serialize-request": "^3.1.0"
+        "@dotcom-reliability-kit/app-info": "^3.3.1",
+        "@dotcom-reliability-kit/logger": "^3.2.1",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+        "@dotcom-reliability-kit/serialize-request": "^3.1.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.0"
@@ -13333,11 +13333,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
+        "@dotcom-reliability-kit/app-info": "^3.3.1",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.5.0"
       },
@@ -13356,10 +13356,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.4"
+        "@dotcom-reliability-kit/log-error": "^4.2.5"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.4",
@@ -13371,12 +13371,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.10",
+      "version": "5.1.11",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/log-error": "^4.2.4",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.0",
+        "@dotcom-reliability-kit/app-info": "^3.3.1",
+        "@dotcom-reliability-kit/log-error": "^4.2.5",
+        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
         "entities": "^5.0.0"
       },
       "devDependencies": {
@@ -13399,13 +13399,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.0",
-        "@dotcom-reliability-kit/errors": "^3.1.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.4",
-        "@dotcom-reliability-kit/logger": "^3.2.0",
+        "@dotcom-reliability-kit/app-info": "^3.3.1",
+        "@dotcom-reliability-kit/errors": "^3.1.2",
+        "@dotcom-reliability-kit/log-error": "^4.2.5",
+        "@dotcom-reliability-kit/logger": "^3.2.1",
         "@opentelemetry/auto-instrumentations-node": "^0.53.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.55.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.55.0",
@@ -13429,7 +13429,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -13437,7 +13437,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0"

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.3.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.0...app-info-v3.3.1) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
 ## [3.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.2.0...app-info-v3.3.0) (2024-07-02)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.10...crash-handler-v4.1.11) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
+
 ## [4.1.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.9...crash-handler-v4.1.10) (2024-10-30)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.4"
+    "@dotcom-reliability-kit/log-error": "^4.2.5"
   }
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.1...errors-v3.1.2) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
 ## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.0...errors-v3.1.1) (2024-06-26)
 
 

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/errors",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A suite of error classes which help you throw the most appropriate error in any situation",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.1.0...eslint-config-v3.1.1) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.0.2...eslint-config-v3.1.0) (2024-04-29)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/eslint-config",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production",
   "repository": {
     "type": "git",

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.5...fetch-error-handler-v0.2.6) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^3.1.1 to ^3.1.2
+
 ## [0.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.4...fetch-error-handler-v0.2.5) (2024-07-01)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "^3.1.1"
+    "@dotcom-reliability-kit/errors": "^3.1.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.4...log-error-v4.2.5) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
+    * @dotcom-reliability-kit/logger bumped from ^3.2.0 to ^3.2.1
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
+    * @dotcom-reliability-kit/serialize-request bumped from ^3.1.0 to ^3.1.1
+
 ## [4.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.3...log-error-v4.2.4) (2024-10-30)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,10 +16,10 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/logger": "^3.2.0",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
-    "@dotcom-reliability-kit/serialize-request": "^3.1.0"
+    "@dotcom-reliability-kit/app-info": "^3.3.1",
+    "@dotcom-reliability-kit/logger": "^3.2.1",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+    "@dotcom-reliability-kit/serialize-request": "^3.1.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.0...logger-v3.2.1) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
+
 ## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.1.7...logger-v3.2.0) (2024-10-30)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
+    "@dotcom-reliability-kit/app-info": "^3.3.1",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.5.0"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.4...middleware-log-errors-v4.2.5) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
+
 ## [4.2.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.3...middleware-log-errors-v4.2.4) (2024-10-30)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.4"
+    "@dotcom-reliability-kit/log-error": "^4.2.5"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.4",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [5.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.10...middleware-render-error-info-v5.1.11) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
+
 ## [5.1.10](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.9...middleware-render-error-info-v5.1.10) (2024-10-30)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.10",
+  "version": "5.1.11",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,9 +16,9 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.0",
-    "@dotcom-reliability-kit/log-error": "^4.2.4",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.0",
+    "@dotcom-reliability-kit/app-info": "^3.3.1",
+    "@dotcom-reliability-kit/log-error": "^4.2.5",
+    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
     "entities": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.0.15](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.14...opentelemetry-v2.0.15) (2024-11-26)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([7a58cf5](https://github.com/Financial-Times/dotcom-reliability-kit/commit/7a58cf52a83eabe601cfeb919c17b76eebab1843))
+* bump @opentelemetry/exporter-metrics-otlp-proto ([0a73e88](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0a73e88a3dbca9bb3d0e5f30b0218cae8d333e6f))
+* bump @opentelemetry/exporter-trace-otlp-proto from 0.54.0 to 0.54.2 ([b9686d1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b9686d130b3a483bba4b653ed5c4b044b3ee484b))
+* bump @opentelemetry/instrumentation-runtime-node ([b0bd76a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b0bd76ab0e90f3200f61dc2f1cd2068de6995420))
+* bump @opentelemetry/sdk-node from 0.54.0 to 0.54.2 ([015c5d8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/015c5d83cd8ab75f07e7426d45f4b039ef44af5c))
+* bump OpenTelemetry packages ([f9748f0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f9748f004e2604e4a67c9c8bf3e57c62d3d660d5))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
+    * @dotcom-reliability-kit/errors bumped from ^3.1.1 to ^3.1.2
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
+    * @dotcom-reliability-kit/logger bumped from ^3.2.0 to ^3.2.1
+
 ## [2.0.14](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.13...opentelemetry-v2.0.14) (2024-10-30)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,10 +17,10 @@
 	"main": "lib/index.js",
 	"types": "types/index.d.ts",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.3.0",
-		"@dotcom-reliability-kit/errors": "^3.1.1",
-		"@dotcom-reliability-kit/log-error": "^4.2.4",
-		"@dotcom-reliability-kit/logger": "^3.2.0",
+		"@dotcom-reliability-kit/app-info": "^3.3.1",
+		"@dotcom-reliability-kit/errors": "^3.1.2",
+		"@dotcom-reliability-kit/log-error": "^4.2.5",
+		"@dotcom-reliability-kit/logger": "^3.2.1",
 		"@opentelemetry/auto-instrumentations-node": "^0.53.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.55.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.55.0",

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.2.0...serialize-error-v3.2.1) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
 ## [3.2.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.1.0...serialize-error-v3.2.0) (2024-05-02)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",

--- a/packages/serialize-request/CHANGELOG.md
+++ b/packages/serialize-request/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.1.0...serialize-request-v3.1.1) (2024-11-26)
+
+
+### Bug Fixes
+
+* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
+
 ## [3.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.0.2...serialize-request-v3.1.0) (2024-04-29)
 
 

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-request",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 3.3.1</summary>

## [3.3.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.0...app-info-v3.3.1) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
</details>

<details><summary>crash-handler: 4.1.11</summary>

## [4.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.10...crash-handler-v4.1.11) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
</details>

<details><summary>errors: 3.1.2</summary>

## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.1...errors-v3.1.2) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
</details>

<details><summary>eslint-config: 3.1.1</summary>

## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.1.0...eslint-config-v3.1.1) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
</details>

<details><summary>fetch-error-handler: 0.2.6</summary>

## [0.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.5...fetch-error-handler-v0.2.6) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^3.1.1 to ^3.1.2
</details>

<details><summary>log-error: 4.2.5</summary>

## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.4...log-error-v4.2.5) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
    * @dotcom-reliability-kit/logger bumped from ^3.2.0 to ^3.2.1
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
    * @dotcom-reliability-kit/serialize-request bumped from ^3.1.0 to ^3.1.1
</details>

<details><summary>logger: 3.2.1</summary>

## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.0...logger-v3.2.1) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
</details>

<details><summary>middleware-log-errors: 4.2.5</summary>

## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.4...middleware-log-errors-v4.2.5) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
</details>

<details><summary>middleware-render-error-info: 5.1.11</summary>

## [5.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.10...middleware-render-error-info-v5.1.11) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.0 to ^3.2.1
</details>

<details><summary>opentelemetry: 2.0.15</summary>

## [2.0.15](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.14...opentelemetry-v2.0.15) (2024-11-26)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([7a58cf5](https://github.com/Financial-Times/dotcom-reliability-kit/commit/7a58cf52a83eabe601cfeb919c17b76eebab1843))
* bump @opentelemetry/exporter-metrics-otlp-proto ([0a73e88](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0a73e88a3dbca9bb3d0e5f30b0218cae8d333e6f))
* bump @opentelemetry/exporter-trace-otlp-proto from 0.54.0 to 0.54.2 ([b9686d1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b9686d130b3a483bba4b653ed5c4b044b3ee484b))
* bump @opentelemetry/instrumentation-runtime-node ([b0bd76a](https://github.com/Financial-Times/dotcom-reliability-kit/commit/b0bd76ab0e90f3200f61dc2f1cd2068de6995420))
* bump @opentelemetry/sdk-node from 0.54.0 to 0.54.2 ([015c5d8](https://github.com/Financial-Times/dotcom-reliability-kit/commit/015c5d83cd8ab75f07e7426d45f4b039ef44af5c))
* bump OpenTelemetry packages ([f9748f0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f9748f004e2604e4a67c9c8bf3e57c62d3d660d5))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.0 to ^3.3.1
    * @dotcom-reliability-kit/errors bumped from ^3.1.1 to ^3.1.2
    * @dotcom-reliability-kit/log-error bumped from ^4.2.4 to ^4.2.5
    * @dotcom-reliability-kit/logger bumped from ^3.2.0 to ^3.2.1
</details>

<details><summary>serialize-error: 3.2.1</summary>

## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.2.0...serialize-error-v3.2.1) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
</details>

<details><summary>serialize-request: 3.1.1</summary>

## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.1.0...serialize-request-v3.1.1) (2024-11-26)


### Bug Fixes

* remove npm engines pinning ([9f51dab](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9f51dab7374e05431de236445c6706dbc1fd3172))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).