### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
-  "packages/app-info": "4.0.0",
-  "packages/crash-handler": "5.0.0",
+  "packages/app-info": "4.1.0",
+  "packages/crash-handler": "5.0.1",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
   "packages/fetch-error-handler": "1.0.0",
-  "packages/log-error": "5.0.0",
-  "packages/logger": "4.0.0",
-  "packages/middleware-log-errors": "5.0.0",
-  "packages/middleware-render-error-info": "6.0.0",
+  "packages/log-error": "5.0.1",
+  "packages/logger": "4.0.1",
+  "packages/middleware-log-errors": "5.0.1",
+  "packages/middleware-render-error-info": "6.0.1",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.2",
+  "packages/opentelemetry": "3.0.3",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13625,7 +13625,7 @@
     },
     "packages/app-info": {
       "name": "@dotcom-reliability-kit/app-info",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "engines": {
         "node": "20.x || 22.x"
@@ -13633,10 +13633,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.0"
+        "@dotcom-reliability-kit/log-error": "^5.0.1"
       },
       "engines": {
         "node": "20.x || 22.x"
@@ -13684,11 +13684,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^4.0.0",
-        "@dotcom-reliability-kit/logger": "^4.0.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
+        "@dotcom-reliability-kit/logger": "^4.0.1",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "@dotcom-reliability-kit/serialize-request": "^4.0.0"
       },
@@ -13701,10 +13701,10 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
         "pino": "^9.6.0"
@@ -13732,10 +13732,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.0"
+        "@dotcom-reliability-kit/log-error": "^5.0.1"
       },
       "devDependencies": {
         "@financial-times/n-express": "^31.10.0",
@@ -13747,11 +13747,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^4.0.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
+        "@dotcom-reliability-kit/log-error": "^5.0.1",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "entities": "^6.0.0"
       },
@@ -13764,13 +13764,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/app-info": "^4.1.0",
         "@dotcom-reliability-kit/errors": "^4.0.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.0",
-        "@dotcom-reliability-kit/logger": "^4.0.0",
+        "@dotcom-reliability-kit/log-error": "^5.0.1",
+        "@dotcom-reliability-kit/logger": "^4.0.1",
         "@opentelemetry/auto-instrumentations-node": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",

--- a/packages/app-info/CHANGELOG.md
+++ b/packages/app-info/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v4.0.0...app-info-v4.1.0) (2025-03-25)
+
+
+### Features
+
+* set cloud provider to AWS for Hako apps ([70c4f94](https://github.com/Financial-Times/dotcom-reliability-kit/commit/70c4f947f83361d02cf5b6728a78fbe6d2ec4659))
+
 ## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v3.3.1...app-info-v4.0.0) (2025-01-20)
 
 

--- a/packages/app-info/package.json
+++ b/packages/app-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/app-info",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A utility to get application info in a consistent way.",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.0...crash-handler-v5.0.1) (2025-03-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
+
 ## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v4.1.12...crash-handler-v5.0.0) (2025-01-20)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.0"
+    "@dotcom-reliability-kit/log-error": "^5.0.1"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.0...log-error-v5.0.1) (2025-03-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
+    * @dotcom-reliability-kit/logger bumped from ^4.0.0 to ^4.0.1
+
 ## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v4.2.6...log-error-v5.0.0) (2025-01-20)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^4.0.0",
-    "@dotcom-reliability-kit/logger": "^4.0.0",
+    "@dotcom-reliability-kit/app-info": "^4.1.0",
+    "@dotcom-reliability-kit/logger": "^4.0.1",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "@dotcom-reliability-kit/serialize-request": "^4.0.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.0...logger-v4.0.1) (2025-03-25)
+
+
+### Bug Fixes
+
+* disable log prettification on AWS ([f6d5804](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6d580478e6ae9722369b6e570cab5cbffab76df))
+
+
+### Documentation Changes
+
+* fix a broken link ([0d978cc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d978ccd6ffc937dffd9f0522c1306a7aac2bb9a))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
+
 ## [4.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v3.2.2...logger-v4.0.0) (2025-01-20)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^4.0.0",
+    "@dotcom-reliability-kit/app-info": "^4.1.0",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
     "pino": "^9.6.0"

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.0...middleware-log-errors-v5.0.1) (2025-03-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
+
 ## [5.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v4.2.6...middleware-log-errors-v5.0.0) (2025-01-20)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.0"
+    "@dotcom-reliability-kit/log-error": "^5.0.1"
   },
   "devDependencies": {
     "@financial-times/n-express": "^31.10.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [6.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.0...middleware-render-error-info-v6.0.1) (2025-03-25)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
+
 ## [6.0.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v5.1.12...middleware-render-error-info-v6.0.0) (2025-01-20)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/app-info": "^4.0.0",
-    "@dotcom-reliability-kit/log-error": "^5.0.0",
+    "@dotcom-reliability-kit/app-info": "^4.1.0",
+    "@dotcom-reliability-kit/log-error": "^5.0.1",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "entities": "^6.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.2...opentelemetry-v3.0.3) (2025-03-25)
+
+
+### Bug Fixes
+
+* update OpenTelemetry to v2 / v0.200 ([0554c51](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0554c510f9456982e85ec79ed378266b7cd37f70))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
+    * @dotcom-reliability-kit/logger bumped from ^4.0.0 to ^4.0.1
+
 ## [3.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.1...opentelemetry-v3.0.2) (2025-03-05)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -17,10 +17,10 @@
 	"main": "lib/index.js",
 	"types": "types/index.d.ts",
 	"dependencies": {
-		"@dotcom-reliability-kit/app-info": "^4.0.0",
+		"@dotcom-reliability-kit/app-info": "^4.1.0",
 		"@dotcom-reliability-kit/errors": "^4.0.0",
-		"@dotcom-reliability-kit/log-error": "^5.0.0",
-		"@dotcom-reliability-kit/logger": "^4.0.0",
+		"@dotcom-reliability-kit/log-error": "^5.0.1",
+		"@dotcom-reliability-kit/logger": "^4.0.1",
 		"@opentelemetry/auto-instrumentations-node": "^0.57.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>app-info: 4.1.0</summary>

## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/app-info-v4.0.0...app-info-v4.1.0) (2025-03-25)


### Features

* set cloud provider to AWS for Hako apps ([70c4f94](https://github.com/Financial-Times/dotcom-reliability-kit/commit/70c4f947f83361d02cf5b6728a78fbe6d2ec4659))
</details>

<details><summary>crash-handler: 5.0.1</summary>

## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.0...crash-handler-v5.0.1) (2025-03-25)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
</details>

<details><summary>log-error: 5.0.1</summary>

## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.0...log-error-v5.0.1) (2025-03-25)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
    * @dotcom-reliability-kit/logger bumped from ^4.0.0 to ^4.0.1
</details>

<details><summary>logger: 4.0.1</summary>

## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.0...logger-v4.0.1) (2025-03-25)


### Bug Fixes

* disable log prettification on AWS ([f6d5804](https://github.com/Financial-Times/dotcom-reliability-kit/commit/f6d580478e6ae9722369b6e570cab5cbffab76df))


### Documentation Changes

* fix a broken link ([0d978cc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0d978ccd6ffc937dffd9f0522c1306a7aac2bb9a))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
</details>

<details><summary>middleware-log-errors: 5.0.1</summary>

## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.0...middleware-log-errors-v5.0.1) (2025-03-25)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
</details>

<details><summary>middleware-render-error-info: 6.0.1</summary>

## [6.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.0...middleware-render-error-info-v6.0.1) (2025-03-25)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
</details>

<details><summary>opentelemetry: 3.0.3</summary>

## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.2...opentelemetry-v3.0.3) (2025-03-25)


### Bug Fixes

* update OpenTelemetry to v2 / v0.200 ([0554c51](https://github.com/Financial-Times/dotcom-reliability-kit/commit/0554c510f9456982e85ec79ed378266b7cd37f70))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/app-info bumped from ^4.0.0 to ^4.1.0
    * @dotcom-reliability-kit/log-error bumped from ^5.0.0 to ^5.0.1
    * @dotcom-reliability-kit/logger bumped from ^4.0.0 to ^4.0.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).