### PR TITLE
feat: set cloud provider to AWS for Hako apps

### DIFF
--- a/packages/app-info/lib/index.js
+++ b/packages/app-info/lib/index.js
@@ -58,7 +58,7 @@ const processType =
  *     Returns the cloud provider type (either aws or heroku).
  */
 const cloudProvider = () => {
-	if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
+	if (process.env.AWS_LAMBDA_FUNCTION_NAME || process.env.HAKO_SERVICE_URL) {
 		return 'aws';
 	}
 	if (process.env.HEROKU_RELEASE_CREATED_AT) {


### PR DESCRIPTION
This updates our cloud provider detection to assume AWS if the `HAKO_SERVICE_URL` environment variable is set. At present, the cloud provider will be `null` for Hako apps.