### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
   "packages/app-info": "3.3.1",
-  "packages/crash-handler": "4.1.11",
+  "packages/crash-handler": "4.1.12",
   "packages/errors": "3.1.2",
   "packages/eslint-config": "3.1.1",
   "packages/fetch-error-handler": "0.2.6",
-  "packages/log-error": "4.2.5",
-  "packages/logger": "3.2.1",
-  "packages/middleware-log-errors": "4.2.5",
-  "packages/middleware-render-error-info": "5.1.11",
+  "packages/log-error": "4.2.6",
+  "packages/logger": "3.2.2",
+  "packages/middleware-log-errors": "4.2.6",
+  "packages/middleware-render-error-info": "5.1.12",
   "packages/serialize-error": "3.2.1",
   "packages/serialize-request": "3.1.1",
-  "packages/opentelemetry": "2.0.16"
+  "packages/opentelemetry": "2.0.17"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13372,10 +13372,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.11",
+      "version": "4.1.12",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.5"
+        "@dotcom-reliability-kit/log-error": "^4.2.6"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -13423,11 +13423,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/logger": "^3.2.1",
+        "@dotcom-reliability-kit/logger": "^3.2.2",
         "@dotcom-reliability-kit/serialize-error": "^3.2.1",
         "@dotcom-reliability-kit/serialize-request": "^3.1.1"
       },
@@ -13440,7 +13440,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.1",
@@ -13463,10 +13463,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.5"
+        "@dotcom-reliability-kit/log-error": "^4.2.6"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.4",
@@ -13478,11 +13478,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.11",
+      "version": "5.1.12",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.5",
+        "@dotcom-reliability-kit/log-error": "^4.2.6",
         "@dotcom-reliability-kit/serialize-error": "^3.2.1",
         "entities": "^6.0.0"
       },
@@ -13495,13 +13495,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.1",
         "@dotcom-reliability-kit/errors": "^3.1.2",
-        "@dotcom-reliability-kit/log-error": "^4.2.5",
-        "@dotcom-reliability-kit/logger": "^3.2.1",
+        "@dotcom-reliability-kit/log-error": "^4.2.6",
+        "@dotcom-reliability-kit/logger": "^3.2.2",
         "@opentelemetry/auto-instrumentations-node": "^0.55.2",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.11...crash-handler-v4.1.12) (2025-01-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
+
 ## [4.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.10...crash-handler-v4.1.11) (2024-11-26)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.11",
+  "version": "4.1.12",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.5"
+    "@dotcom-reliability-kit/log-error": "^4.2.6"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.5...log-error-v4.2.6) (2025-01-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^3.2.1 to ^3.2.2
+
 ## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.4...log-error-v4.2.5) (2024-11-26)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.1",
-    "@dotcom-reliability-kit/logger": "^3.2.1",
+    "@dotcom-reliability-kit/logger": "^3.2.2",
     "@dotcom-reliability-kit/serialize-error": "^3.2.1",
     "@dotcom-reliability-kit/serialize-request": "^3.1.1"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.1...logger-v3.2.2) (2025-01-15)
+
+
+### Bug Fixes
+
+* bump pino from 9.5.0 to 9.6.0 ([d1bfac0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d1bfac02d5d527bdc126f043f3e7cba0f8dbce0b))
+
 ## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.0...logger-v3.2.1) (2024-11-26)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.5...middleware-log-errors-v4.2.6) (2025-01-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
+
 ## [4.2.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.4...middleware-log-errors-v4.2.5) (2024-11-26)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.5"
+    "@dotcom-reliability-kit/log-error": "^4.2.6"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.4",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.11...middleware-render-error-info-v5.1.12) (2025-01-15)
+
+
+### Bug Fixes
+
+* bump entities from 5.0.0 to 6.0.0 ([bb013a3](https://github.com/Financial-Times/dotcom-reliability-kit/commit/bb013a3d8c47137196fe6870b00e7a7dcda958c1))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
+
 ## [5.1.11](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.10...middleware-render-error-info-v5.1.11) (2024-11-26)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^3.3.1",
-    "@dotcom-reliability-kit/log-error": "^4.2.5",
+    "@dotcom-reliability-kit/log-error": "^4.2.6",
     "@dotcom-reliability-kit/serialize-error": "^3.2.1",
     "entities": "^6.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.17](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.16...opentelemetry-v2.0.17) (2025-01-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
+    * @dotcom-reliability-kit/logger bumped from ^3.2.1 to ^3.2.2
+
 ## [2.0.16](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.15...opentelemetry-v2.0.16) (2025-01-14)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.16",
+	"version": "2.0.17",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^3.3.1",
 		"@dotcom-reliability-kit/errors": "^3.1.2",
-		"@dotcom-reliability-kit/log-error": "^4.2.5",
-		"@dotcom-reliability-kit/logger": "^3.2.1",
+		"@dotcom-reliability-kit/log-error": "^4.2.6",
+		"@dotcom-reliability-kit/logger": "^3.2.2",
 		"@opentelemetry/auto-instrumentations-node": "^0.55.2",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 4.1.12</summary>

## [4.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.11...crash-handler-v4.1.12) (2025-01-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
</details>

<details><summary>log-error: 4.2.6</summary>

## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.5...log-error-v4.2.6) (2025-01-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^3.2.1 to ^3.2.2
</details>

<details><summary>logger: 3.2.2</summary>

## [3.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.1...logger-v3.2.2) (2025-01-15)


### Bug Fixes

* bump pino from 9.5.0 to 9.6.0 ([d1bfac0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/d1bfac02d5d527bdc126f043f3e7cba0f8dbce0b))
</details>

<details><summary>middleware-log-errors: 4.2.6</summary>

## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.5...middleware-log-errors-v4.2.6) (2025-01-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
</details>

<details><summary>middleware-render-error-info: 5.1.12</summary>

## [5.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.11...middleware-render-error-info-v5.1.12) (2025-01-15)


### Bug Fixes

* bump entities from 5.0.0 to 6.0.0 ([bb013a3](https://github.com/Financial-Times/dotcom-reliability-kit/commit/bb013a3d8c47137196fe6870b00e7a7dcda958c1))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
</details>

<details><summary>opentelemetry: 2.0.17</summary>

## [2.0.17](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.16...opentelemetry-v2.0.17) (2025-01-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.5 to ^4.2.6
    * @dotcom-reliability-kit/logger bumped from ^3.2.1 to ^3.2.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).