### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,16 +1,16 @@
 {
   "packages/app-info": "4.1.0",
-  "packages/client-metrics-web": "0.0.0",
-  "packages/crash-handler": "5.0.2",
+  "packages/client-metrics-web": "0.1.0",
+  "packages/crash-handler": "5.0.3",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
   "packages/fetch-error-handler": "1.0.0",
-  "packages/log-error": "5.0.2",
-  "packages/logger": "4.1.0",
-  "packages/middleware-log-errors": "5.0.2",
-  "packages/middleware-render-error-info": "6.0.2",
+  "packages/log-error": "5.0.3",
+  "packages/logger": "4.1.1",
+  "packages/middleware-log-errors": "5.0.3",
+  "packages/middleware-render-error-info": "6.0.3",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.4",
+  "packages/opentelemetry": "3.0.5",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12466,7 +12466,7 @@
     },
     "packages/client-metrics-web": {
       "name": "@dotcom-reliability-kit/client-metrics-web",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "aws-rum-web": "^1.21.0"
@@ -12477,10 +12477,10 @@
     },
     "packages/crash-handler": {
       "name": "@dotcom-reliability-kit/crash-handler",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.2"
+        "@dotcom-reliability-kit/log-error": "^5.0.3"
       },
       "engines": {
         "node": "20.x || 22.x"
@@ -12528,11 +12528,11 @@
     },
     "packages/log-error": {
       "name": "@dotcom-reliability-kit/log-error",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
-        "@dotcom-reliability-kit/logger": "^4.1.0",
+        "@dotcom-reliability-kit/logger": "^4.1.1",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "@dotcom-reliability-kit/serialize-request": "^4.0.0"
       },
@@ -12545,7 +12545,7 @@
     },
     "packages/logger": {
       "name": "@dotcom-reliability-kit/logger",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
@@ -12575,10 +12575,10 @@
     },
     "packages/middleware-log-errors": {
       "name": "@dotcom-reliability-kit/middleware-log-errors",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^5.0.2"
+        "@dotcom-reliability-kit/log-error": "^5.0.3"
       },
       "devDependencies": {
         "@types/express": "^5.0.1",
@@ -12590,11 +12590,11 @@
     },
     "packages/middleware-render-error-info": {
       "name": "@dotcom-reliability-kit/middleware-render-error-info",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.2",
+        "@dotcom-reliability-kit/log-error": "^5.0.3",
         "@dotcom-reliability-kit/serialize-error": "^4.0.0",
         "entities": "^6.0.0"
       },
@@ -12607,13 +12607,13 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",
         "@dotcom-reliability-kit/errors": "^4.0.0",
-        "@dotcom-reliability-kit/log-error": "^5.0.2",
-        "@dotcom-reliability-kit/logger": "^4.1.0",
+        "@dotcom-reliability-kit/log-error": "^5.0.3",
+        "@dotcom-reliability-kit/logger": "^4.1.1",
         "@opentelemetry/auto-instrumentations-node": "^0.57.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",

--- a/packages/client-metrics-web/CHANGELOG.md
+++ b/packages/client-metrics-web/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 (2025-04-09)
+
+
+### Features
+
+* add a new client-metrics-web package ([23c1ffc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/23c1ffc08038fc159a6d931dc377ca4d7b02fe9b))

--- a/packages/client-metrics-web/package.json
+++ b/packages/client-metrics-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/client-metrics-web",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "A client for sending operational metrics to AWS CloudWatch RUM from the web",
   "repository": {
     "type": "git",

--- a/packages/crash-handler/CHANGELOG.md
+++ b/packages/crash-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.2...crash-handler-v5.0.3) (2025-04-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
+
 ## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.1...crash-handler-v5.0.2) (2025-03-27)
 
 

--- a/packages/crash-handler/package.json
+++ b/packages/crash-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/crash-handler",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A method to bind an uncaught exception handler to ensure that fatal application errors are logged",
   "repository": {
     "type": "git",
@@ -16,6 +16,6 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.2"
+    "@dotcom-reliability-kit/log-error": "^5.0.3"
   }
 }

--- a/packages/log-error/CHANGELOG.md
+++ b/packages/log-error/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.2...log-error-v5.0.3) (2025-04-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/logger bumped from ^4.1.0 to ^4.1.1
+
 ## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.1...log-error-v5.0.2) (2025-03-27)
 
 

--- a/packages/log-error/package.json
+++ b/packages/log-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/log-error",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A method to consistently log error object with optional request information",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^4.1.0",
-    "@dotcom-reliability-kit/logger": "^4.1.0",
+    "@dotcom-reliability-kit/logger": "^4.1.1",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "@dotcom-reliability-kit/serialize-request": "^4.0.0"
   },

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.1.0...logger-v4.1.1) (2025-04-09)
+
+
+### Documentation Changes
+
+* improve mock logger sample ([82c2d19](https://github.com/Financial-Times/dotcom-reliability-kit/commit/82c2d19c2cf5ceb152c21a3feb2366f5f238effe))
+
 ## [4.1.0](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.0.1...logger-v4.1.0) (2025-03-27)
 
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/logger",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A simple and fast logger based on Pino, with FT preferences baked in",
   "repository": {
     "type": "git",

--- a/packages/middleware-log-errors/CHANGELOG.md
+++ b/packages/middleware-log-errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.2...middleware-log-errors-v5.0.3) (2025-04-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
+
 ## [5.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.1...middleware-log-errors-v5.0.2) (2025-03-27)
 
 

--- a/packages/middleware-log-errors/package.json
+++ b/packages/middleware-log-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-log-errors",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Express middleware to consistently log errors",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@dotcom-reliability-kit/log-error": "^5.0.2"
+    "@dotcom-reliability-kit/log-error": "^5.0.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.1",

--- a/packages/middleware-render-error-info/CHANGELOG.md
+++ b/packages/middleware-render-error-info/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [6.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.2...middleware-render-error-info-v6.0.3) (2025-04-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
+
 ## [6.0.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.1...middleware-render-error-info-v6.0.2) (2025-03-27)
 
 

--- a/packages/middleware-render-error-info/package.json
+++ b/packages/middleware-render-error-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/middleware-render-error-info",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Express middleware to render error information in a way that makes local debugging easier and production error rendering more consistent.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@dotcom-reliability-kit/app-info": "^4.1.0",
-    "@dotcom-reliability-kit/log-error": "^5.0.2",
+    "@dotcom-reliability-kit/log-error": "^5.0.3",
     "@dotcom-reliability-kit/serialize-error": "^4.0.0",
     "entities": "^6.0.0"
   },

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.4...opentelemetry-v3.0.5) (2025-04-09)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/auto-instrumentations-node ([9554b0f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9554b0fe0c1bd6f6f54a027fc312644e908a7aca))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
+    * @dotcom-reliability-kit/logger bumped from ^4.1.0 to ^4.1.1
+
 ## [3.0.4](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.3...opentelemetry-v3.0.4) (2025-03-27)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.4",
+	"version": "3.0.5",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",
@@ -19,8 +19,8 @@
 	"dependencies": {
 		"@dotcom-reliability-kit/app-info": "^4.1.0",
 		"@dotcom-reliability-kit/errors": "^4.0.0",
-		"@dotcom-reliability-kit/log-error": "^5.0.2",
-		"@dotcom-reliability-kit/logger": "^4.1.0",
+		"@dotcom-reliability-kit/log-error": "^5.0.3",
+		"@dotcom-reliability-kit/logger": "^4.1.1",
 		"@opentelemetry/auto-instrumentations-node": "^0.57.1",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>client-metrics-web: 0.1.0</summary>

## 0.1.0 (2025-04-09)


### Features

* add a new client-metrics-web package ([23c1ffc](https://github.com/Financial-Times/dotcom-reliability-kit/commit/23c1ffc08038fc159a6d931dc377ca4d7b02fe9b))
</details>

<details><summary>crash-handler: 5.0.3</summary>

## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/crash-handler-v5.0.2...crash-handler-v5.0.3) (2025-04-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
</details>

<details><summary>log-error: 5.0.3</summary>

## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/log-error-v5.0.2...log-error-v5.0.3) (2025-04-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/logger bumped from ^4.1.0 to ^4.1.1
</details>

<details><summary>logger: 4.1.1</summary>

## [4.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/logger-v4.1.0...logger-v4.1.1) (2025-04-09)


### Documentation Changes

* improve mock logger sample ([82c2d19](https://github.com/Financial-Times/dotcom-reliability-kit/commit/82c2d19c2cf5ceb152c21a3feb2366f5f238effe))
</details>

<details><summary>middleware-log-errors: 5.0.3</summary>

## [5.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-log-errors-v5.0.2...middleware-log-errors-v5.0.3) (2025-04-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
</details>

<details><summary>middleware-render-error-info: 6.0.3</summary>

## [6.0.3](https://github.com/Financial-Times/dotcom-reliability-kit/compare/middleware-render-error-info-v6.0.2...middleware-render-error-info-v6.0.3) (2025-04-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
</details>

<details><summary>opentelemetry: 3.0.5</summary>

## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.4...opentelemetry-v3.0.5) (2025-04-09)


### Bug Fixes

* bump @opentelemetry/auto-instrumentations-node ([9554b0f](https://github.com/Financial-Times/dotcom-reliability-kit/commit/9554b0fe0c1bd6f6f54a027fc312644e908a7aca))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @dotcom-reliability-kit/log-error bumped from ^5.0.2 to ^5.0.3
    * @dotcom-reliability-kit/logger bumped from ^4.1.0 to ^4.1.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).