### PR TITLE
fix: remove npm engines pinning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13306,8 +13305,7 @@
       "version": "3.3.0",
       "license": "MIT",
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/crash-handler": {
@@ -13318,8 +13316,7 @@
         "@dotcom-reliability-kit/log-error": "^4.2.4"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/errors": {
@@ -13327,8 +13324,7 @@
       "version": "3.1.1",
       "license": "MIT",
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/eslint-config": {
@@ -13339,8 +13335,7 @@
         "@types/eslint": "^8.56.6"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
         "eslint": ">=8.27.0"
@@ -13361,8 +13356,7 @@
         "undici": "^6.20.1"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/log-error": {
@@ -13379,8 +13373,7 @@
         "@types/express": "^5.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/logger": {
@@ -13400,8 +13393,7 @@
         "@types/lodash.clonedeep": "^4.5.9"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
         "pino-pretty": ">=7.0.0 <11.0.0"
@@ -13419,8 +13411,7 @@
         "@types/express": "^5.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/middleware-render-error-info": {
@@ -13437,8 +13428,7 @@
         "@types/express": "^5.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/middleware-render-error-info/node_modules/entities": {
@@ -13479,8 +13469,7 @@
       "version": "3.2.0",
       "license": "MIT",
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "packages/serialize-request": {
@@ -13491,8 +13480,7 @@
         "@types/express": "^5.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "resources/logos": {
@@ -13508,8 +13496,7 @@
         "@types/svgo": "^3.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x",
-        "npm": "8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       }
     },
     "resources/splunk-dashboards": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,10 @@
     "typescript": "^5.6.3"
   },
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "volta": {
-    "node": "20.10.0",
-    "npm": "10.2.5"
+    "node": "20.10.0"
   },
   "lint-staged": {
     "**/*.js": [

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: app-info\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts"

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: crash-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: errors\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: eslint-config\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: fetch-error-handler\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: log-error\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: logger\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-log-errors\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: middleware-render-error-info\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-error\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts"

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -11,8 +11,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues?q=label:\"package: serialize-request\"",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/resources/logos/package.json
+++ b/resources/logos/package.json
@@ -12,8 +12,7 @@
   "bugs": "https://github.com/Financial-Times/dotcom-reliability-kit/issues",
   "license": "MIT",
   "engines": {
-    "node": "18.x || 20.x || 22.x",
-    "npm": "8.x || 9.x || 10.x"
+    "node": "18.x || 20.x || 22.x"
   },
   "scripts": {
     "build": "./scripts/build.js"


### PR DESCRIPTION
We decided we no longer need this now that we have no use of npm 7.