### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,6 +10,6 @@
   "packages/middleware-render-error-info": "6.0.0",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.0",
+  "packages/opentelemetry": "3.0.1",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13806,7 +13806,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.0.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.0...opentelemetry-v3.0.1) (2025-02-19)
+
+
+### Bug Fixes
+
+* update all OpenTelemetry packages ([40f5f4b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/40f5f4b1019498b6aac1a75d69e3c3b0bb8a90e5))
+
 ## [3.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v2.0.17...opentelemetry-v3.0.0) (2025-01-20)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 3.0.1</summary>

## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.0...opentelemetry-v3.0.1) (2025-02-19)


### Bug Fixes

* update all OpenTelemetry packages ([40f5f4b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/40f5f4b1019498b6aac1a75d69e3c3b0bb8a90e5))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).