### PR TITLE
fix: disable log prettification on AWS

### DIFF
--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -69,11 +69,14 @@ const prettificationAvailable = (() => {
 /**
  * Whether log prettification is allowed. We never allow log
  * prettification if the `NODE_ENV` environment variable is
- * set to "production".
+ * set to "production". We also disallow prettification if the
+ * cloud provider is AWS, pino-pretty does not work well with
+ * CloudWatch logs
  *
  * @type {boolean}
  */
-const prettificationAllowed = appInfo.environment !== 'production';
+const prettificationAllowed =
+	appInfo.environment !== 'production' && appInfo.cloudProvider !== 'aws';
 
 /**
  * Class representing a logger.


### PR DESCRIPTION
pino-pretty doesn't seem to work at all when sending logs to AWS CloudWatch. We also never want prettified logs to be in production, so this protects us against the case where `NODE_ENV` isn't set in an AWS context.