### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,5 @@
   "packages/middleware-render-error-info": "5.1.11",
   "packages/serialize-error": "3.2.1",
   "packages/serialize-request": "3.1.1",
-  "packages/opentelemetry": "2.0.15"
+  "packages/opentelemetry": "2.0.16"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13495,7 +13495,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.1",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.16](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.15...opentelemetry-v2.0.16) (2025-01-14)
+
+
+### Bug Fixes
+
+* update all OpenTelemetry packages ([f62e636](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f62e636079267f2a14c5509dcdd0582d2dba6e99))
+
 ## [2.0.15](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.14...opentelemetry-v2.0.15) (2024-11-26)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.15",
+	"version": "2.0.16",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 2.0.16</summary>

## [2.0.16](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.15...opentelemetry-v2.0.16) (2025-01-14)


### Bug Fixes

* update all OpenTelemetry packages ([f62e636](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f62e636079267f2a14c5509dcdd0582d2dba6e99))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).