### PR TITLE
Dependabot config tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: '/'
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "fix:"
       prefix-development: "chore:"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - '@types/*'
       origami:
         patterns:
           - "@financial-times/o-*"


### PR DESCRIPTION
This does a couple of things:

  1. **Allow 20 open Dependabot PRs:** Occasionally OpenTelemetry updates clog up our 5 PR limit which means we don't see important things like security updates for other packages. Let's increase the limit.

      This project's build isn't particularly complex and it doesn't create review apps or anything so I don't think it'll negatively impact anything.

  2. **Exclude `@types` packages from development dependencies group:** these packages are normally development dependencies but Dependabot is smart enough to update them alongside their _actual_ dependencies. Let's let it do that.