### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/app-info": "4.1.0",
-  "packages/client-metrics-web": "0.1.0",
+  "packages/client-metrics-web": "0.1.1",
   "packages/crash-handler": "5.0.3",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
@@ -11,6 +11,6 @@
   "packages/middleware-render-error-info": "6.0.3",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.5",
+  "packages/opentelemetry": "3.0.6",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12414,7 +12414,7 @@
     },
     "packages/client-metrics-web": {
       "name": "@dotcom-reliability-kit/client-metrics-web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "aws-rum-web": "^1.22.0"
@@ -12555,7 +12555,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",

--- a/packages/client-metrics-web/CHANGELOG.md
+++ b/packages/client-metrics-web/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/client-metrics-web-v0.1.0...client-metrics-web-v0.1.1) (2025-04-15)
+
+
+### Bug Fixes
+
+* bump aws-rum-web from 1.21.0 to 1.22.0 ([110b1fd](https://github.com/Financial-Times/dotcom-reliability-kit/commit/110b1fde9bfc064801f976f696d845568a4cffb9))
+
+
+### Documentation Changes
+
+* correct the page kit package ([e792d64](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e792d645f1fbcce8bd708ded71b545f8be6c12c9))
+
 ## 0.1.0 (2025-04-09)
 
 

--- a/packages/client-metrics-web/package.json
+++ b/packages/client-metrics-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/client-metrics-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A client for sending operational metrics to AWS CloudWatch RUM from the web",
   "repository": {
     "type": "git",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.5...opentelemetry-v3.0.6) (2025-04-15)
+
+
+### Bug Fixes
+
+* bump @opentelemetry/semantic-conventions from 1.30.0 to 1.32.0 ([fbab356](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fbab3563fe718be4f7ada0f7b96265ea336c5f31))
+
 ## [3.0.5](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.4...opentelemetry-v3.0.5) (2025-04-09)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>client-metrics-web: 0.1.1</summary>

## [0.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/client-metrics-web-v0.1.0...client-metrics-web-v0.1.1) (2025-04-15)


### Bug Fixes

* bump aws-rum-web from 1.21.0 to 1.22.0 ([110b1fd](https://github.com/Financial-Times/dotcom-reliability-kit/commit/110b1fde9bfc064801f976f696d845568a4cffb9))


### Documentation Changes

* correct the page kit package ([e792d64](https://github.com/Financial-Times/dotcom-reliability-kit/commit/e792d645f1fbcce8bd708ded71b545f8be6c12c9))
</details>

<details><summary>opentelemetry: 3.0.6</summary>

## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.5...opentelemetry-v3.0.6) (2025-04-15)


### Bug Fixes

* bump @opentelemetry/semantic-conventions from 1.30.0 to 1.32.0 ([fbab356](https://github.com/Financial-Times/dotcom-reliability-kit/commit/fbab3563fe718be4f7ada0f7b96265ea336c5f31))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).