### PR TITLE
fix: update auto-instrumentations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.57.1.tgz",
-      "integrity": "sha512-yy+K3vYybqJ6Z4XZCXYYxEC1DtEpPrnJdwxkhI0sTtVlrVnzx49iRLqpMmdvQ4b09+PrvXSN9t0jODMCGNrs8w==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.58.0.tgz",
+      "integrity": "sha512-gtqPqkXp8TG6vrmbzAJUKjJm3nrCiVGgImlV1tj8lsVqpnKDCB1Kl7bCcXod36+Tq/O4rCeTDmW90dCHeuv9jQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.200.0",
@@ -2696,7 +2696,7 @@
         "@opentelemetry/instrumentation-cucumber": "^0.15.0",
         "@opentelemetry/instrumentation-dataloader": "^0.17.0",
         "@opentelemetry/instrumentation-dns": "^0.44.0",
-        "@opentelemetry/instrumentation-express": "^0.48.0",
+        "@opentelemetry/instrumentation-express": "^0.48.1",
         "@opentelemetry/instrumentation-fastify": "^0.45.0",
         "@opentelemetry/instrumentation-fs": "^0.20.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.44.0",
@@ -2705,7 +2705,7 @@
         "@opentelemetry/instrumentation-hapi": "^0.46.0",
         "@opentelemetry/instrumentation-http": "^0.200.0",
         "@opentelemetry/instrumentation-ioredis": "^0.48.0",
-        "@opentelemetry/instrumentation-kafkajs": "^0.9.0",
+        "@opentelemetry/instrumentation-kafkajs": "^0.9.1",
         "@opentelemetry/instrumentation-knex": "^0.45.0",
         "@opentelemetry/instrumentation-koa": "^0.48.0",
         "@opentelemetry/instrumentation-lru-memoizer": "^0.45.0",
@@ -2722,6 +2722,7 @@
         "@opentelemetry/instrumentation-redis-4": "^0.47.0",
         "@opentelemetry/instrumentation-restify": "^0.46.0",
         "@opentelemetry/instrumentation-router": "^0.45.0",
+        "@opentelemetry/instrumentation-runtime-node": "^0.14.0",
         "@opentelemetry/instrumentation-socket.io": "^0.47.0",
         "@opentelemetry/instrumentation-tedious": "^0.19.0",
         "@opentelemetry/instrumentation-undici": "^0.11.0",
@@ -3168,9 +3169,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.48.0.tgz",
-      "integrity": "sha512-x9L6YD7AfE+7hysSv8k0d0sFmq3Vo3zoa/5eeJBYkGWHnD92CvekKouPyqUt71oX0htmZRdIawrhrwrAi2sonQ==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.48.1.tgz",
+      "integrity": "sha512-j8NYOf9DRWtchbWor/zA0poI42TpZG9tViIKA0e1lC+6MshTqSJYtgNv8Fn1sx1Wn/TRyp+5OgSXiE4LDfvpEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3316,9 +3317,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.9.0.tgz",
-      "integrity": "sha512-Uxt/LTSmrzTYtnPpPn/L2W7+tjn38+v8tSnJ7hvaE3/aRXmZA5e72n+pHv0mlCI0pVNTihiQCUE62XYWPZ4jjA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.9.1.tgz",
+      "integrity": "sha512-eGl5WKBqd0unOKm7PJKjEa1G+ac9nvpDjyv870nUYuSnUkyDc/Fag5keddIjHixTJwRp3FmyP7n+AadAjh52Vw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.200.0",
@@ -3600,9 +3601,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-runtime-node": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.13.0.tgz",
-      "integrity": "sha512-+uJN4KVRx5t26s/pchP6wN8Y2bFbuVsPPDjUklXfEGtfGJkwUZmBKafhw3c74ihwEo8RSSy2xqRhLSwp7zIYOQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.14.0.tgz",
+      "integrity": "sha512-y78dGoFMKwHSz0SD113Gt1dFTcfunpPZXIJh2SzJN27Lyb9FIzuMfjc3Iu3+s/N6qNOLuS9mKnPe3/qVGG4Waw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.200.0"
@@ -12562,11 +12563,10 @@
         "@dotcom-reliability-kit/errors": "^4.0.0",
         "@dotcom-reliability-kit/log-error": "^5.0.3",
         "@dotcom-reliability-kit/logger": "^4.1.1",
-        "@opentelemetry/auto-instrumentations-node": "^0.57.1",
+        "@opentelemetry/auto-instrumentations-node": "^0.58.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",
         "@opentelemetry/host-metrics": "^0.36.0",
-        "@opentelemetry/instrumentation-runtime-node": "^0.13.0",
         "@opentelemetry/sdk-node": "^0.200.0",
         "@opentelemetry/semantic-conventions": "^1.32.0"
       },

--- a/packages/opentelemetry/lib/config/instrumentations.js
+++ b/packages/opentelemetry/lib/config/instrumentations.js
@@ -1,9 +1,6 @@
 const {
 	getNodeAutoInstrumentations
 } = require('@opentelemetry/auto-instrumentations-node');
-const {
-	RuntimeNodeInstrumentation
-} = require('@opentelemetry/instrumentation-runtime-node');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const { UserInputError } = require('@dotcom-reliability-kit/errors');
 
@@ -21,17 +18,14 @@ const IGNORED_REQUEST_PATHS = ['/__gtg', '/__health', '/favicon.ico'];
  * @returns {NodeSDKConfiguration['instrumentations']}
  */
 exports.createInstrumentationConfig = function createInstrumentationConfig() {
-	return [
-		getNodeAutoInstrumentations({
-			'@opentelemetry/instrumentation-http': {
-				ignoreIncomingRequestHook
-			},
-			'@opentelemetry/instrumentation-pino': {
-				enabled: false
-			}
-		}),
-		new RuntimeNodeInstrumentation()
-	];
+	return getNodeAutoInstrumentations({
+		'@opentelemetry/instrumentation-http': {
+			ignoreIncomingRequestHook
+		},
+		'@opentelemetry/instrumentation-pino': {
+			enabled: false
+		}
+	});
 };
 
 /**

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -21,11 +21,10 @@
 		"@dotcom-reliability-kit/errors": "^4.0.0",
 		"@dotcom-reliability-kit/log-error": "^5.0.3",
 		"@dotcom-reliability-kit/logger": "^4.1.1",
-		"@opentelemetry/auto-instrumentations-node": "^0.57.1",
+		"@opentelemetry/auto-instrumentations-node": "^0.58.0",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.200.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.200.0",
 		"@opentelemetry/host-metrics": "^0.36.0",
-		"@opentelemetry/instrumentation-runtime-node": "^0.13.0",
 		"@opentelemetry/sdk-node": "^0.200.0",
 		"@opentelemetry/semantic-conventions": "^1.32.0"
 	},

--- a/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
+++ b/packages/opentelemetry/test/unit/lib/config/instrumentations.spec.js
@@ -3,16 +3,12 @@ jest.mock('@opentelemetry/auto-instrumentations-node', () => ({
 		.fn()
 		.mockReturnValue('mock-auto-instrumentations')
 }));
-jest.mock('@opentelemetry/instrumentation-runtime-node');
 jest.mock('@dotcom-reliability-kit/log-error');
 jest.mock('@dotcom-reliability-kit/errors');
 
 const {
 	getNodeAutoInstrumentations
 } = require('@opentelemetry/auto-instrumentations-node');
-const {
-	RuntimeNodeInstrumentation
-} = require('@opentelemetry/instrumentation-runtime-node');
 const { logRecoverableError } = require('@dotcom-reliability-kit/log-error');
 const { UserInputError } = require('@dotcom-reliability-kit/errors');
 
@@ -29,7 +25,6 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 		let instrumentations;
 
 		beforeEach(() => {
-			RuntimeNodeInstrumentation.mockReset();
 			instrumentations = createInstrumentationConfig();
 		});
 
@@ -43,11 +38,6 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 					enabled: false
 				}
 			});
-		});
-
-		it('sets up runtime Node.js instrumentations', () => {
-			expect(RuntimeNodeInstrumentation).toHaveBeenCalledTimes(1);
-			expect(RuntimeNodeInstrumentation).toHaveBeenCalledWith();
 		});
 
 		describe('ignore incoming request hook function', () => {
@@ -131,11 +121,8 @@ describe('@dotcom-reliability-kit/opentelemetry/lib/config/instrumentation', () 
 			});
 		});
 
-		it('returns an array of instrumentations', () => {
-			expect(instrumentations).toEqual([
-				'mock-auto-instrumentations',
-				expect.any(RuntimeNodeInstrumentation)
-			]);
+		it('returns the auto-instrumentations', () => {
+			expect(instrumentations).toEqual('mock-auto-instrumentations');
 		});
 	});
 });


### PR DESCRIPTION
@opentelemetry/auto-instrumentations-node now imports and initialises @opentelemetry/instrumentation-runtime-node by default, as of v0.58.0.

Because of this we no longer need to intialise it or install it ourselves, this is not a breaking change for us because the initialisation is just moving.