### PR TITLE
docs: improve mock logger sample

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -616,12 +616,17 @@ jest.mock('@dotcom-reliability-kit/logger');
 This is because, in order to mock the logger, Jest will still load the original module which creates a fully fledged logger with bindings to `process.stdout`. You can get around this by providing your own manual mock logger, either as a second argument to `jest.mock` or as a file in `__mocks__/@dotcom-reliability-kit/logger.js`. E.g.
 
 ```js
+const mockedLogger = {
+	debug: jest.fn(),
+	error: jest.fn(),
+	fatal: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+};
+
 jest.mock('@dotcom-reliability-kit/logger', () => ({
-    debug: jest.fn(),
-    error: jest.fn(),
-    fatal: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn()
+	...mockedLogger,
+	Logger: jest.fn(() => mockedLogger),
 }));
 ```
 


### PR DESCRIPTION
This is just a simple improvement in the docs so the example we use to mock logger also covers cases where the developer invoked Logger constructor in their code.

Feel free to reject if you don't think that's useful or change in case you think there is a better way of doing it.