### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "packages/app-info": "3.3.1",
-  "packages/crash-handler": "4.1.12",
-  "packages/errors": "3.1.2",
-  "packages/eslint-config": "3.1.1",
-  "packages/fetch-error-handler": "0.2.6",
-  "packages/log-error": "4.2.6",
-  "packages/logger": "3.2.2",
-  "packages/middleware-log-errors": "4.2.6",
-  "packages/middleware-render-error-info": "5.1.12",
-  "packages/serialize-error": "3.2.1",
-  "packages/serialize-request": "3.1.1",
-  "packages/opentelemetry": "2.0.17"
+  "packages/app-info": "4.0.0",
+  "packages/crash-handler": "5.0.0",
+  "packages/errors": "4.0.0",
+  "packages/eslint-config": "4.0.0",
+  "packages/fetch-error-handler": "0.3.0",
+  "packages/log-error": "5.0.0",
+  "packages/logger": "4.0.0",
+  "packages/middleware-log-errors": "5.0.0",
+  "packages/middleware-render-error-info": "6.0.0",
+  "packages/serialize-error": "4.0.0",
+  "packages/serialize-request": "4.0.0",
+  "packages/opentelemetry": "3.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13370,7 +13370,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "3.3.1",
+      "version": "4.0.0",
       "license": "MIT",
       "engines": {
         "node": "20.x || 22.x"
@@ -13378,10 +13378,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "4.1.12",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.6"
+        "@dotcom-reliability-kit/log-error": "^5.0.0"
       },
       "engines": {
         "node": "20.x || 22.x"
@@ -13389,7 +13389,7 @@
     },
     "packages/errors": {
       "name": "@dotcom-reliability-kit/errors",
-      "version": "3.1.2",
+      "version": "4.0.0",
       "license": "MIT",
       "engines": {
         "node": "20.x || 22.x"
@@ -13397,7 +13397,7 @@
     },
     "packages/eslint-config": {
       "name": "@dotcom-reliability-kit/eslint-config",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^8.56.6"
@@ -13411,10 +13411,10 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^3.1.2"
+        "@dotcom-reliability-kit/errors": "^4.0.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -13429,13 +13429,13 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "4.2.6",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/logger": "^3.2.2",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
-        "@dotcom-reliability-kit/serialize-request": "^3.1.1"
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/logger": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^4.0.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0"
@@ -13446,11 +13446,11 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "3.2.2",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.6.0"
       },
@@ -13469,10 +13469,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "4.2.6",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^4.2.6"
+        "@dotcom-reliability-kit/log-error": "^5.0.0"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.9.4",
@@ -13484,12 +13484,12 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "5.1.12",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/log-error": "^4.2.6",
-        "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/log-error": "^5.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "entities": "^6.0.0"
       },
       "devDependencies": {
@@ -13501,13 +13501,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "2.0.17",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^3.3.1",
-        "@dotcom-reliability-kit/errors": "^3.1.2",
-        "@dotcom-reliability-kit/log-error": "^4.2.6",
-        "@dotcom-reliability-kit/logger": "^3.2.2",
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/errors": "^4.0.0",
+        "@dotcom-reliability-kit/log-error": "^5.0.0",
+        "@dotcom-reliability-kit/logger": "^4.0.0",
         "@opentelemetry/auto-instrumentations-node": "^0.55.2",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",
@@ -13531,7 +13531,7 @@
     },
     "packages/serialize-error": {
       "name": "@dotcom-reliability-kit/serialize-error",
-      "version": "3.2.1",
+      "version": "4.0.0",
       "license": "MIT",
       "engines": {
         "node": "20.x || 22.x"
@@ -13539,7 +13539,7 @@
     },
     "packages/serialize-request": {
       "name": "@dotcom-reliability-kit/serialize-request",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0"

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.1...app-info-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
 ## [3.3.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.0...app-info-v3.3.1) (2024-11-26)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "3.3.1",
+  "version": "4.0.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.12...crash-handler-v5.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
+
 ## [4.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.11...crash-handler-v4.1.12) (2025-01-15)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "4.1.12",
+  "version": "5.0.0",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.6"
+    "@dotcom-reliability-kit/log-error": "^5.0.0"
   }
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.2...errors-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
 ## [3.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.1...errors-v3.1.2) (2024-11-26)
 
 

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/errors",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "A suite of error classes which help you throw the most appropriate error in any situation",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.1.1...eslint-config-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
 ## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.1.0...eslint-config-v3.1.1) (2024-11-26)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/eslint-config",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production",
   "repository": {
     "type": "git",

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.6...fetch-error-handler-v0.3.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/errors bumped from ^3.1.2 to ^4.0.0
+
 ## [0.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.5...fetch-error-handler-v0.2.6) (2024-11-26)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/errors": "^3.1.2"
+    "@dotcom-reliability-kit/errors": "^4.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.6...log-error-v5.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
+    * @dotcom-reliability-kit/logger bumped from ^3.2.2 to ^4.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
+    * @dotcom-reliability-kit/serialize-request bumped from ^3.1.1 to ^4.0.0
+
 ## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.5...log-error-v4.2.6) (2025-01-15)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "4.2.6",
+  "version": "5.0.0",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,10 +16,10 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.1",
-    "@dotcom-reliability-kit/logger": "^3.2.2",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
-    "@dotcom-reliability-kit/serialize-request": "^3.1.1"
+    "@dotcom-reliability-kit/app-info": "^4.0.0",
+    "@dotcom-reliability-kit/logger": "^4.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+    "@dotcom-reliability-kit/serialize-request": "^4.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.2...logger-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
+
 ## [3.2.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.1...logger-v3.2.2) (2025-01-15)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.1",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+    "@dotcom-reliability-kit/app-info": "^4.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.6.0"
   },

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.6...middleware-log-errors-v5.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
+
 ## [4.2.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.5...middleware-log-errors-v4.2.6) (2025-01-15)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "4.2.6",
+  "version": "5.0.0",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^4.2.6"
+    "@dotcom-reliability-kit/log-error": "^5.0.0"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.9.4",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [6.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.12...middleware-render-error-info-v6.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
+    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
+
 ## [5.1.12](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.11...middleware-render-error-info-v5.1.12) (2025-01-15)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "5.1.12",
+  "version": "6.0.0",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,9 +16,9 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^3.3.1",
-    "@dotcom-reliability-kit/log-error": "^4.2.6",
-    "@dotcom-reliability-kit/serialize-error": "^3.2.1",
+    "@dotcom-reliability-kit/app-info": "^4.0.0",
+    "@dotcom-reliability-kit/log-error": "^5.0.0",
+    "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "entities": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.17...opentelemetry-v3.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
+    * @dotcom-reliability-kit/errors bumped from ^3.1.2 to ^4.0.0
+    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
+    * @dotcom-reliability-kit/logger bumped from ^3.2.2 to ^4.0.0
+
 ## [2.0.17](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.16...opentelemetry-v2.0.17) (2025-01-15)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "2.0.17",
+	"version": "3.0.0",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,10 +17,10 @@
 	"main": "lib/index.js",
 	"types": "types/index.d.ts",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^3.3.1",
-		"@dotcom-reliability-kit/errors": "^3.1.2",
-		"@dotcom-reliability-kit/log-error": "^4.2.6",
-		"@dotcom-reliability-kit/logger": "^3.2.2",
+		"@dotcom-reliability-kit/app-info": "^4.0.0",
+		"@dotcom-reliability-kit/errors": "^4.0.0",
+		"@dotcom-reliability-kit/log-error": "^5.0.0",
+		"@dotcom-reliability-kit/logger": "^4.0.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.55.2",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",

--- a/packages/serialize-error/CHANGELOG.md
+++ b/packages/serialize-error/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.2.1...serialize-error-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
 ## [3.2.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.2.0...serialize-error-v3.2.1) (2024-11-26)
 
 

--- a/packages/serialize-error/package.json
+++ b/packages/serialize-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-error",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "description": "A utility function to serialize an error object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",

--- a/packages/serialize-request/CHANGELOG.md
+++ b/packages/serialize-request/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.1.1...serialize-request-v4.0.0) (2025-01-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop support for Node.js 18
+
+### Documentation Changes
+
+* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))
+
+
+### Miscellaneous
+
+* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
+
 ## [3.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.1.0...serialize-request-v3.1.1) (2024-11-26)
 
 

--- a/packages/serialize-request/package.json
+++ b/packages/serialize-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/serialize-request",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "A utility function to serialize a request object in a way that's friendly to loggers, view engines, and converting to JSON",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.1...app-info-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
</details>

<details><summary>crash-handler: 5.0.0</summary>

## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.12...crash-handler-v5.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
</details>

<details><summary>errors: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/errors-v3.1.2...errors-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
</details>

<details><summary>eslint-config: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/eslint-config-v3.1.1...eslint-config-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
</details>

<details><summary>fetch-error-handler: 0.3.0</summary>

## [0.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.6...fetch-error-handler-v0.3.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/errors bumped from ^3.1.2 to ^4.0.0
</details>

<details><summary>log-error: 5.0.0</summary>

## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.6...log-error-v5.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
    * @dotcom-reliability-kit/logger bumped from ^3.2.2 to ^4.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
    * @dotcom-reliability-kit/serialize-request bumped from ^3.1.1 to ^4.0.0
</details>

<details><summary>logger: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.2...logger-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
</details>

<details><summary>middleware-log-errors: 5.0.0</summary>

## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.6...middleware-log-errors-v5.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
</details>

<details><summary>middleware-render-error-info: 6.0.0</summary>

## [6.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.12...middleware-render-error-info-v6.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
    * @dotcom-reliability-kit/serialize-error bumped from ^3.2.1 to ^4.0.0
</details>

<details><summary>opentelemetry: 3.0.0</summary>

## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.17...opentelemetry-v3.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^3.3.1 to ^4.0.0
    * @dotcom-reliability-kit/errors bumped from ^3.1.2 to ^4.0.0
    * @dotcom-reliability-kit/log-error bumped from ^4.2.6 to ^5.0.0
    * @dotcom-reliability-kit/logger bumped from ^3.2.2 to ^4.0.0
</details>

<details><summary>serialize-error: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-error-v3.2.1...serialize-error-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
</details>

<details><summary>serialize-request: 4.0.0</summary>

## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/serialize-request-v3.1.1...serialize-request-v4.0.0) (2025-01-20)


### ⚠ BREAKING CHANGES

* drop support for Node.js 18

### Documentation Changes

* add migration guides for new major versions ([610c171](https://github.com/Financial-Times/dotcom-reliability-kit/commit/610c17189f0564051b793a0d590a6c9721b41a53))


### Miscellaneous

* drop support for Node.js 18 ([3efb889](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3efb8896bc49424d3745753e0a57b06c6ede8165))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).