### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/app-info": "4.1.0",
-  "packages/client-metrics-web": "0.1.1",
+  "packages/client-metrics-web": "0.1.2",
   "packages/crash-handler": "5.0.3",
   "packages/errors": "4.0.0",
   "packages/eslint-config": "4.0.0",
@@ -11,6 +11,6 @@
   "packages/middleware-render-error-info": "6.0.3",
   "packages/serialize-error": "4.0.0",
   "packages/serialize-request": "4.0.0",
-  "packages/opentelemetry": "3.0.6",
+  "packages/opentelemetry": "3.0.7",
   "packages/middleware-allow-request-methods": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12415,7 +12415,7 @@
     },
     "packages/client-metrics-web": {
       "name": "@dotcom-reliability-kit/client-metrics-web",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "aws-rum-web": "^1.22.1"
@@ -12556,7 +12556,7 @@
     },
     "packages/opentelemetry": {
       "name": "@dotcom-reliability-kit/opentelemetry",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^4.1.0",

--- a/packages/client-metrics-web/CHANGELOG.md
+++ b/packages/client-metrics-web/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/client-metrics-web-v0.1.1...client-metrics-web-v0.1.2) (2025-04-22)
+
+
+### Bug Fixes
+
+* bump aws-rum-web from 1.22.0 to 1.22.1 ([3a60ca1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3a60ca1db06bcdb6cd3d81945a419a5980e77f59))
+* correct metrics client constructor options ([1bd66e0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1bd66e065bc843e05a6f73cf70be445cda1443f7))
+
+
+### Documentation Changes
+
+* clarify how dom event details map to metrics ([60becc2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/60becc27f99783b9903ddb9b9fad57ac363c809f))
+
 ## [0.1.1](https://github.com/Financial-Times/dotcom-reliability-kit/compare/client-metrics-web-v0.1.0...client-metrics-web-v0.1.1) (2025-04-15)
 
 

--- a/packages/client-metrics-web/package.json
+++ b/packages/client-metrics-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-reliability-kit/client-metrics-web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A client for sending operational metrics to AWS CloudWatch RUM from the web",
   "repository": {
     "type": "git",

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.6...opentelemetry-v3.0.7) (2025-04-22)
+
+
+### Bug Fixes
+
+* update auto-instrumentations ([08dc1e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/08dc1e96538e9387af757401f5e8acca24d191a0))
+
 ## [3.0.6](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.5...opentelemetry-v3.0.6) (2025-04-15)
 
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dotcom-reliability-kit/opentelemetry",
-	"version": "3.0.6",
+	"version": "3.0.7",
 	"description": "An OpenTelemetry client that's preconfigured for drop-in use in FT apps.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
:rock: I've created a release for you
---


<details><summary>client-metrics-web: 0.1.2</summary>

## [0.1.2](https://github.com/Financial-Times/dotcom-reliability-kit/compare/client-metrics-web-v0.1.1...client-metrics-web-v0.1.2) (2025-04-22)


### Bug Fixes

* bump aws-rum-web from 1.22.0 to 1.22.1 ([3a60ca1](https://github.com/Financial-Times/dotcom-reliability-kit/commit/3a60ca1db06bcdb6cd3d81945a419a5980e77f59))
* correct metrics client constructor options ([1bd66e0](https://github.com/Financial-Times/dotcom-reliability-kit/commit/1bd66e065bc843e05a6f73cf70be445cda1443f7))


### Documentation Changes

* clarify how dom event details map to metrics ([60becc2](https://github.com/Financial-Times/dotcom-reliability-kit/commit/60becc27f99783b9903ddb9b9fad57ac363c809f))
</details>

<details><summary>opentelemetry: 3.0.7</summary>

## [3.0.7](https://github.com/Financial-Times/dotcom-reliability-kit/compare/opentelemetry-v3.0.6...opentelemetry-v3.0.7) (2025-04-22)


### Bug Fixes

* update auto-instrumentations ([08dc1e9](https://github.com/Financial-Times/dotcom-reliability-kit/commit/08dc1e96538e9387af757401f5e8acca24d191a0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).