### PR TITLE
fix: explicitly install all modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11918,6 +11918,7 @@
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.203.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
         "@opentelemetry/host-metrics": "^0.36.0",
+        "@opentelemetry/otlp-exporter-base": "^0.203.0",
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/semantic-conventions": "^1.36.0"
       },

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -24,6 +24,7 @@
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.203.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
 		"@opentelemetry/host-metrics": "^0.36.0",
+		"@opentelemetry/otlp-exporter-base": "^0.203.0",
 		"@opentelemetry/sdk-node": "^0.203.0",
 		"@opentelemetry/semantic-conventions": "^1.36.0"
 	},


### PR DESCRIPTION
We were accidentally depending on @opentelemetry/otlp-exporter-base transitively and the latest bumps meant that this doesn't work any more. Oops.