### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,5 @@
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
   "packages/opentelemetry": "3.0.0",
-  "packages/middleware-allow-request-methods": "0.0.0"
+  "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13607,7 +13607,7 @@
     },
     "packages/middleware-allow-request-methods": {
       "name": "@dotcom-reliability-kit/middleware-allow-request-methods",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": "20.x || 22.x"

--- a/packages/middleware-allow-request-methods/CHANGELOG.md
+++ b/packages/middleware-allow-request-methods/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2025-02-11)
+
+
+### Features
+
+* manage bad requests with 'allow request methods' package ([678f377](https://github.com/Financial-Times/dotcom-reliability-kit/commit/678f37741b1e1d1037a6e772dd1fed8aaf84f300))

--- a/packages/middleware-allow-request-methods/package.json
+++ b/packages/middleware-allow-request-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-allow-request-methods",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Express middleware that returns 405 (rather than 404) for disallowed request methods",
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>middleware-allow-request-methods: 1.0.0</summary>

## 1.0.0 (2025-02-11)


### Features

* manage bad requests with 'allow request methods' package ([678f377](https://github.com/Financial-Times/dotcom-reliability-kit/commit/678f37741b1e1d1037a6e772dd1fed8aaf84f300))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).