### PR TITLE
fix: update all OpenTelemetry packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,9 +2025,10 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.5.tgz",
-      "integrity": "sha512-d3iiHxdpg5+ZcJ6jnDSOT8Z0O0VMVGy34jAnYLUX8yd36b1qn8f1TwOA/Lc7TsOh03IkPJ38eGI5qD2EjNkoEA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
+      "integrity": "sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2040,6 +2041,7 @@
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
       "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -3015,6 +3017,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -3328,22 +3331,23 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.55.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.55.2.tgz",
-      "integrity": "sha512-m6Wt1vlDYocFX4+m6Y3df1kAXRjYrY57Y8O0VjDRTP+kSHdjH/52/2KmlWGhk2NiDasOt2Pb+DZoMqkQLezZew==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.56.0.tgz",
+      "integrity": "sha512-d1X3DQY0+VmhNUir/3U3JO6Uh0FOSm8G91zsPzVVKc6NGDwmHP6Dn7PMVH70O6FZ0yErzlHqRx8vkNiAsTWt5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/instrumentation-amqplib": "^0.46.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.50.1",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.50.2",
         "@opentelemetry/instrumentation-aws-sdk": "^0.49.0",
         "@opentelemetry/instrumentation-bunyan": "^0.45.0",
         "@opentelemetry/instrumentation-cassandra-driver": "^0.45.0",
         "@opentelemetry/instrumentation-connect": "^0.43.0",
-        "@opentelemetry/instrumentation-cucumber": "^0.13.0",
+        "@opentelemetry/instrumentation-cucumber": "^0.14.0",
         "@opentelemetry/instrumentation-dataloader": "^0.16.0",
         "@opentelemetry/instrumentation-dns": "^0.43.0",
         "@opentelemetry/instrumentation-express": "^0.47.0",
-        "@opentelemetry/instrumentation-fastify": "^0.44.0",
+        "@opentelemetry/instrumentation-fastify": "^0.44.1",
         "@opentelemetry/instrumentation-fs": "^0.19.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.43.0",
         "@opentelemetry/instrumentation-graphql": "^0.47.0",
@@ -3359,10 +3363,10 @@
         "@opentelemetry/instrumentation-mongodb": "^0.51.0",
         "@opentelemetry/instrumentation-mongoose": "^0.46.0",
         "@opentelemetry/instrumentation-mysql": "^0.45.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.45.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.45.1",
         "@opentelemetry/instrumentation-nestjs-core": "^0.44.0",
         "@opentelemetry/instrumentation-net": "^0.43.0",
-        "@opentelemetry/instrumentation-pg": "^0.50.0",
+        "@opentelemetry/instrumentation-pg": "^0.51.0",
         "@opentelemetry/instrumentation-pino": "^0.46.0",
         "@opentelemetry/instrumentation-redis": "^0.46.0",
         "@opentelemetry/instrumentation-redis-4": "^0.46.0",
@@ -3372,11 +3376,11 @@
         "@opentelemetry/instrumentation-tedious": "^0.18.0",
         "@opentelemetry/instrumentation-undici": "^0.10.0",
         "@opentelemetry/instrumentation-winston": "^0.44.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.29.7",
-        "@opentelemetry/resource-detector-aws": "^1.10.0",
-        "@opentelemetry/resource-detector-azure": "^0.5.0",
-        "@opentelemetry/resource-detector-container": "^0.5.3",
-        "@opentelemetry/resource-detector-gcp": "^0.32.0",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.30.0",
+        "@opentelemetry/resource-detector-aws": "^1.11.0",
+        "@opentelemetry/resource-detector-azure": "^0.6.0",
+        "@opentelemetry/resource-detector-container": "^0.6.0",
+        "@opentelemetry/resource-detector-gcp": "^0.33.0",
         "@opentelemetry/resources": "^1.24.0",
         "@opentelemetry/sdk-node": "^0.57.0"
       },
@@ -3421,15 +3425,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.57.1.tgz",
-      "integrity": "sha512-RL8qmZH1H/H7Hbj0xKxF0Gg8kX9ic0aoMS3Kv5kj864lWxlpuR5YtGGn5OjGYwCmq6nYbsNy257fFp1U63pABw==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.57.2.tgz",
+      "integrity": "sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
-        "@opentelemetry/sdk-logs": "0.57.1"
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
+        "@opentelemetry/sdk-logs": "0.57.2"
       },
       "engines": {
         "node": ">=14"
@@ -3439,15 +3445,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.1.tgz",
-      "integrity": "sha512-u8Cr6yDX57/n89aSJwAQNHQIYodcl6o8jTcaPKNktMvNfd7ny3R7aE7GKBC5Wg0zejP9heBgyN0OGwrPhptx7A==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.2.tgz",
+      "integrity": "sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
-        "@opentelemetry/sdk-logs": "0.57.1"
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
+        "@opentelemetry/sdk-logs": "0.57.2"
       },
       "engines": {
         "node": ">=14"
@@ -3456,17 +3463,30 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.57.1.tgz",
-      "integrity": "sha512-WtR85NHdIVrIFfsK5bwx7miGG5WzOsuT4BNmuZ3EfZ0veowkrgoUSynsNnXW1YFXL6QhPbScjUfeTjnnV9bnIQ==",
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.57.2.tgz",
+      "integrity": "sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
         "@opentelemetry/sdk-trace-base": "1.30.1"
       },
       "engines": {
@@ -3476,17 +3496,30 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.57.1.tgz",
-      "integrity": "sha512-8B7k5q4AUldbfvubcHApg1XQaio/cO/VUWsM5PSaRP2fsjGNwbn2ih04J3gLD+AmgslvyuDcA2SZiDXEKwAxtQ==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.57.2.tgz",
+      "integrity": "sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.57.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-metrics": "1.30.1"
       },
@@ -3498,13 +3531,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.1.tgz",
-      "integrity": "sha512-jpKYVZY7fdwTdy+eAy/Mp9DZMaQpj7caMzlo3QqQDSJx5FZEY6zWzgcKvDvF6h+gdHE7LgUjaPOvJVUs354jJg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.2.tgz",
+      "integrity": "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-metrics": "1.30.1"
       },
@@ -3516,14 +3550,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.57.1.tgz",
-      "integrity": "sha512-53AJmYJr8lypU6kAQT1/FVKR2QKcxRp4Gd54L3oF9hc2fw/FtvVfXV+PelB+qL318PqUlVjVtDOa4SQ5tAREfA==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.57.2.tgz",
+      "integrity": "sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.57.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-metrics": "1.30.1"
       },
@@ -3535,9 +3570,10 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.1.tgz",
-      "integrity": "sha512-lwwOQzyvhzioGCYmIh7mXo+RLSoEVhuO0dFzWeEiQhFkjSUOPgKQKNTgYtl2KO1L7XIbHp5LIgn4nZrYx191Rg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.2.tgz",
+      "integrity": "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -3551,14 +3587,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.1.tgz",
-      "integrity": "sha512-a9/4w2nyfehxMA64VGcZ4OXePGLjTz9H/dvqbOzVmIBZe9R6bkOeT68M9WoxAEdUZcJDK8XS3EloJId1rjPrag==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
+      "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1"
       },
@@ -3570,13 +3608,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.1.tgz",
-      "integrity": "sha512-43dLEjlf6JGxpVt9RaRlJAvjHG1wGsbAuNd67RIDy/95zfKk2aNovtiGUgFdS/kcvgvS90upIUbgn0xUd9JjMg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.2.tgz",
+      "integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1"
       },
@@ -3588,13 +3627,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.57.1.tgz",
-      "integrity": "sha512-REN6UZTNoP3Tb7vuCEy+yAjNmJGi7MLqCMdDoUSbsWGwpopxtSnsbkfVfLPsZAsumWkcq0p8p6lYvqUBDhUqIA==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.57.2.tgz",
+      "integrity": "sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1"
       },
@@ -3634,6 +3674,7 @@
       "version": "0.35.5",
       "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.5.tgz",
       "integrity": "sha512-Zf9Cjl7H6JalspnK5KD1+LLKSVecSinouVctNmUxRy+WP+20KwHq+qg4hADllkEmJ99MZByLLmEmzrr7s92V6g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "systeminformation": "5.23.8"
       },
@@ -3680,9 +3721,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.50.1.tgz",
-      "integrity": "sha512-Kk+9tdmsLeX4QeOvL4A2gSOfEqIKVMLbVO76CbTjmlIcL9rQjHefwxp1m62YO/nwujuZ0JKTJbz264e8foTMeQ==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.50.2.tgz",
+      "integrity": "sha512-jz1a7t2q0SsiztEMyZjFLEFC4pOQ+1C588gWzl878k9Qr6TI1Wu3sa7/dikxJmeRIETcOTUilaa2Otxh6HUVlA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -3761,9 +3803,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.13.0.tgz",
-      "integrity": "sha512-ZBswBKONU2g7mhjEKF4vkTXxezq16QdvGaD5W4o01/t5KzvCZGQ6hYPsB34miJIj/hh6UrFLRDAjqb7nur5I3Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.14.0.tgz",
+      "integrity": "sha512-i/GlurL1IM+CnbmItW8kx59YxAp0wu/YQkzQQRU/YGmUjym5g+/dOVjnk/K46lAU49Nn1XyFd7S3ZNf83PHL2Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
@@ -3820,9 +3863,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.0.tgz",
-      "integrity": "sha512-mO2iyzyrk8GibUOSW8ffvFeau/frFONpSzDq3sEPbsHXIbHOXiM6VX3Q7oydnwaAxHDmxClOCRuYDNbXSO1rSA==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.1.tgz",
+      "integrity": "sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.57.0",
@@ -4083,9 +4127,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
-      "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.1.tgz",
+      "integrity": "sha512-9R/vxEc02vlSqyQSmXRTvFMZVht8vgSJokKhiWA3z8Idu0mmdKFKeHiuW5yRGxM/WOi+7DWqQfYM7zw/cJc3sA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -4129,13 +4174,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
-      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.0.tgz",
+      "integrity": "sha512-/NStIcUWUofc11dL7tSgMk25NqvhtbHDCncgm+yc4iJF8Ste2Q/lwUitjfxqj4qWM280uFmBEtcmtMMjbjRU7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -4230,6 +4276,7 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.12.1.tgz",
       "integrity": "sha512-l+BnkJVAN3bFugDMW9IxGwtdlA6HxLYDkP/YdEJ8i5g7vbS8upxTutyCQVVg8eSL4JABN3LRrFmMekUXdpyJLg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.57.0"
       },
@@ -4302,12 +4349,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.1.tgz",
-      "integrity": "sha512-GNBJAEYfeiYJQ3O2dvXgiNZ/qjWrBxSb1L1s7iV/jKBRGMN3Nv+miTk2SLeEobF5E5ZK4rVcHKlBZ71bPVIv/g==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-transformer": "0.57.1"
+        "@opentelemetry/otlp-transformer": "0.57.2"
       },
       "engines": {
         "node": ">=14"
@@ -4317,14 +4365,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.1.tgz",
-      "integrity": "sha512-wWflmkDhH/3wf6yEqPmzmqA6r+A8+LQABfIVZC0jDGtWVJj6eCWcGHU41UxupMbbsgjZRLYtWDilaCHOjmR7gg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1"
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2"
       },
       "engines": {
         "node": ">=14"
@@ -4334,14 +4383,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.1.tgz",
-      "integrity": "sha512-EX67y+ukNNfFrOLyjYGw8AMy0JPIlEX1dW60SGUNZWW2hSQyyolX7EqFuHP5LtXLjJHNfzx5SMBVQ3owaQCNDw==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
         "@opentelemetry/sdk-metrics": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
         "protobufjs": "^7.3.0"
@@ -4351,6 +4401,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
@@ -4401,9 +4463,10 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.29.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.7.tgz",
-      "integrity": "sha512-PExUl/R+reSQI6Y/eNtgAsk6RHk1ElYSzOa8/FHfdc/nLmx9sqMasBEpLMkETkzDP7t27ORuXe4F9vwkV2uwwg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.30.0.tgz",
+      "integrity": "sha512-CniMuVcJENb7e6ljXC8BuE8xyHKV6kjHjFzAjbeK7BIq2JSPOqfvC+jjhUYnnSGFnDyoZxJCIbt6XIdwPWRPhg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
@@ -4417,9 +4480,10 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.10.0.tgz",
-      "integrity": "sha512-cTF2R6r+m4/vXEZwiAeoIZ3XOPmtQpGrMY4mSltshwKYhZwdJVJOC6l/MWm4cF7hB9+Hp/VRBjJiNw7OgCLbOg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.11.0.tgz",
+      "integrity": "sha512-j7qQ75enAJrlSPkPowasScuukZ2ffFG659rhxOpUM4dBe/O8Jpq+dy4pIdFtjWKkM9i7LgisdUt/GW7wGIWoEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
@@ -4433,9 +4497,10 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-azure": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.5.0.tgz",
-      "integrity": "sha512-FKcSmAKBKTD04b0CVQxY+H32Y0sWCUD9U8v1BYXStmwiS9DfQ5Lqr73qcmXvKIs8HXZtxYfHzXZY+BgcPTFKww==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.6.0.tgz",
+      "integrity": "sha512-cQbR/x9IhCYk47GWt4uC1G5yQN8JJ02Ec8uT38fj7uIXRbAARulwGr7Ax0dUo0eAtXEKQ+fXdzkLR1Am8cw4mg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.25.1",
         "@opentelemetry/resources": "^1.10.1",
@@ -4449,9 +4514,10 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.5.3.tgz",
-      "integrity": "sha512-x5DxWu+ZALBuFpxwO2viv9ktH4Y3Gk9LaYKn2U8J+aeD412iy/OcGLPbQ76Px7pQ8qaJ5rnjcevBOHYT4aA+zQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.6.0.tgz",
+      "integrity": "sha512-HxOzOsGlIjAbnTjwRBWQOsjrQIZ4NnQaaBc6noO8fW0v9ahyRxzwDFVr/3X1kSYLnpr2RGeWmMGDX6VcHECsLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
@@ -4465,9 +4531,10 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.32.0.tgz",
-      "integrity": "sha512-+WdWSG4sZAfsk5DvRj/OUmatsHc+7Rdz8xdmxQdr1jpfUWjcKwOkGA4rondIf2ou/qPLOeYCs6hLLexsRdZaUw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.33.0.tgz",
+      "integrity": "sha512-y368hq2UM6j42Py7xlR4rTfl+wC4CdGNGT38nqW+6BwGTQso0NC/GeifcwqorEKs/JWU9azA6XNDyUBNEjFpGA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
@@ -4505,11 +4572,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.1.tgz",
-      "integrity": "sha512-jGdObb/BGWu6Peo3cL3skx/Rl1Ak/wDDO3vpPrrThGbqE7isvkCsX6uE+OAt8Ayjm9YC8UGkohWbLR09JmM0FA==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1"
       },
@@ -4518,6 +4586,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
@@ -4536,26 +4616,27 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.57.1.tgz",
-      "integrity": "sha512-0i25YQCpNiE1RDiaZ6ECO3Hgd6DIJeyHyA2AY9C4szMdZV5cM2m8/nrwK6fyNZdOEjRd54D/FkyP3aqZVIPGvg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.57.2.tgz",
+      "integrity": "sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.57.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.57.1",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.57.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.57.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.57.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.57.1",
-        "@opentelemetry/exporter-prometheus": "0.57.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.57.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.57.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.57.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.57.2",
+        "@opentelemetry/exporter-logs-otlp-http": "0.57.2",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.57.2",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.57.2",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2",
+        "@opentelemetry/exporter-prometheus": "0.57.2",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.57.2",
+        "@opentelemetry/exporter-trace-otlp-http": "0.57.2",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.57.2",
         "@opentelemetry/exporter-zipkin": "1.30.1",
-        "@opentelemetry/instrumentation": "0.57.1",
+        "@opentelemetry/instrumentation": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
         "@opentelemetry/sdk-metrics": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
         "@opentelemetry/sdk-trace-node": "1.30.1",
@@ -4566,6 +4647,38 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
@@ -4620,9 +4733,10 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+      "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -4631,6 +4745,7 @@
       "version": "0.40.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
       "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.1.0"
       },
@@ -4665,27 +4780,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -4694,27 +4814,32 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5424,7 +5549,8 @@
     "node_modules/@types/aws-lambda": {
       "version": "8.10.143",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.143.tgz",
-      "integrity": "sha512-u5vzlcR14ge/4pMTTMDQr3MF0wEe38B2F9o84uC4F43vN5DGTy63npRrB6jQhyt+C0lGv4ZfiRcRkqJoZuPnmg=="
+      "integrity": "sha512-u5vzlcR14ge/4pMTTMDQr3MF0wEe38B2F9o84uC4F43vN5DGTy63npRrB6jQhyt+C0lGv4ZfiRcRkqJoZuPnmg==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.2",
@@ -5665,6 +5791,7 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
       "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -5675,6 +5802,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
       "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
       }
@@ -6158,6 +6286,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -7863,7 +7992,8 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -8176,6 +8306,7 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -8188,11 +8319,13 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
-      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
         "json-bigint": "^1.0.0"
       },
       "engines": {
@@ -8365,6 +8498,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -9615,6 +9757,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -10245,9 +10388,10 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
-      "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -11007,19 +11151,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
-      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.1.tgz",
+      "integrity": "sha512-gjTHWGYWsEgy9MsY0Gp6ZJxV24IjDqdpTW7Eh0x+WfJLFsm/TJx1MzL6T0D88mBvkpxotCQ6TwW6N+Kko7lhgQ==",
+      "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -11364,6 +11511,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11372,6 +11520,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11380,6 +11529,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11388,6 +11538,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -11476,6 +11627,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -13408,6 +13560,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
@@ -13656,25 +13809,17 @@
         "@dotcom-reliability-kit/errors": "^4.0.0",
         "@dotcom-reliability-kit/log-error": "^5.0.0",
         "@dotcom-reliability-kit/logger": "^4.0.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.55.2",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",
+        "@opentelemetry/auto-instrumentations-node": "^0.56.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.57.2",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.57.2",
         "@opentelemetry/host-metrics": "^0.35.5",
         "@opentelemetry/instrumentation-runtime-node": "^0.12.1",
-        "@opentelemetry/sdk-node": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.28.0"
+        "@opentelemetry/sdk-node": "^0.57.2",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
       },
       "engines": {
         "node": "20.x || 22.x",
         "npm": "8.x || 9.x || 10.x"
-      }
-    },
-    "packages/opentelemetry/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/serialize-error": {

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -21,12 +21,12 @@
 		"@dotcom-reliability-kit/errors": "^4.0.0",
 		"@dotcom-reliability-kit/log-error": "^5.0.0",
 		"@dotcom-reliability-kit/logger": "^4.0.0",
-		"@opentelemetry/auto-instrumentations-node": "^0.55.2",
-		"@opentelemetry/exporter-metrics-otlp-proto": "^0.57.1",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.57.1",
+		"@opentelemetry/auto-instrumentations-node": "^0.56.0",
+		"@opentelemetry/exporter-metrics-otlp-proto": "^0.57.2",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.57.2",
 		"@opentelemetry/host-metrics": "^0.35.5",
 		"@opentelemetry/instrumentation-runtime-node": "^0.12.1",
-		"@opentelemetry/sdk-node": "^0.57.1",
-		"@opentelemetry/semantic-conventions": "^1.28.0"
+		"@opentelemetry/sdk-node": "^0.57.2",
+		"@opentelemetry/semantic-conventions": "^1.30.0"
 	}
 }


### PR DESCRIPTION
There's a small breaking change, turning of Fastify instrumentations by default, however I checked and nothing is using this.