### PR TITLE
Mark fetch-error-handler as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ We maintain documentation in this repo:
     * **[@dotcom-reliability-kit/eslint-config](./packages/eslint-config/#readme):**<br/>
     A linting config, specifically focussed on enhancing code quality and proactively catching errors/bugs before they make it into production.
 
+    * **[@dotcom-reliability-kit/fetch-error-handler](./packages/fetch-error-handler/#readme):**<br/>
+      Properly handle fetch errors and avoid a lot of boilerplate in your app.
+
     * **[@dotcom-reliability-kit/log-error](./packages/log-error/#readme):**<br/>
       A method to consistently log error object with optional request information
 

--- a/packages/fetch-error-handler/README.md
+++ b/packages/fetch-error-handler/README.md
@@ -3,9 +3,6 @@
 
 Properly handle fetch errors and avoid a lot of boilerplate in your app. This module is part of [FT.com Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit#readme).
 
-> [!WARNING]<br />
-> This package is in beta and hasn't been tested extensively in production yet. Feel free to use, and any feedback is greatly appreciated.
-
   * [Usage](#usage)
     * [Wrap the fetch function](#wrap-the-fetch-function)
     * [Handle errors with `.then`](#handle-errors-with-then)


### PR DESCRIPTION
This library has been used in production for months and is now serving as a replacement for the deprecated `n-fetch` and `n-eager-fetch` libraries.

There have been no reported issues, it's installed in 9 production systems (including content pipeline), and we're seeing ~2m errors per week in Splunk that were successfully handled by this library:

```
index IN (heroku, aws_cloudwatch)
(error.code=FETCH_* OR error.cause.code=FETCH_*)
```