### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,6 +10,6 @@
   "packages/middleware-render-error-info": "6.0.0",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.1",
+  "packages/opentelemetry": "3.0.2",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13846,7 +13846,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.0.0",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.1...opentelemetry-v3.0.2) (2025-03-05)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([0de44ba](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0de44badb861b57684fdd6aa4eca9dd4ca2b75cb))
+* bump @opentelemetry/instrumentation-runtime-node ([05a7060](https://github.com/Financial-Times/dotcom-reliability-kit/commit/05a706042bd85df08add8bd4e85a73918ad4e15c))
+
 ## [3.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.0...opentelemetry-v3.0.1) (2025-02-19)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>opentelemetry: 3.0.2</summary>

## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.1...opentelemetry-v3.0.2) (2025-03-05)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([0de44ba](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0de44badb861b57684fdd6aa4eca9dd4ca2b75cb))
* bump @opentelemetry/instrumentation-runtime-node ([05a7060](https://github.com/Financial-Times/dotcom-reliability-kit/commit/05a706042bd85df08add8bd4e85a73918ad4e15c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).