### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,7 +3,7 @@
   "packages/crash-handler": "5.0.0",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
-  "packages/fetch-error-handler": "0.3.0",
+  "packages/fetch-error-handler": "1.0.0",
   "packages/log-error": "5.0.0",
   "packages/logger": "4.0.0",
   "packages/middleware-log-errors": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13411,7 +13411,7 @@
     },
     "packages/fetch-error-handler": {
       "name": "@dotcom-reliability-kit/fetch-error-handler",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^4.0.0"

--- a/packages/fetch-error-handler/CHANGELOG.md
+++ b/packages/fetch-error-handler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.3.0...fetch-error-handler-v1.0.0) (2025-01-30)
+
+
+### Miscellaneous
+
+* mark fetch-error-handler as stable ([f1d50ce](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f1d50ce0cd37c1517ddeed84dd6a55cc59935ba2))
+
 ## [0.3.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.2.6...fetch-error-handler-v0.3.0) (2025-01-20)
 
 

--- a/packages/fetch-error-handler/package.json
+++ b/packages/fetch-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/fetch-error-handler",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Properly handle fetch errors and avoid a lot of boilerplate in your app.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>fetch-error-handler: 1.0.0</summary>

## [1.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/fetch-error-handler-v0.3.0...fetch-error-handler-v1.0.0) (2025-01-30)


### Miscellaneous

* mark fetch-error-handler as stable ([f1d50ce](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f1d50ce0cd37c1517ddeed84dd6a55cc59935ba2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).