### PR TITLE
chore: run dependabot against the root directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,7 @@ version: 2
 updates:
 
   - package-ecosystem: "npm"
-    directories:
-      - /
-      - /resources/logos
-      - /packages/app-info
-      - /packages/crash-handler
-      - /packages/errors
-      - /packages/eslint-config
-      - /packages/fetch-error-handler
-      - /packages/log-error
-      - /packages/logger
-      - /packages/middleware-log-errors
-      - /packages/middleware-render-error-info
-      - /packages/opentelemetry
-      - /packages/serialize-error
-      - /packages/serialize-request
+    directory: '/'
     schedule:
       interval: "daily"
     commit-message:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,8 +65,6 @@ The name of the package must be lowercase with words hyphen-delimited.
 npm run create-package <NAME>
 ```
 
-You'll also need to manually add an entry for the package to [the Dependabot config](../.github/dependabot.yml) so that dependency update pull requests can be opened.
-
 It's important that you run `npm install` before committing. This ensures that the new package is registered in the main `package-lock.json`.
 
 You'll need to manually add the package to the list of packages in the README once it's ready to be used by other teams.


### PR DESCRIPTION
Turns out we only need to specify the root directory for Dependabot, @ivomurrell checked this with Tool Kit and Dependabot will update all workspaces.