### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
   "packages/app-info": "4.1.0",
-  "packages/crash-handler": "5.0.1",
+  "packages/crash-handler": "5.0.2",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
   "packages/fetch-error-handler": "1.0.0",
-  "packages/log-error": "5.0.1",
-  "packages/logger": "4.0.1",
-  "packages/middleware-log-errors": "5.0.1",
-  "packages/middleware-render-error-info": "6.0.1",
+  "packages/log-error": "5.0.2",
+  "packages/logger": "4.1.0",
+  "packages/middleware-log-errors": "5.0.2",
+  "packages/middleware-render-error-info": "6.0.2",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.3",
+  "packages/opentelemetry": "3.0.4",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13603,10 +13603,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.1"
+        "@dotcom-reliability-kit/log-error": "^5.0.2"
       },
       "engines": {
         "node": "20.x || 22.x"
@@ -13654,11 +13654,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
-        "@dotcom-reliability-kit/logger": "^4.0.1",
+        "@dotcom-reliability-kit/logger": "^4.1.0",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "@dotcom-reliability-kit/serialize-request": "^4.0.0"
       },
@@ -13671,7 +13671,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
@@ -13702,10 +13702,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.1"
+        "@dotcom-reliability-kit/log-error": "^5.0.2"
       },
       "devDependencies": {
         "@financial-times/n-express": "^32.0.0",
@@ -13717,11 +13717,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.1",
+        "@dotcom-reliability-kit/log-error": "^5.0.2",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "entities": "^6.0.0"
       },
@@ -13734,13 +13734,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
         "@dotcom-reliability-kit/errors": "^4.0.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.1",
-        "@dotcom-reliability-kit/logger": "^4.0.1",
+        "@dotcom-reliability-kit/log-error": "^5.0.2",
+        "@dotcom-reliability-kit/logger": "^4.1.0",
         "@opentelemetry/auto-instrumentations-node": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.1...crash-handler-v5.0.2) (2025-03-27)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
+
 ## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.0...crash-handler-v5.0.1) (2025-03-25)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.1"
+    "@dotcom-reliability-kit/log-error": "^5.0.2"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.1...log-error-v5.0.2) (2025-03-27)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^4.0.1 to ^4.1.0
+
 ## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.0...log-error-v5.0.1) (2025-03-25)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^4.1.0",
-    "@dotcom-reliability-kit/logger": "^4.0.1",
+    "@dotcom-reliability-kit/logger": "^4.1.0",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "@dotcom-reliability-kit/serialize-request": "^4.0.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.1...logger-v4.1.0) (2025-03-27)
+
+
+### Features
+
+* disable prettifier for more prod env names ([aead95b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/aead95b965d15b7a80721f0d06131cb94c57821e)), closes [#1368](https://github.com/Financial-Times/dotcom-reliability-kit/issues/1368)
+
 ## [4.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.0...logger-v4.0.1) (2025-03-25)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.1...middleware-log-errors-v5.0.2) (2025-03-27)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
+
 ## [5.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.0...middleware-log-errors-v5.0.1) (2025-03-25)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.1"
+    "@dotcom-reliability-kit/log-error": "^5.0.2"
   },
   "devDependencies": {
     "@financial-times/n-express": "^32.0.0",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [6.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.1...middleware-render-error-info-v6.0.2) (2025-03-27)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
+
 ## [6.0.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.0...middleware-render-error-info-v6.0.1) (2025-03-25)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^4.1.0",
-    "@dotcom-reliability-kit/log-error": "^5.0.1",
+    "@dotcom-reliability-kit/log-error": "^5.0.2",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "entities": "^6.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.3...opentelemetry-v3.0.4) (2025-03-27)
+
+
+### Bug Fixes
+
+* merge resource attributes with the defaults ([3bc489b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3bc489ba05e4deea93d483e4eae8c35cd72f571d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
+    * @dotcom-reliability-kit/logger bumped from ^4.0.1 to ^4.1.0
+
 ## [3.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.2...opentelemetry-v3.0.3) (2025-03-25)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^4.1.0",
 		"@dotcom-reliability-kit/errors": "^4.0.0",
-		"@dotcom-reliability-kit/log-error": "^5.0.1",
-		"@dotcom-reliability-kit/logger": "^4.0.1",
+		"@dotcom-reliability-kit/log-error": "^5.0.2",
+		"@dotcom-reliability-kit/logger": "^4.1.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.57.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>crash-handler: 5.0.2</summary>

## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.1...crash-handler-v5.0.2) (2025-03-27)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
</details>

<details><summary>log-error: 5.0.2</summary>

## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.1...log-error-v5.0.2) (2025-03-27)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^4.0.1 to ^4.1.0
</details>

<details><summary>logger: 4.1.0</summary>

## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.1...logger-v4.1.0) (2025-03-27)


### Features

* disable prettifier for more prod env names ([aead95b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/aead95b965d15b7a80721f0d06131cb94c57821e)), closes [#1368](https://github.com/Financial-Times/dotcom-reliability-kit/issues/1368)
</details>

<details><summary>middleware-log-errors: 5.0.2</summary>

## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.1...middleware-log-errors-v5.0.2) (2025-03-27)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
</details>

<details><summary>middleware-render-error-info: 6.0.2</summary>

## [6.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.1...middleware-render-error-info-v6.0.2) (2025-03-27)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
</details>

<details><summary>opentelemetry: 3.0.4</summary>

## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.3...opentelemetry-v3.0.4) (2025-03-27)


### Bug Fixes

* merge resource attributes with the defaults ([3bc489b](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3bc489ba05e4deea93d483e4eae8c35cd72f571d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.1 to ^5.0.2
    * @dotcom-reliability-kit/logger bumped from ^4.0.1 to ^4.1.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).